### PR TITLE
Exposing GameState::JoinInput to Lua.

### DIFF
--- a/Docs/Luadoc/Lua.xml
+++ b/Docs/Luadoc/Lua.xml
@@ -783,6 +783,7 @@
 			<Function name='IsSideJoined'/>
 			<Function name='IsWinner'/>
 			<Function name='JoinPlayer'/>
+			<Function name='JoinInput'/>
 			<Function name='PlayerIsUsingModifier'/>
 			<Function name='PlayersCanJoin'/>
 			<Function name='RefreshNoteSkinData'/>

--- a/Docs/Luadoc/LuaDocumentation.xml
+++ b/Docs/Luadoc/LuaDocumentation.xml
@@ -2327,7 +2327,10 @@ save yourself some time, copy this for undocumented things:
 		Returns <code>true</code> if player <code>pn</code> is the winner.
 	</Function>
 	<Function name='JoinPlayer' return='void' arguments='PlayerNumber pn'>
-		Joins player <code>pn</code>.
+		Joins player <code>pn</code>.  Does not deduct coins.
+	</Function>
+	<Function name='JoinInput' return='bool' arguments='PlayerNumber pn'>
+		Similar to JoinPlayer, but checks whether the player is allowed to join and returns false if the player is not allowed to join.  Also deducts coins for joining.  A player can't join if PlayersCanJoin() returns false, or that side is already joined (is true for both sides when in a style that is OnePlayerTwoSides), or there are not enough coins.
 	</Function>
 	<Function name='PlayerIsUsingModifier' return='bool' arguments='PlayerNumber pn, string sModifier'>
 		Returns <code>true</code> if player <code>pn</code> is using modifier <code>sModifier</code>.

--- a/src/GameState.cpp
+++ b/src/GameState.cpp
@@ -2474,6 +2474,11 @@ public:
 	static int Reset( T* p, lua_State *L )				{ p->Reset(); return 0; }
 	static int JoinPlayer( T* p, lua_State *L )				{ p->JoinPlayer(Enum::Check<PlayerNumber>(L, 1)); return 0; }
 	static int UnjoinPlayer( T* p, lua_State *L )				{ p->UnjoinPlayer(Enum::Check<PlayerNumber>(L, 1)); return 0; }
+	static int JoinInput( T* p, lua_State *L )
+	{
+		lua_pushboolean(L, p->JoinInput(Enum::Check<PlayerNumber>(L, 1)));
+		return 1;
+	}
 	static int GetSongPercent( T* p, lua_State *L )				{ lua_pushnumber(L, p->GetSongPercent(FArg(1))); return 1; }
 	DEFINE_METHOD( GetCurMusicSeconds,	m_Position.m_fMusicSeconds )
 
@@ -2606,6 +2611,7 @@ public:
 		ADD_METHOD( Reset );
 		ADD_METHOD( JoinPlayer );
 		ADD_METHOD( UnjoinPlayer );
+		ADD_METHOD( JoinInput );
 		ADD_METHOD( GetSongPercent );
 		ADD_METHOD( GetCurMusicSeconds );
 		ADD_METHOD( GetCharacter );


### PR DESCRIPTION
There didn't seem to be another way to join players on a custom screen and make sure coins were deducted.
