### PR TITLE
Fix building on older versions on FFMpeg

### DIFF
--- a/src/arch/MovieTexture/MovieTexture_FFMpeg.h
+++ b/src/arch/MovieTexture/MovieTexture_FFMpeg.h
@@ -11,10 +11,8 @@ namespace avcodec
 	extern "C"
 	{
 		#include <libavformat/avformat.h>
-		#include <libavcodec/avcodec.h>
 		#include <libswscale/swscale.h>
 		#include <libavutil/pixdesc.h>
-		#include <libavutil/frame.h>
 	}
 };
 


### PR DESCRIPTION
Some of the .h files I added to includes do not exist on some older versions of FFMpeg (breaking compilation), but seem to be included anyway on newer versions indirectly via the other include directives, so I'm removing them
