### PR TITLE
Bump cache version for XML changes

### DIFF
--- a/src/Song.cpp
+++ b/src/Song.cpp
@@ -42,7 +42,7 @@
  * @brief The internal version of the cache for StepMania.
  *
  * Increment this value to invalidate the current cache. */
-const int FILE_CACHE_VERSION = 215;
+const int FILE_CACHE_VERSION = 216;
 
 /** @brief How long does a song sample last by default? */
 const float DEFAULT_MUSIC_SAMPLE_LENGTH = 12.f;


### PR DESCRIPTION
Apologies in advance...

The XML patchset includes more items in the FGCHANGES line, which is stored in cache.  Previous caches wouldn't include these entries.  So we need a rebuild.
