### PR TITLE
Some recent compilers / libs don't like using enums as index mechanisms

### DIFF
--- a/src/NotesLoaderDWI.cpp
+++ b/src/NotesLoaderDWI.cpp
@@ -19,7 +19,7 @@ Difficulty DwiCompatibleStringToDifficulty( const RString& sDC );
 static std::map<int,int> g_mapDanceNoteToNoteDataColumn;
 
 /** @brief The different types of core DWI arrows and pads. */
-enum
+enum DanceNotes
 {
 	DANCE_NOTE_NONE = 0,
 	DANCE_NOTE_PAD1_LEFT,


### PR DESCRIPTION
This specifically breaks the Android compilation, because in Android's case the operator[] map accessor demands a const reference. Seems to compile on my end, but can anyone verify this with a proper DWI test bench?
