### PR TITLE
Miscellaneous bug fixes and features.

### DIFF
--- a/Docs/Luadoc/Lua.xml
+++ b/Docs/Luadoc/Lua.xml
@@ -550,6 +550,7 @@
 			<Function name='NoStroke'/>
 			<Function name='PixelFont'/>
 			<Function name='Stroke'/>
+			<Function name='distort'/>
 			<Function name='jitter'/>
 			<Function name='maxheight'/>
 			<Function name='maxwidth'/>
@@ -558,6 +559,7 @@
 			<Function name='settextf'/>
 			<Function name='strokecolor'/>
 			<Function name='textglowmode'/>
+			<Function name='undistort'/>
 			<Function name='uppercase'/>
 			<Function name='vertspacing'/>
 			<Function name='wrapwidthpixels'/>
@@ -1107,6 +1109,7 @@
 			<Function name='GetAliveSeconds'/>
 			<Function name='GetBestFullComboTapNoteScore'/>
 			<Function name='GetCaloriesBurned'/>
+			<Function name='GetComboList'/>
 			<Function name='GetCurMaxScore'/>
 			<Function name='GetCurrentCombo'/>
 			<Function name='GetCurrentLife'/>
@@ -1118,6 +1121,7 @@
 			<Function name='GetHoldNoteScores'/>
 			<Function name='GetLessonScoreActual'/>
 			<Function name='GetLessonScoreNeeded'/>
+			<Function name='GetLifeRecord'/>
 			<Function name='GetLifeRemainingSeconds'/>
 			<Function name='GetMachineHighScoreIndex'/>
 			<Function name='GetNumControllerSteps'/>
@@ -1138,6 +1142,7 @@
 			<Function name='GetTapNoteScores'/>
 			<Function name='IsDisqualified'/>
 			<Function name='MaxCombo'/>
+			<Function name='SetCurCombo'/>
 			<Function name='SetCurMaxScore'/>
 			<Function name='SetScore'/>
 		</Class>
@@ -1511,6 +1516,8 @@
 			<Function name='LoadFromSongBanner'/>
 			<Function name='SetAllStateDelays'/>
 			<Function name='SetCustomImageRect'/>
+			<Function name='SetCustomPosCoords'/>
+			<Function name='StopUsingCustomPosCoords'/>
 			<Function name='SetEffectMode'/>
 			<Function name='SetSecondsIntoAnimation'/>
 			<Function name='SetTexture'/>

--- a/Docs/Luadoc/LuaDocumentation.xml
+++ b/Docs/Luadoc/LuaDocumentation.xml
@@ -716,7 +716,7 @@ save yourself some time, copy this for undocumented things:
 	</Function>
 </Namespace>
 <Namespace name='SongUtil'>
-	<Function name='GetPlayableSteps' return='Steps' arguments='Song so'>
+	<Function name='GetPlayableSteps' return='{Steps}' arguments='Song so'>
 		Gets the playable Steps for the present Song based on the present Game.
 	</Function>
 	<Function name='IsStepsPlayable' return='bool' arguments='Song so, Steps st'>
@@ -1611,6 +1611,14 @@ save yourself some time, copy this for undocumented things:
 	<Function name='GetText' return='string' arguments=''>
 		Returns the text that is currently set.
 	</Function>
+	<Function name='distort' return='void' arguments='float distortion_percentage'>
+		Causes each character of text to be randomly distorted by
+		distortion_percentage of its size when the text is set.  The distortion
+		only changes when the text changes.
+	</Function>
+	<Function name='undistort' return='void' arguments=''>
+		Turns off distortion.
+	</Function>
 	<Function name='jitter' return='void' arguments='bool bJitter'>
 		If <code>bJitter</code> is <code>true</code>, move each character of the string around by a small random amount.
 	</Function>
@@ -2035,10 +2043,12 @@ save yourself some time, copy this for undocumented things:
 	<Function name='PlayAnnouncer' return='void' arguments='string sPath'>
 		Plays a sound from the current announcer.
 	</Function>
