### PR TITLE
Correct array bound for ModIcon text

### DIFF
--- a/src/ModIconRow.cpp
+++ b/src/ModIconRow.cpp
@@ -173,7 +173,7 @@ void ModIconRow::SetFromGameState()
 		}
 	}
 
-	for( unsigned i=0; i<vsOptions.size(); i++ )
+	for( unsigned i=0; i<m_vpModIcon.size(); i++ )
 		m_vpModIcon[i]->Set( vsText[i] );
 }
 


### PR DESCRIPTION
Should fix problems with selecting more than NumModIcons mods in SMO.

This appears to fix #8 - could someone with SMO experience verify?
