### PR TITLE
HNS_Missed

### DIFF
--- a/Themes/_fallback/metrics.ini
+++ b/Themes/_fallback/metrics.ini
@@ -405,6 +405,7 @@ LabelOnCommand=x,6;y,22.5;shadowlength,1;zoom,0.75;diffusebottomedge,color("0.75
 
 [HoldJudgment]
 # System Direction
+HoldJudgmentMissedHoldCommand=
 HoldJudgmentLetGoCommand=finishtweening;visible,true;shadowlength,0;diffusealpha,1;zoom,1;y,-10;linear,0.8;y,10;sleep,0.5;linear,0.1;zoomy,0.5;zoomx,2;diffusealpha,0
 HoldJudgmentHeldCommand=finishtweening;visible,true;shadowlength,0;diffusealpha,1;zoom,1.25;linear,0.3;zoomx,1;zoomy,1;sleep,0.5;linear,0.1;zoomy,0.5;zoomx,2;diffusealpha,0
 
@@ -643,6 +644,7 @@ LifePercentChangeMiss=-0.080
 LifePercentChangeHitMine=-0.160
 LifePercentChangeHeld=IsGame("Pump") and 0.000 or 0.008
 LifePercentChangeLetGo=IsGame("Pump") and 0.000 or -0.080
+LifePercentChangeMissedHold=0.000
 LifePercentChangeCheckpointMiss=-0.080
 LifePercentChangeCheckpointHit=0.008
 
@@ -1239,6 +1241,7 @@ DeltaSecondsW2Command=
 DeltaSecondsW1Command=
 DeltaSecondsLetGoCommand=
 DeltaSecondsHeldCommand=
+DeltaSecondsMissedHoldCommand=
 DeltaSecondsGainLifeCommand=
 
 [ScoreDisplayPercentage Percent]
@@ -1336,6 +1339,7 @@ PercentScoreWeightCheckpointHit=3
 PercentScoreWeightCheckpointMiss=0
 PercentScoreWeightHeld=IsGame("Pump") and 0 or 3
 PercentScoreWeightHitMine=-2
+PercentScoreWeightMissedHold=0
 PercentScoreWeightLetGo=0
 PercentScoreWeightMiss=0
 PercentScoreWeightW1=3
@@ -1347,6 +1351,7 @@ GradeWeightCheckpointHit=2
 GradeWeightCheckpointMiss=-8
 GradeWeightHeld=IsGame("Pump") and 0 or 6
 GradeWeightHitMine=-8
+GradeWeightMissedHold=0
 GradeWeightLetGo=0
 GradeWeightMiss=-8
 GradeWeightW1=2

--- a/src/CombinedLifeMeterTug.cpp
+++ b/src/CombinedLifeMeterTug.cpp
@@ -26,6 +26,7 @@ static void TugMeterPercentChangeInit( size_t /*ScoreEvent*/ i, RString &sNameOu
 	case SE_CheckpointMiss:	defaultValueOut = -0.002f;	break;
 	case SE_Held:		defaultValueOut = +0.008f;	break;
 	case SE_LetGo:		defaultValueOut = -0.020f;	break;
+	case SE_Missed:		defaultValueOut = +0.000f;	break;
 	}
 }
 