-	<Function name='PlayMusicPart' return='void' arguments='string musicPath, float musicStart, float musicLength, float fadeIn, float fadeOut'>
-		Play the sound at <code>musicPath</code> starting from <code>musicStart</code> for
-		<code>musicLength</code> seconds one time. Both <code>fadeIn</code> and
-		<code>fadeOut</code> can be customized as required.
+	<Function name='PlayMusicPart' return='void' arguments='string musicPath, float musicStart, float musicLength, float fadeIn, float fadeOut, bool loop, bool, applyRate'>
+ 		Play the sound at <code>musicPath</code> starting from <code>musicStart</code> for
+ 		<code>musicLength</code> seconds one time. Both <code>fadeIn</code> and
+		<code>fadeOut</code> can be customized as required.  <code>loop</code>
+		tells the sound manager to loop the music part.  <code>applyRate</code>
+		tells the sound manager to apply the current music rate.
 	</Function>
 	<Function name='PlayOnce' return='void' arguments='string sPath'>
 		Play the sound at <code>sPath</code> one time.
@@ -3217,6 +3227,9 @@ save yourself some time, copy this for undocumented things:
 	<Function name='GetCaloriesBurned' return='float' arguments=''>
 		Returns the number of calories burned.
 	</Function>
+	<Function name='GetComboList' return= '{combo}' arguments=''>
+		Returns a table of all the combos.  Each entry in the table is a table containing the StartSecond, SizeSeconds, Count, Rollover, StageCount, and IsZero information for that combo.
+	</Function>
 	<Function name='GetCurMaxScore' return='int' arguments=''>
 		Returns the current possible maximum score.
 	</Function>
@@ -3249,6 +3262,11 @@ save yourself some time, copy this for undocumented things:
 	</Function>
 	<Function name='GetLessonScoreNeeded' return='int' arguments=''>
 		Returns the score needed to pass the lesson.
+	</Function>
+	<Function name='GetLifeRecord' return='{float}' arguments='float last_second, int samples'>
+		Returns table of samples of the life record from 0 to last_second.
+		'samples' determines the size of the table.  'samples' defaults to 100
+		if not specified.
 	</Function>
 	<Function name='GetLifeRemainingSeconds' return='float' arguments=''>
 		Returns the player's life remaining seconds.
@@ -4276,6 +4294,13 @@ save yourself some time, copy this for undocumented things:
 	</Function>
 	<Function name='SetCustomImageRect' return='void' arguments='float fLeft, float fTop, float fRight, float fBottom'>
 		Sets the custom image rectangle. (Works in image pixel space.)
+	</Function>
+	<Function name='SetCustomPosCoords' return='void' arguments='float ulx, float uly, float llx, float lly, float lrx, float lry, float urx, float ury'>
+		Sets custom offsets for the corners of the Sprite.  Coordinates are paired,
+		corner order is upper left, lower left, lower right, upper right.
+	</Function>
+	<Function name='StopUsingCustomPosCoords' return='void' arguments=''>
+		Turns off the custom pos coords for the sprite.
 	</Function>
 	<Function name='SetEffectMode' return='void' arguments='EffectMode mode'>
 		Set the <Link class='ENUM' function='EffectMode' /> to <code>mode</code>.

--- a/Themes/_fallback/metrics.ini
+++ b/Themes/_fallback/metrics.ini
@@ -4423,6 +4423,7 @@ BodyHeight=38
 
 [ComboGraph]
 BodyWidth=140
+BodyHeight=11
 
 # Arcade #################################
 [ScreenLogo]

--- a/Utils/build.sh
+++ b/Utils/build.sh
@@ -158,7 +158,7 @@ if [ -n "$s_ffmpeg" ]; then
 #		message 'Cleaning up temporary files'
 #		call rm $ffmarc
 	fi
-	args="--enable-static --enable-gpl --enable-version3 --enable-nonfree --enable-libx264 --enable-libfaac --enable-libmp3lame --enable-libtheora --enable-libvorbis --disable-libvpx --disable-vaapi --enable-libxvid --disable-debug --enable-memalign-hack --disable-network --enable-small --disable-encoders --disable-ffserver --extra-cflags=-Dattribute_deprecated="
+	args="--enable-static --enable-gpl --enable-version3 --enable-nonfree --enable-libx264 --disable-libfaac --disable-libmp3lame --enable-libtheora --enable-libvorbis --disable-libvpx --disable-vaapi --enable-libxvid --disable-debug --enable-memalign-hack --disable-network --enable-small --disable-encoders --disable-ffserver --extra-cflags=-Dattribute_deprecated="
 	cd $ffmpeg
 	message 'Configuring ffmpeg'
 	call ./configure --prefix="`pwd`/_inst" $args

