### PR TITLE
added GetHasteRate method, made GiveUpSeconds a metric

### DIFF
--- a/Themes/_fallback/metrics.ini
+++ b/Themes/_fallback/metrics.ini
@@ -3313,6 +3313,7 @@ PlayerType="Player"
 PlayerInitCommand=y,SCREEN_CENTER_Y;zoom,(THEME:GetMetric("Common","ScreenHeight")/480)
 StartGivesUp=true
 BackGivesUp=false
+GiveUpSeconds=2.5
 # rage
 AllowCenter1Player=true
 #

--- a/src/ScreenGameplay.cpp
+++ b/src/ScreenGameplay.cpp
@@ -335,6 +335,7 @@ void ScreenGameplay::Init()
 	GIVE_UP_START_TEXT.Load(		m_sName, "GiveUpStartText" );
 	GIVE_UP_BACK_TEXT.Load(			m_sName, "GiveUpBackText" );
 	GIVE_UP_ABORTED_TEXT.Load(		m_sName, "GiveUpAbortedText" );
+	GIVE_UP_SECONDS.Load(			m_sName, "GiveUpSeconds" );
 	MUSIC_FADE_OUT_SECONDS.Load(		m_sName, "MusicFadeOutSeconds" );
 	OUT_TRANSITION_LENGTH.Load(		m_sName, "OutTransitionLength" );
 	COURSE_TRANSITION_LENGTH.Load(		m_sName, "CourseTransitionLength" );
@@ -1805,9 +1806,9 @@ void ScreenGameplay::Update( float fDeltaTime )
 			}
 
 			// update give up
-			bool bGiveUpTimerFired = !m_GiveUpTimer.IsZero() && m_GiveUpTimer.Ago() > 2.5f;
-			
-				
+			bool bGiveUpTimerFired = !m_GiveUpTimer.IsZero() && m_GiveUpTimer.Ago() > GIVE_UP_SECONDS;
+
+
 			bool bAllHumanHaveBigMissCombo = true;
 			FOREACH_EnabledPlayerNumberInfo( m_vPlayerInfo, pi )
 			{
@@ -2865,7 +2866,8 @@ public:
 	}
 	static int PauseGame( T* p, lua_State *L )		{ p->Pause( BArg(1)); return 0; }
 	static int IsPaused( T* p, lua_State *L )		{ lua_pushboolean( L, p->IsPaused() ); return 1; }
-
+	static int GetHasteRate( T* p, lua_State *L )    { lua_pushnumber( L, p->GetHasteRate() ); return 1; }
+	
 	LunaScreenGameplay()
 	{
 		ADD_METHOD( GetNextCourseSong );
@@ -2876,6 +2878,7 @@ public:
 		// sm-ssc additions:
 		ADD_METHOD( PauseGame );
 		ADD_METHOD( IsPaused );
+		ADD_METHOD( GetHasteRate );
 	}
 };
 

--- a/src/ScreenGameplay.h
+++ b/src/ScreenGameplay.h
@@ -170,6 +170,7 @@ public:
 	PlayerInfo *GetDummyPlayerInfo( int iDummyIndex );
 	void Pause(bool bPause) { PauseGame(bPause); }
 	bool IsPaused() const { return m_bPaused; }
+	float GetHasteRate();
 
 protected:
 	virtual void UpdateStageStats( MultiPlayer /* mp */ ) {};	// overridden for multiplayer
@@ -182,6 +183,7 @@ protected:
 	LocalizedString GIVE_UP_START_TEXT;
 	LocalizedString GIVE_UP_BACK_TEXT;
 	LocalizedString GIVE_UP_ABORTED_TEXT;
+	ThemeMetric<float> GIVE_UP_SECONDS;
 	ThemeMetric<float> MUSIC_FADE_OUT_SECONDS;
 	ThemeMetric<float> OUT_TRANSITION_LENGTH;
 	ThemeMetric<float> COURSE_TRANSITION_LENGTH;
@@ -212,7 +214,6 @@ protected:
 	void UpdateLights();
 	void SendCrossedMessages();
 	void BeginBackingOutFromGameplay();
-	float GetHasteRate();
 
 	void PlayTicks();
 	void UpdateSongPosition( float fDeltaTime );


### PR DESCRIPTION
without haste rate, it's impossible to display an accurate BPM. Give up
time should be controllable.