@@ -101,6 +102,7 @@ void CombinedLifeMeterTug::ChangeLife( PlayerNumber pn, HoldNoteScore score, Tap
 	{
 	case HNS_Held:			fPercentToMove = g_fTugMeterPercentChange[SE_Held];	break;
 	case HNS_LetGo:			fPercentToMove = g_fTugMeterPercentChange[SE_LetGo];	break;
+	case HNS_Missed:			fPercentToMove = g_fTugMeterPercentChange[SE_Missed];	break;
 	default:
 		FAIL_M(ssprintf("Invalid HoldNoteScore: %i", score));
 	}

--- a/src/GameConstantsAndTypes.cpp
+++ b/src/GameConstantsAndTypes.cpp
@@ -235,19 +235,21 @@ static const char *HoldNoteScoreNames[] = {
 	"None",
 	"LetGo",
 	"Held",
+	"MissedHold",
 };
 XToString( HoldNoteScore );
 LuaXType( HoldNoteScore );
 HoldNoteScore StringToHoldNoteScore( const RString &s )
 {
 	// for backward compatibility
-	if     ( s == "NG" )	return HNS_LetGo;
-	else if( s == "OK" )	return HNS_Held;
+	if     ( s == "NG" )		return HNS_LetGo;
+	else if( s == "OK" )		return HNS_Held;
 
 	// new style
-	else if( s == "None" )	return HNS_None;
-	else if( s == "LetGo" )	return HNS_LetGo;
-	else if( s == "Held" )	return HNS_Held;
+	else if( s == "None" )		return HNS_None;
+	else if( s == "LetGo" )		return HNS_LetGo;
+	else if( s == "Held" )		return HNS_Held;
+	else if( s == "MissedHold" )	return HNS_Missed;
 
 	return HoldNoteScore_Invalid;
 }
@@ -278,6 +280,7 @@ static const char *ScoreEventNames[] = {
 	"CheckpointMiss",
 	"Held",
 	"LetGo",
+	"MissedHold",
 };
 XToString( ScoreEvent );
 

--- a/src/GameConstantsAndTypes.h
+++ b/src/GameConstantsAndTypes.h
@@ -249,6 +249,7 @@ enum HoldNoteScore
 	HNS_None,		/**< The HoldNote was not scored yet. */
 	HNS_LetGo,		/**< The HoldNote has passed, but the player missed it. */
 	HNS_Held,		/**< The HoldNote has passed, and was successfully held all the way. */
+	HNS_Missed,		/**< The HoldNote has passed, and was never initialized. */
 	NUM_HoldNoteScore,	/**< The number of hold note scores. */
 	HoldNoteScore_Invalid,
 };
@@ -302,6 +303,7 @@ enum ScoreEvent
 	SE_CheckpointMiss,
 	SE_Held,
 	SE_LetGo,
+	SE_Missed,
 	NUM_ScoreEvent
 };
 const RString& ScoreEventToString( ScoreEvent se );

--- a/src/HoldJudgment.cpp
+++ b/src/HoldJudgment.cpp
@@ -50,7 +50,11 @@ void HoldJudgment::SetHoldJudgment( HoldNoteScore hns )
 {
 	//LOG->Trace( "Judgment::SetJudgment()" );
 
-	ResetAnimation();
+	// Matt: To save API. Command can handle if desired.
+	if( hns != HNS_Missed )
+	{
+		ResetAnimation();
+	}
 
 	switch( hns )
 	{
@@ -61,6 +65,10 @@ void HoldJudgment::SetHoldJudgment( HoldNoteScore hns )
 	case HNS_LetGo:
 		m_sprJudgment->SetState( 1 );
 		m_sprJudgment->PlayCommand( "LetGo" );
+		break;
+	case HNS_Missed:
+		//m_sprJudgment->SetState( 2 ); // Matt: Not until after 5.0
+		m_sprJudgment->PlayCommand( "MissedHold" );
 		break;
 	case HNS_None:
 	default:

--- a/src/LifeMeterBar.cpp
+++ b/src/LifeMeterBar.cpp
@@ -159,6 +159,7 @@ void LifeMeterBar::ChangeLife( HoldNoteScore score, TapNoteScore tscore )
 		{
 		case HNS_Held:		fDeltaLife = m_fLifePercentChange.GetValue(SE_Held);	break;
 		case HNS_LetGo:	fDeltaLife = m_fLifePercentChange.GetValue(SE_LetGo);	break;
+		case HNS_Missed:	fDeltaLife = m_fLifePercentChange.GetValue(SE_Missed);	break;
 		default:
 			FAIL_M(ssprintf("Invalid HoldNoteScore: %i", score));
 		}
@@ -170,6 +171,7 @@ void LifeMeterBar::ChangeLife( HoldNoteScore score, TapNoteScore tscore )
 		{
 		case HNS_Held:		fDeltaLife = +0.000f;	break;
 		case HNS_LetGo:	fDeltaLife = m_fLifePercentChange.GetValue(SE_LetGo);	break;
+		case HNS_Missed:		fDeltaLife = +0.000f;	break;
 		default:
 			FAIL_M(ssprintf("Invalid HoldNoteScore: %i", score));
 		}
@@ -179,6 +181,7 @@ void LifeMeterBar::ChangeLife( HoldNoteScore score, TapNoteScore tscore )
 		{
 		case HNS_Held:		fDeltaLife = +0;	break;
 		case HNS_LetGo:	fDeltaLife = -1.0f;	break;
+		case HNS_Missed:	fDeltaLife = +0;	break;
 		default:
 			FAIL_M(ssprintf("Invalid HoldNoteScore: %i", score));
 		}

--- a/src/LifeMeterTime.cpp
+++ b/src/LifeMeterTime.cpp
@@ -32,6 +32,7 @@ static const float g_fTimeMeterSecondsChangeInit[] =
 	-0.0f, // SE_CheckpointMiss
 	-0.0f, // SE_Held
 	-4.0f, // SE_LetGo
+	-0.0f, // SE_Missed
 };
 COMPILE_ASSERT( ARRAYLEN(g_fTimeMeterSecondsChangeInit) == NUM_ScoreEvent );
 
@@ -143,6 +144,7 @@ void LifeMeterTime::ChangeLife( HoldNoteScore hns, TapNoteScore tns )
 		FAIL_M(ssprintf("Invalid HoldNoteScore: %i", hns));
 	case HNS_Held:	fMeterChange = g_fTimeMeterSecondsChange[SE_Held];	break;
 	case HNS_LetGo:	fMeterChange = g_fTimeMeterSecondsChange[SE_LetGo];	break;
+	case HNS_Missed:	fMeterChange = g_fTimeMeterSecondsChange[SE_Missed];	break;
 	}
 
 	float fOldLife = m_fLifeTotalLostSeconds;