--- a/src/BitmapText.h
+++ b/src/BitmapText.h
@@ -34,6 +34,8 @@ public:
 	void SetUppercase( bool b );
 	void SetRainbowScroll( bool b )	{ m_bRainbowScroll = b; }
 	void SetJitter( bool b )	{ m_bJitter = b; }
+	void SetDistortion( float f );
+	void UnSetDistortion();
 
 	void SetHorizAlign( float f );
 
@@ -77,6 +79,8 @@ protected:
 	float		m_fMaxHeight;			// 0 = no max
 	bool		m_bRainbowScroll;
 	bool		m_bJitter;
+	bool		m_bUsingDistortion;
+	float		m_fDistortion;
 	int			m_iVertSpacing;
 
 	vector<RageSpriteVertex>	m_aVertices;

--- a/src/ComboGraph.cpp
+++ b/src/ComboGraph.cpp
@@ -22,6 +22,11 @@ ComboGraph::ComboGraph()
 void ComboGraph::Load( RString sMetricsGroup )
 {
 	BODY_WIDTH.Load( sMetricsGroup, "BodyWidth" );
+	BODY_HEIGHT.Load( sMetricsGroup, "BodyHeight" );
+
+	// These need to be set so that a theme can use zoomtowidth/zoomtoheight and get correct behavior.
+	this->SetWidth(BODY_WIDTH);
+	this->SetHeight(BODY_HEIGHT);
 
 	Actor *pActor = NULL;
 
@@ -29,6 +34,7 @@ void ComboGraph::Load( RString sMetricsGroup )
 	if( m_pBacking != NULL )
 	{
 		m_pBacking->ZoomToWidth( BODY_WIDTH );
+		m_pBacking->ZoomToHeight( BODY_HEIGHT );
 		this->AddChild( m_pBacking );
 	}
 
@@ -36,6 +42,7 @@ void ComboGraph::Load( RString sMetricsGroup )
 	if( m_pNormalCombo != NULL )
 	{
 		m_pNormalCombo->ZoomToWidth( BODY_WIDTH );
+		m_pNormalCombo->ZoomToHeight( BODY_HEIGHT );
 		this->AddChild( m_pNormalCombo );
 	}
 
@@ -43,6 +50,7 @@ void ComboGraph::Load( RString sMetricsGroup )
 	if( m_pMaxCombo != NULL )
 	{
 		m_pMaxCombo->ZoomToWidth( BODY_WIDTH );
+		m_pMaxCombo->ZoomToHeight( BODY_HEIGHT );
 		this->AddChild( m_pMaxCombo );
 	}
 

--- a/src/ComboGraph.h
+++ b/src/ComboGraph.h
@@ -24,6 +24,7 @@ public:
 
 private:
 	ThemeMetric<float> BODY_WIDTH;
+	ThemeMetric<float> BODY_HEIGHT;
 	Actor *m_pBacking;
 	Actor *m_pNormalCombo;
 	Actor *m_pMaxCombo;

--- a/src/GameCommand.cpp
+++ b/src/GameCommand.cpp
@@ -442,6 +442,15 @@ int GetNumCreditsPaid()
 
 int GetCreditsRequiredToPlayStyle( const Style *style )
 {
+	// GameState::GetCoinsNeededToJoin returns 0 if the coin mode isn't
+	// CoinMode_Pay, which means the theme can't make sure that there are
+	// enough credits available.  GameCommand::IsPlayable will cause a crash
+	// if there aren't enough credits.  So we have to check the coin mode here
+	// and return 0 if the player doesn't have to pay.
+	if( GAMESTATE->GetCoinMode() != CoinMode_Pay )
+	{
+		return 0;
+	}
 	if( GAMESTATE->GetPremium() == Premium_2PlayersFor1Credit )
 		return 1;
 

--- a/src/GameSoundManager.cpp
+++ b/src/GameSoundManager.cpp
@@ -684,7 +684,8 @@ void GameSoundManager::PlayMusic(
 	float fLengthSeconds, 
 	float fFadeInLengthSeconds, 
 	float fFadeOutLengthSeconds, 
-	bool bAlignBeat
+	bool bAlignBeat,
+	bool bApplyMusicRate
 	)
 {
 	PlayMusicParams params;
@@ -696,7 +697,7 @@ void GameSoundManager::PlayMusic(
 	params.fFadeInLengthSeconds = fFadeInLengthSeconds;
 	params.fFadeOutLengthSeconds = fFadeOutLengthSeconds;
 	params.bAlignBeat = bAlignBeat;
-	params.bApplyMusicRate = false;
+	params.bApplyMusicRate = bApplyMusicRate;
 	PlayMusic( params );
 }
 
@@ -831,16 +832,26 @@ public:
 		float musicLength = FArg(3);
 		float fadeIn = 0;
 		float fadeOut = 0;
+		bool loop= false;
+		bool applyRate= false;
 		if (lua_gettop(L) >= 4 && !lua_isnil(L,4))
 		{
 			fadeIn = FArg(4);
 			if (lua_gettop(L) >= 5 && !lua_isnil(L,5))
 			{
 				fadeOut = FArg(5);
+				if (lua_gettop(L) >= 6 && !lua_isnil(L,6))
+				{
+					loop = BArg(6);
+					if (lua_gettop(L) >= 7 && !lua_isnil(L,7))
+					{
+						applyRate = BArg(7);
+					}
+				}
 			}
 		}
-		p->PlayMusic(musicPath, NULL, false, musicStart, musicLength,
-					 fadeIn, fadeOut);
+		p->PlayMusic(musicPath, NULL, loop, musicStart, musicLength,
+			fadeIn, fadeOut, applyRate);
 		return 0;
 	}
 

--- a/src/GameSoundManager.h
+++ b/src/GameSoundManager.h
@@ -50,7 +50,8 @@ public:
 		float length_sec = -1, 
 		float fFadeInLengthSeconds = 0,
 		float fade_len = 0, 
-		bool align_beat = true );
+		bool align_beat = true,
+		bool bApplyMusicRate = false);
 	void StopMusic() { PlayMusic(""); }
 	void DimMusic( float fVolume, float fDurationSeconds );
 	RString GetMusicPath() const;

