### PR TITLE
Fix F3+1 handling in Event Mode

### DIFF
--- a/src/ScreenDebugOverlay.cpp
+++ b/src/ScreenDebugOverlay.cpp
@@ -683,7 +683,7 @@ class DebugLineCoinMode : public IDebugLine
 	{
 		if (GAMESTATE->GetCoinMode() == CoinMode_Home)
 			GamePreferences::m_CoinMode.Set(CoinMode_Free);
-		else if (GAMESTATE->GetCoinMode() == CoinMode_Free)
+		else if (GAMESTATE->GetCoinMode() == CoinMode_Free && !GAMESTATE->IsEventMode())
 			GamePreferences::m_CoinMode.Set(CoinMode_Pay);
 		else
 			GamePreferences::m_CoinMode.Set(CoinMode_Home);


### PR DESCRIPTION
Since Event+Pay is treated as Free Play mode, the debug overlay menu would get stuck on Free if Event Mode was on.  Fixes #59.