--- a/src/Player.cpp
+++ b/src/Player.cpp
@@ -1436,7 +1436,7 @@ void Player::UpdateHoldNotes( int iSongRow, float fDeltaTime, vector<TrackRowTap
 		}
 		else 
 		{
-			hns = HNS_None;
+			hns = HNS_Missed;
 		}
 	}
 

--- a/src/ScoreKeeperNormal.cpp
+++ b/src/ScoreKeeperNormal.cpp
@@ -718,6 +718,7 @@ int ScoreKeeperNormal::HoldNoteScoreToDancePoints( HoldNoteScore hns, bool bBegi
 	case HNS_None:	iWeight = 0;										break;
 	case HNS_LetGo:	iWeight = g_iPercentScoreWeight.GetValue(SE_LetGo);	break;
 	case HNS_Held:	iWeight = g_iPercentScoreWeight.GetValue(SE_Held);	break;
+	case HNS_Missed:	iWeight = g_iPercentScoreWeight.GetValue(SE_Missed);	break;
 	}
 	if( bBeginner && PREFSMAN->m_bMercifulBeginner )
 		iWeight = max( 0, iWeight );
@@ -761,6 +762,7 @@ int ScoreKeeperNormal::HoldNoteScoreToGradePoints( HoldNoteScore hns, bool bBegi
 	case HNS_None:	iWeight = 0;									break;
 	case HNS_LetGo:	iWeight = g_iGradeWeight.GetValue(SE_LetGo);	break;
 	case HNS_Held:	iWeight = g_iGradeWeight.GetValue(SE_Held);		break;
+	case HNS_Missed:	iWeight = g_iGradeWeight.GetValue(SE_Missed);		break;
 	}
 	if( bBeginner && PREFSMAN->m_bMercifulBeginner )
 		iWeight = max( 0, iWeight );

--- a/src/ScoreKeeperRave.cpp
+++ b/src/ScoreKeeperRave.cpp
@@ -29,6 +29,7 @@ static void SuperMeterPercentChangeInit( size_t /*ScoreEvent*/ i, RString &sName
 	case SE_CheckpointMiss:	defaultValueOut = -0.20f; break;
 	case SE_Held:			defaultValueOut = +0.04f; break;
 	case SE_LetGo:			defaultValueOut = -0.20f; break;
+	case SE_Missed:			defaultValueOut = -0.00f; break;
 	DEFAULT_FAIL(ci);
 	}
 }
@@ -95,6 +96,7 @@ void ScoreKeeperRave::HandleHoldScore( const TapNote &tn )
 	{
 		case HNS_Held: fPercentToMove = g_fSuperMeterPercentChange[SE_Held]; break;
 		case HNS_LetGo: fPercentToMove = g_fSuperMeterPercentChange[SE_LetGo]; break;
+		case HNS_Missed: fPercentToMove = g_fSuperMeterPercentChange[SE_Missed]; break;
 		default: break;
 	}
 	AddSuperMeterDelta( fPercentToMove );


### PR DESCRIPTION
Added an HNS type to handle holds which are never initialized due to
missed taps. This fixes a long standing issue with
iCurPossibleDancePoints and allows themes to decide how to handled this
case.