--- a/src/GameState.cpp
+++ b/src/GameState.cpp
@@ -2474,6 +2474,11 @@ public:
 	static int Reset( T* p, lua_State *L )				{ p->Reset(); return 0; }
 	static int JoinPlayer( T* p, lua_State *L )				{ p->JoinPlayer(Enum::Check<PlayerNumber>(L, 1)); return 0; }
 	static int UnjoinPlayer( T* p, lua_State *L )				{ p->UnjoinPlayer(Enum::Check<PlayerNumber>(L, 1)); return 0; }
+	static int JoinInput( T* p, lua_State *L )
+	{
+		lua_pushboolean(L, p->JoinInput(Enum::Check<PlayerNumber>(L, 1)));
+		return 1;
+	}
 	static int GetSongPercent( T* p, lua_State *L )				{ lua_pushnumber(L, p->GetSongPercent(FArg(1))); return 1; }
 	DEFINE_METHOD( GetCurMusicSeconds,	m_Position.m_fMusicSeconds )
 
@@ -2606,6 +2611,7 @@ public:
 		ADD_METHOD( Reset );
 		ADD_METHOD( JoinPlayer );
 		ADD_METHOD( UnjoinPlayer );
+		ADD_METHOD( JoinInput );
 		ADD_METHOD( GetSongPercent );
 		ADD_METHOD( GetCurMusicSeconds );
 		ADD_METHOD( GetCharacter );

--- a/src/PlayerOptions.cpp
+++ b/src/PlayerOptions.cpp
@@ -366,6 +366,14 @@ bool PlayerOptions::FromOneModString( const RString &sOneMod, RString &sErrorOut
 	}
 
 	else if( sBit == "clearall" )				Init();
+	else if( sBit == "resetspeed" )
+	{
+		// Copied from Init.
+		m_fMaxScrollBPM = 0;		m_SpeedfMaxScrollBPM = 1.0f;
+		m_fTimeSpacing = 0;		m_SpeedfTimeSpacing = 1.0f;
+		m_fScrollSpeed = 1.0f;		m_SpeedfScrollSpeed = 1.0f;
+		m_fScrollBPM = 200;		m_SpeedfScrollBPM = 1.0f;
+	}
 	else if( sBit == "boost" )				SET_FLOAT( fAccels[ACCEL_BOOST] )
 	else if( sBit == "brake" || sBit == "land" )		SET_FLOAT( fAccels[ACCEL_BRAKE] )
 	else if( sBit == "wave" )				SET_FLOAT( fAccels[ACCEL_WAVE] )

