### PR TITLE
Add RubberBand time/pitch scaling library

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -335,6 +335,13 @@ fi
 
 AM_CONDITIONAL(HAVE_PTHREAD, test "$have_pthread" = "yes")
 
+AC_CHECK_LIB( rubberband, rubberband_new, [have_rubberband=xyes])
+if test "$have_rubberband" = xyes; then
+	AC_DEFINE([HAVE_RUBBERBAND],1,[rubberband is available])
+	LIBS="$LIBS -lrubberband"
+fi
+AM_CONDITIONAL(HAVE_RUBBERBAND, [test "$have_rubberband" = xyes])
+
 # Always:
 AC_DEFINE(_GNU_SOURCE, 1, [Use GNU extensions])
 AC_DEFINE(__STDC_FORMAT_MACROS, 1, [Use PRId64 and similar])

--- a/src/AutoKeysounds.cpp
+++ b/src/AutoKeysounds.cpp
@@ -24,7 +24,11 @@
 #include "RageSoundReader_Extend.h"
 #include "RageSoundReader_Merge.h"
 #include "RageSoundReader_Pan.h"
+#ifdef HAVE_RUBBERBAND
+#include "RageSoundReader_RubberBand.h"
+#else
 #include "RageSoundReader_PitchChange.h"
+#endif
 #include "RageSoundReader_PostBuffering.h"
 #include "RageSoundReader_ThreadedBuffer.h"
 #include "RageSoundManager.h"
@@ -280,14 +284,22 @@ void AutoKeysounds::FinishLoading()
 	}
 	ASSERT_M( m_pSharedSound != NULL, ssprintf("No keysounds were loaded for the song %s!", pSong->m_sMainTitle.c_str() ));
 
+#ifdef HAVE_RUBBERBAND
+	m_pSharedSound = new RageSoundReader_RubberBand( m_pSharedSound );
+#else
 	m_pSharedSound = new RageSoundReader_PitchChange( m_pSharedSound );
