### PR TITLE
net2013 project contained refrences to net2011 projects

### DIFF
--- a/src/StepMania-net2013.vcxproj
+++ b/src/StepMania-net2013.vcxproj
@@ -2383,11 +2383,11 @@ cl /Zl /nologo /c verstub.cpp /Fo"$(IntDir)"</Command>
     <ResourceCompile Include="archutils\Win32\WindowsResources.rc" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="libtomcrypt\libtomcrypt-net2011.vcxproj">
+    <ProjectReference Include="libtomcrypt\libtomcrypt-net2013.vcxproj">
       <Project>{f70dd0fe-a74a-42e7-b81f-e35c49fc9eb9}</Project>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>
-    <ProjectReference Include="libtommath\libtommath-net2011.vcxproj">
+    <ProjectReference Include="libtommath\libtommath-net2013.vcxproj">
       <Project>{fede5283-1518-4b1d-8124-5c54db17ea57}</Project>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>


### PR DESCRIPTION
https://github.com/stepmania/stepmania/issues/87 this fix allows build on machines using only Visual Studio 2013