--- a/src/PlayerStageStats.cpp
+++ b/src/PlayerStageStats.cpp
@@ -741,6 +741,58 @@ public:
 		}
 		return 1;
 	}
+	static int GetComboList( T* p, lua_State *L )
+	{
+		lua_createtable(L, p->m_ComboList.size(), 0);
+		for( size_t i= 0; i < p->m_ComboList.size(); ++i)
+		{
+			lua_createtable(L, 0, 6);
+			lua_pushstring(L, "StartSecond");
+			lua_pushnumber(L, p->m_ComboList[i].m_fStartSecond);
+			lua_rawset(L, -3);
+			lua_pushstring(L, "SizeSeconds");
+			lua_pushnumber(L, p->m_ComboList[i].m_fSizeSeconds);
+			lua_rawset(L, -3);
+			lua_pushstring(L, "Count");
+			lua_pushnumber(L, p->m_ComboList[i].m_cnt);
+			lua_rawset(L, -3);
+			lua_pushstring(L, "Rollover");
+			lua_pushnumber(L, p->m_ComboList[i].m_rollover);
+			lua_rawset(L, -3);
+			lua_pushstring(L, "StageCount");
+			lua_pushnumber(L, p->m_ComboList[i].GetStageCnt());
+			lua_rawset(L, -3);
+			lua_pushstring(L, "IsZero");
+			lua_pushnumber(L, p->m_ComboList[i].IsZero());
+			lua_rawset(L, -3);
+			lua_rawseti(L, -2, i+1);
+		}
+		return 1;
+	}
+	static int GetLifeRecord( T* p, lua_State *L )
+	{
+		float last_second= FArg(1);
+		int samples= 100;
+		if (lua_gettop(L) >= 2 && !lua_isnil(L,2))
+		{
+			samples= IArg(2);
+			if(samples <= 0)
+			{
+				LOG->Trace("PlayerStageStats:GetLifeRecord requires an integer greater than 0.  Defaulting to 100.");
+				samples= 100;
+			}
+		}
+		lua_createtable(L, samples, 0);
+		for(int i= 0; i < samples; ++i)
+		{
+			// The scale from range is [0, samples-1] because that is i's range.
+			float from= SCALE(i, 0, (float)samples-1.0f, 0.0f, last_second);
+			float curr= p->GetLifeRecordLerpAt(from);
+			lua_pushnumber(L, curr);
+			lua_rawseti(L, -2, i+1);
+		}
+		return 1;
+	}
 
 	static int GetRadarPossible( T* p, lua_State *L ) { p->m_radarPossible.PushSelf(L); return 1; }
 	static int GetRadarActual( T* p, lua_State *L ) { p->m_radarActual.PushSelf(L); return 1; }
@@ -761,6 +813,11 @@ public:
 			return 1;
 		}
 		return 0;
+	}
+	static int SetCurCombo( T* p, lua_State *L)
+	{
+		p->m_iCurCombo= IArg(1);
+		return 1;
 	}
   
 	static int FailPlayer( T* p, lua_State * )
@@ -800,6 +857,8 @@ public:
 		ADD_METHOD( IsDisqualified );
 		ADD_METHOD( GetPlayedSteps );
 		ADD_METHOD( GetPossibleSteps );
+		ADD_METHOD( GetComboList );
+		ADD_METHOD( GetLifeRecord );
 		ADD_METHOD( GetAliveSeconds );
 		ADD_METHOD( GetPercentageOfTaps );
 		ADD_METHOD( GetRadarActual );
@@ -809,6 +868,7 @@ public:
 		ADD_METHOD( SetScore );
 		ADD_METHOD( GetCurMaxScore );
 		ADD_METHOD( SetCurMaxScore );
+		ADD_METHOD( SetCurCombo );
 		ADD_METHOD( FailPlayer );
 		ADD_METHOD( GetSongsPassed );
 		ADD_METHOD( GetSongsPlayed );

