### PR TITLE
Added resetspeed mod to PlayerOptions.

### DIFF
--- a/src/PlayerOptions.cpp
+++ b/src/PlayerOptions.cpp
@@ -368,11 +368,16 @@ bool PlayerOptions::FromOneModString( const RString &sOneMod, RString &sErrorOut
 	else if( sBit == "clearall" )				Init();
 	else if( sBit == "resetspeed" )
 	{
-		// Copied from Init.
-		m_fMaxScrollBPM = 0;		m_SpeedfMaxScrollBPM = 1.0f;
-		m_fTimeSpacing = 0;		m_SpeedfTimeSpacing = 1.0f;
-		m_fScrollSpeed = 1.0f;		m_SpeedfScrollSpeed = 1.0f;
-		m_fScrollBPM = 200;		m_SpeedfScrollBPM = 1.0f;
+		/* level is set to the values from Init() because all speed related
+		   fields are being reset to initial values, and they each have different
+		   initial values.  -kyz */
+		level= 0;
+		SET_FLOAT(fMaxScrollBPM);
+		SET_FLOAT(fTimeSpacing);
+		level= 1.0f;
+		SET_FLOAT(fScrollSpeed);
+		level= 200.0f;
+		SET_FLOAT(fScrollBPM)
 	}
 	else if( sBit == "boost" )				SET_FLOAT( fAccels[ACCEL_BOOST] )
 	else if( sBit == "brake" || sBit == "land" )		SET_FLOAT( fAccels[ACCEL_BRAKE] )


### PR DESCRIPTION
Added to enable a theme to unapply any speed mod currently applied to a player.  Otherwise, making CMods and XMods not multiply when you don't want them to multiply is much harder.