+#endif
 	m_pSharedSound = new RageSoundReader_PostBuffering( m_pSharedSound );
 	m_pSharedSound = new RageSoundReader_Pan( m_pSharedSound );
 	apSounds.push_back( m_pSharedSound );
 
 	if( m_pPlayerSounds[0] != NULL )
 	{
+#ifdef HAVE_RUBBERBAND
+		m_pPlayerSounds[0] = new RageSoundReader_RubberBand( m_pPlayerSounds[0] );
+#else
 		m_pPlayerSounds[0] = new RageSoundReader_PitchChange( m_pPlayerSounds[0] );
+#endif
 		m_pPlayerSounds[0] = new RageSoundReader_PostBuffering( m_pPlayerSounds[0] );
 		m_pPlayerSounds[0] = new RageSoundReader_Pan( m_pPlayerSounds[0] );
 		apSounds.push_back( m_pPlayerSounds[0] );
@@ -295,7 +307,11 @@ void AutoKeysounds::FinishLoading()
 
 	if( m_pPlayerSounds[1] != NULL )
 	{
+#ifdef HAVE_RUBBERBAND
+		m_pPlayerSounds[1] = new RageSoundReader_RubberBand( m_pPlayerSounds[1] );
+#else
 		m_pPlayerSounds[1] = new RageSoundReader_PitchChange( m_pPlayerSounds[1] );
+#endif
 		m_pPlayerSounds[1] = new RageSoundReader_PostBuffering( m_pPlayerSounds[1] );
 		m_pPlayerSounds[1] = new RageSoundReader_Pan( m_pPlayerSounds[1] );
 		apSounds.push_back( m_pPlayerSounds[1] );

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -508,7 +508,11 @@ RageFileDriverReadAhead.cpp RageFileDriverReadAhead.h \
 RageFileDriverSlice.cpp RageFileDriverSlice.h \
 RageFileDriverTimeout.cpp RageFileDriverTimeout.h
 
-Rage = $(PCRE) $(Lua) $(jsoncpp) $(RageFile) $(RageSoundFileReaders) \
+if HAVE_RUBBERBAND
+ RubberBand = RageSoundReader_RubberBand.cpp RageSoundReader_RubberBand.h
+endif
+
+Rage = $(PCRE) $(Lua) $(jsoncpp) $(RageFile) $(RageSoundFileReaders) $(RubberBand) \
 RageBitmapTexture.cpp RageBitmapTexture.h \
 RageDisplay.cpp RageDisplay.h \
 RageDisplay_OGL.cpp RageDisplay_OGL.h \

--- a/src/RageSound.cpp
+++ b/src/RageSound.cpp
@@ -29,7 +29,11 @@
 
 #include "RageSoundReader_Extend.h"
 #include "RageSoundReader_Pan.h"
+#ifdef HAVE_RUBBERBAND
+#include "RageSoundReader_RubberBand.h"
+#else
 #include "RageSoundReader_PitchChange.h"
+#endif
 #include "RageSoundReader_PostBuffering.h"
 #include "RageSoundReader_Preload.h"
 #include "RageSoundReader_Resample_Good.h"
@@ -215,7 +219,11 @@ bool RageSound::Load( RString sSoundFilePath, bool bPrecache, const RageSoundLoa
 
 	if( pParams->m_bSupportRateChanging )
 	{
+#ifdef HAVE_RUBBERBAND
+		RageSoundReader_RubberBand *pRate = new RageSoundReader_RubberBand( m_pSource );
+#else
 		RageSoundReader_PitchChange *pRate = new RageSoundReader_PitchChange( m_pSource );
+#endif
 		m_pSource = pRate;
 	}
 

--- a/src/RageSoundReader_RubberBand.cpp
+++ b/src/RageSoundReader_RubberBand.cpp
@@ -1,0 +1,131 @@
+/*
+ * Implements properties: 
+ *   "Speed" - cause the sound to play faster or slower
+ *   "Pitch" - raise or lower the pitch of the sound
+ *
+ * This class just forwards calls to the RubberBand library.
+ */
+
+#include "global.h"
+#include "RageSoundReader_RubberBand.h"
+#include "RageLog.h"
+
+int OPTIONS =
+	RubberBand::RubberBandStretcher::OptionProcessRealTime;
+
+RageSoundReader_RubberBand::RageSoundReader_RubberBand( RageSoundReader *pSource ):
+	RageSoundReader_Filter( NULL ),
+	m_RubberBand(
+			pSource->GetSampleRate(),
+			pSource->GetNumChannels(),
+			OPTIONS)
+{
+	m_pSource = pSource;
+}
+
+RageSoundReader_RubberBand::RageSoundReader_RubberBand( const RageSoundReader_RubberBand &cpy ):
+	RageSoundReader_Filter( cpy ),
+	m_RubberBand(
+			cpy.m_pSource->GetSampleRate(),
+			cpy.m_pSource->GetNumChannels(),
+			OPTIONS)
+{
+	m_pSource = cpy.m_pSource;
+}
+
+int RageSoundReader_RubberBand::Read( float *pBuf, int iFrames )
+{
+	int iStride = m_pSource->GetNumChannels();
+	float ** pTmpBufs = (float **)alloca(iStride * sizeof(float *));
+	while ( m_RubberBand.available() < iFrames )
+	{
+		size_t uSamplesNeeded = m_RubberBand.getSamplesRequired();
+		float * pTmpBufInterleaved = (float *)alloca(uSamplesNeeded * sizeof(float) * iStride);
+		for (int i = 0; i < iStride; ++i) {
+			pTmpBufs[i] = (float *)alloca(uSamplesNeeded * sizeof(float));
+		}
+		int iFramesSoFar = 0;
+		while (uSamplesNeeded != 0) {
+			int iFramesRead = m_pSource->Read(pTmpBufInterleaved, uSamplesNeeded);
+			if (iFramesRead < 0) {
+				return iFramesRead;
+			}
+			if (iFramesRead == 0) {
+				printf("0 frames read\n");
+			}
+			// We need to deinterleave the data
+			for (int i = 0; i < iFramesRead; ++i) {
+				for (int j = 0; j < iStride; ++j) {
+					pTmpBufs[j][i + iFramesSoFar] = pTmpBufInterleaved[i*iStride + j];
+				}
+			}
+			if ((size_t)iFramesRead > uSamplesNeeded) {
+				uSamplesNeeded = 0;
+			} else {
+				uSamplesNeeded -= iFramesRead;
+				iFramesSoFar += iFramesRead;
+			}
+		}
+		m_RubberBand.process(pTmpBufs, (size_t)iFramesSoFar, false);
+	}
+
+	// Read data out and interleave
+	for (int i = 0; i < iStride; ++i) {
+		pTmpBufs[i] = (float *)alloca(iFrames * sizeof(float));
+	}
+	int iFramesRead = (int)m_RubberBand.retrieve(pTmpBufs, iFrames);
+	for (int i = 0; i < iFramesRead; ++i) {
+		for (int j = 0; j < iStride; ++j) {
+			pBuf[i * iStride + j] = pTmpBufs[j][i];
+		}
+	}
+	return iFramesRead;
+}
+
+bool RageSoundReader_RubberBand::SetProperty( const RString &sProperty, float fValue )
+{
+	if( sProperty == "Rate" )
+	{
+		/* Don't propagate this.  m_pResample will take it, but it's under
+		 * our control. */
+		return false;
+	}
+	if( sProperty == "Speed" )
+	{
+		SetSpeedRatio( fValue );
+		return true;
+	}
+
+	if( sProperty == "Pitch" )
+	{
+		SetPitchRatio( fValue );
+		return true;
+	}
+
+	return RageSoundReader_Filter::SetProperty( sProperty, fValue );
+}
+
+/*
+ * Copyright (c) 2006 Glenn Maynard
+ * All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, and/or sell copies of the Software, and to permit persons to
+ * whom the Software is furnished to do so, provided that the above
+ * copyright notice(s) and this permission notice appear in all copies of
+ * the Software and that both the above copyright notice(s) and this
+ * permission notice appear in supporting documentation.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF
+ * THIRD PARTY RIGHTS. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS
+ * INCLUDED IN THIS NOTICE BE LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT
+ * OR CONSEQUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+ * OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+ * OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+ * PERFORMANCE OF THIS SOFTWARE.
+ */

--- a/src/RageSoundReader_RubberBand.h
+++ b/src/RageSoundReader_RubberBand.h
@@ -1,0 +1,63 @@
+/* RageSoundReader_RubberBand - change the pitch and speed of an audio stream independently using RubberBand Library. */
+
+#ifndef RAGE_SOUND_READER_RUBBER_BAND_H
+#define RAGE_SOUND_READER_RUBBER_BAND_H
+
+#ifndef HAVE_RUBBERBAND
+#error "HAVE_RUBBERBAND is not defined"
+#endif
+
+#include <rubberband/RubberBandStretcher.h>
+#include "RageSoundReader_Filter.h"
+
+class RageSoundReader_RubberBand: public RageSoundReader_Filter
+{
+public:
+	RageSoundReader_RubberBand( RageSoundReader *pSource );
+	RageSoundReader_RubberBand( const RageSoundReader_RubberBand &cpy );
+
+	virtual int Read( float *pBuf, int iFrames );
+	virtual bool SetProperty( const RString &sProperty, float fValue );
+
+	void SetSpeedRatio( float fRatio ) { m_RubberBand.setTimeRatio(1/fRatio); }
+	void SetPitchRatio( float fRatio ) { m_RubberBand.setPitchScale(1/fRatio); }
+
+	virtual RageSoundReader_RubberBand *Copy() const { return new RageSoundReader_RubberBand(*this); }
+
+	virtual float GetStreamToSourceRatio() const {
+		return (1/m_RubberBand.getTimeRatio()) * m_pSource->GetStreamToSourceRatio();
+	}
+
+private:
+	RubberBand::RubberBandStretcher m_RubberBand;
+
+	// Swallow up warnings. If they must be used, define them.
+	RageSoundReader_RubberBand& operator=(const RageSoundReader_RubberBand& rhs);
+};
+
+#endif
+
+/*
+ * Copyright (c) 2006 Glenn Maynard
+ * All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, and/or sell copies of the Software, and to permit persons to
+ * whom the Software is furnished to do so, provided that the above
+ * copyright notice(s) and this permission notice appear in all copies of
+ * the Software and that both the above copyright notice(s) and this
+ * permission notice appear in supporting documentation.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF
+ * THIRD PARTY RIGHTS. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS
+ * INCLUDED IN THIS NOTICE BE LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT
+ * OR CONSEQUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+ * OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+ * OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+ * PERFORMANCE OF THIS SOFTWARE.
+ */


### PR DESCRIPTION
RubberBand is a library that provides real-time time and pitch scaling for
audio. The results have higher quality than solutions already in stepmania.

I added this mainly for myself since I have to play songs slower to practice, and the quality was bugging me. Right now it always uses it if autoconf can find the library. Maybe you want an explicit configure option? Also the library sources are not included in tree, (it seems like you are bundling dependencies).

The patch replaces occurrences of `RageSoundReader_PitchChange` with `RageSoundReader_RubberBand` using `#ifdef`s. The new class has the same functionality, but is a wrapper around the rubberband library.