--- a/src/PlayerStageStats.h
+++ b/src/PlayerStageStats.h
@@ -99,6 +99,7 @@ public:
 
 	struct Combo_t
 	{
+		// Update GetComboList in PlayerStageStats.cpp when adding new members that should be visible from the Lua side.
 		/** 
 		 * @brief The start time of the combo.
 		 *

--- a/src/PrefsManager.h
+++ b/src/PrefsManager.h
@@ -11,7 +11,7 @@ void ValidateSongsPerPlay( int &val );
 /** @brief How many songs can be played during a normal game max?
  *
  * This assumes no extra stages, no event mode, no course modes. */
-const int MAX_SONGS_PER_PLAY = 7;
+const int MAX_SONGS_PER_PLAY = 128;
 
 enum MusicWheelUsesSections
 { 

--- a/src/ScoreKeeperNormal.cpp
+++ b/src/ScoreKeeperNormal.cpp
@@ -586,12 +586,10 @@ void ScoreKeeperNormal::HandleHoldScore( const TapNote &tn )
 	// update dance points totals
 	if( !m_pPlayerStageStats->m_bFailed )
 		m_pPlayerStageStats->m_iActualDancePoints += HoldNoteScoreToDancePoints( holdScore );
+	// increment the current total possible dance score
 	m_pPlayerStageStats->m_iCurPossibleDancePoints += HoldNoteScoreToDancePoints( HNS_Held );
 	m_pPlayerStageStats->m_iHoldNoteScores[holdScore] ++;
 
-	// increment the current total possible dance score
-
-	m_pPlayerStageStats->m_iCurPossibleDancePoints += HoldNoteScoreToDancePoints( HNS_Held );
 
 	AddHoldScore( holdScore );
 

--- a/src/Screen.cpp
+++ b/src/Screen.cpp
@@ -25,6 +25,7 @@ LuaXType( ScreenType );
 
 void Screen::InitScreen( Screen *pScreen )
 {
+	pScreen->m_bShouldAllowLateJoin= false;
 	pScreen->Init();
 }
 
@@ -304,6 +305,12 @@ public:
 		return 0;
 	}
 
+	static int SetAllowLateJoin( T* p, lua_State *L )
+	{
+		p->m_bShouldAllowLateJoin= BArg(1);
+		return 0;
+	}
+
 	LunaScreen()
 	{
 		ADD_METHOD( GetNextScreenName );
@@ -311,6 +318,7 @@ public:
 		ADD_METHOD( PostScreenMessage );
 		ADD_METHOD( lockinput );
 		ADD_METHOD( GetScreenType );
+		ADD_METHOD( SetAllowLateJoin );
 	}
 };
 

--- a/src/Screen.h
+++ b/src/Screen.h
@@ -80,7 +80,7 @@ public:
 	/**
 	 * @brief Determine if we allow extra players to join in on this screen.
 	 * @return false, for players should never be able to join while in progress. */
-	virtual bool AllowLateJoin() const { return false; }
+	virtual bool AllowLateJoin() const { return m_bShouldAllowLateJoin; }
 
 	// Lua
 	virtual void PushSelf( lua_State *L );
@@ -121,6 +121,8 @@ protected:
 	bool m_bRunning;
 
 public:
+	bool m_bShouldAllowLateJoin; // So that it can be exposed to Lua.
+
 	RString GetNextScreenName() const;
 	RString GetPrevScreen() const;
 

--- a/src/Sprite.h
+++ b/src/Sprite.h
@@ -52,9 +52,11 @@ public:
 	void SetCustomTextureCoords( float fTexCoords[8] );
 	void SetCustomImageRect( RectF rectImageCoords );	// in image pixel space
 	void SetCustomImageCoords( float fImageCoords[8] );
+	void SetCustomPosCoords( float fPosCoords[8] );
 	const RectF *GetCurrentTextureCoordRect() const;
 	const RectF *GetTextureCoordRectForState( int iState ) const;
 	void StopUsingCustomCoords();
+	void StopUsingCustomPosCoords();
 	void GetActiveTextureCoords(float fTexCoordsOut[8]) const;
 	void StretchTexCoords( float fX, float fY );
 	void AddImageCoords( float fX, float fY ); // in image pixel space
@@ -99,6 +101,7 @@ private:
 
 	EffectMode m_EffectMode;
 	bool m_bUsingCustomTexCoords;
