### PR TITLE
Allow ActorScrollers to use SetDrawByZPosition without turning off Loop

### DIFF
--- a/src/ActorScroller.cpp
+++ b/src/ActorScroller.cpp
@@ -257,7 +257,6 @@ void ActorScroller::PositionItemsAndDrawPrimitives( bool bDrawPrimitives )
 		iLastItemToDraw = clamp( iLastItemToDraw, 0, m_iNumItems );
 	}
 
-	bool bDelayedDraw = m_bDrawByZPosition;
 	vector<Actor*> subs;
 
 	{
@@ -291,14 +290,14 @@ void ActorScroller::PositionItemsAndDrawPrimitives( bool bDrawPrimitives )
 		m_exprTransformFunction.TransformItemCached( *m_SubActors[iIndex], fPosition, iItem, m_iNumItems );
 		if( bDrawPrimitives )
 		{
-			if( bDelayedDraw )
+			if( m_bDrawByZPosition )
 				subs.push_back( m_SubActors[iIndex] );
 			else
 				m_SubActors[iIndex]->Draw();
 		}
 	}
 
-	if( bDelayedDraw )
+	if( m_bDrawByZPosition )
 	{
 		ActorUtil::SortByZPosition( subs );
 		FOREACH( Actor*, subs, a )


### PR DESCRIPTION
Previously, if I wanted to do SetDrawByZPosition(true) on an ActorScroller, I would also have to SetLoop(false).  This prevented me from actually looping ActorScrollers that were z-positioned.

There is already a metric for this (LoopScroller) which I can set to true without having it impact SetDrawByZPosition.  This commit should not impact the _fallback or default themes as neither use SetDrawByZPosition anywhere.

Feedback from someone who knows more about this is definitely encouraged.