+	bool m_bUsingCustomPosCoords;
 	bool m_bSkipNextUpdate;
 	/**
 	 * @brief Set up the coordinates for the texture.
@@ -107,6 +110,16 @@ private:
 	 * The remaining six are for the (x, y) coordinates for bottom left,
 	 * bottom right, and top right respectively. */
 	float m_CustomTexCoords[8];
+	/**
+	 * @brief Set up the coordinates for the position.
+	 *
+	 * These are offsets for the quad the sprite will be drawn to.
+	 * The first two are the (x, y) offsets for the top left.
+	 * The remaining six are for the (x, y) coordinates for bottom left,
+	 * bottom right, and top right respectively.
+	 * These are offsets instead of a replacement for m_size to avoid
+	 * complicating the cropping code. */
+	float m_CustomPosCoords[8];
 
 	// Remembered clipped dimensions are applied on Load().
 	// -1 means no remembered dimensions;

--- a/src/Style.h
+++ b/src/Style.h
@@ -32,7 +32,7 @@ public:
 	/**
 	 * @brief The name of the style.
 	 *
-	 * At this time, it is currently unused. */
+	 * Used by GameManager::GameAndStringToStyle to determine whether this is the style that matches the string. */
 	const char *		m_szName;
 
 	/**


### PR DESCRIPTION
Bug fixes:
combo_graph_height_fix
-- This diff fixes http://ssc.ajworld.net/sm-ssc/bugtracker/view.php?id=1091
    The ComboGraph on ScreenEvaluation will not be the right size without this.

miscounted_hold_points_fix
-- ScoreKeeperNormal had a bug where it was adding the value of a hold to the current possible dance points twice.

misleading_comment_in_style.h
-- Comment in Style.h said something is unused when it is not unused.  Changed to explain how the thing is actually used.

getcredits_fix
-- See comment in GetCreditsRequiredToPlayStyle in GameCommand.cpp.

Features:
crazy_sprites
-- This implements a custom vertex position feature for sprites.  This
    implementation is probably not a good way of providing this feature, but
    is used to shape the custom GraphDisplay on ScreenEvaluation.
    The functions added are Sprite:SetCustomPosCoords and
    Sprite:StopUsingCustomPosCoords, and are documented in Lua.xml.

crazy_text
-- This implements a random distortion function for BitmapText.  Flip
    "global_distortion_mode" in "Scripts/01 misc.lua" to true until you get
    bored of the distorted text.
    The functions added are BitmapText:distort and BitmapText:undistort, and
    are documented in Lua.xml.

get_combo_list
-- This implements http://ssc.ajworld.net/sm-ssc/bugtracker/view.php?id=1098
    This is used to make a custom replacement for ComboGraph.
    The function added is PlayerStageStats:GetComboList, documented in Lua.xml.

get_life_record
-- This exposes the C++ function PlayerStageStats::GetLifeRecord to Lua.
    This is used to make a custom replacement for GraphDisplay.
    The function added is PlayerStageStats:GetLifeRecord, documented in Lua.xml.

make_playmusicpart_loopable
-- This adds the "loop" and "ApplyRate" arguments to SOUND:PlayMusicPart.
    This is used to make the sample music on ScreenSelectMusic loop.
    The changes are documented in Lua.xml.

resetspeed_mod
-- This implements http://ssc.ajworld.net/sm-ssc/bugtracker/view.php?id=1097

joininput_exposed
-- This exposes GameState::JoinInput() to Lua because I don't use
    ScreenSelect and this seemed like a good way to make sure coins were
    decremented when a player joined.

SetAllowLateJoin
-- This changes Screen::AllowLateJoin to return the value of a member
    variable.  It's still virtual, so it's still overridden by all the built in
    screen classes, but this way the member variable can be set throught from
    lua through the function Screen:SetAllowLateJoin.  I don't use the built in
    ScreenSelectMusic, but I wanted to allow late joining on my lua based
    replacement for it.

MAX_SONGS_PER_PLAY = 128
-- Because I have a replacement for the stage system, and I can't find a good
    way to disable it without making event mode misbehave.

SetCurCombo
-- This adds GAMESTATE:SetCurCombo because I want combos to carry over between
    songs, and that feature was removed.  PlayerStageStats::UpdateComboList has
    the argument "bRollover" and some related logic, so it looks like somebody
    intended it to fill that role, but it doesn't work.
    So SetCurCombo exists as a workaround until I feel like disentangling why
    PlayerStageStats::Init gets called a dozen times every time a song starts.
