### PR TITLE
run profile CustomLoadFunction when changing theme or assigning a local profile to a player

### DIFF
--- a/src/Profile.h
+++ b/src/Profile.h
@@ -349,6 +349,7 @@ public:
 
 	// Loading and saving
 	ProfileLoadResult LoadAllFromDir( RString sDir, bool bRequireSignature );
+	void LoadCustomFunction( RString sDir );
 	bool SaveAllToDir( RString sDir, bool bSignData ) const;
 
 	ProfileLoadResult LoadEditableDataFromDir( RString sDir );

--- a/src/ProfileManager.cpp
+++ b/src/ProfileManager.cpp
@@ -148,7 +148,7 @@ ProfileLoadResult ProfileManager::LoadProfile( PlayerNumber pn, RString sProfile
 
 	// Try to load the original, non-backup data.
 	ProfileLoadResult lr = GetProfile(pn)->LoadAllFromDir( m_sProfileDir[pn], PREFSMAN->m_bSignProfileData );
-	
+
 	RString sBackupDir = m_sProfileDir[pn] + LAST_GOOD_SUBDIR;
 
 	if( lr == ProfileLoadResult_Success )
@@ -201,6 +201,8 @@ bool ProfileManager::LoadLocalProfileFromMachine( PlayerNumber pn )
 		return false;
 	}
 
+	GetProfile(pn)->LoadCustomFunction( m_sProfileDir[pn] );
+	
 	return true;
 }
 
@@ -247,7 +249,7 @@ bool ProfileManager::LoadProfileFromMemoryCard( PlayerNumber pn, bool bLoadEdits
 				m_sProfileDirImportedFrom[pn] = asDirsToTry[i];
 			break;
 		}
-		
+
 		if( res == ProfileLoadResult_FailedTampered )
 		{
 			m_bNewProfile[pn] = false;
@@ -277,7 +279,7 @@ bool ProfileManager::LoadProfileFromMemoryCard( PlayerNumber pn, bool bLoadEdits
 
 	return true; // If a card is inserted, we want to use the memory card to save - even if the Profile load failed.
 }
-			
+
 bool ProfileManager::LoadFirstAvailableProfile( PlayerNumber pn, bool bLoadEdits )
 {
 	if( LoadProfileFromMemoryCard(pn, bLoadEdits) )

--- a/src/ThemeManager.cpp
+++ b/src/ThemeManager.cpp
@@ -12,6 +12,8 @@
 #include "RageFile.h"
 #if !defined(SMPACKAGE)
 #include "ScreenManager.h"
+#include "ProfileManager.h"
+#include "Profile.h"
 #include "ActorUtil.h"
 #endif
 #include "Foreach.h"
@@ -415,12 +417,20 @@ void ThemeManager::SwitchThemeAndLanguage( const RString &sThemeName_, const RSt
 		// reload common sounds
 		if( SCREENMAN != NULL )
 			SCREENMAN->ThemeChanged();
+
 #endif
 
 		/* Lua globals can use metrics which are cached, and vice versa.  Update Lua
 		 * globals first; it's Lua's job to explicitly update cached metrics that it
 		 * uses. */
 		UpdateLuaGlobals();
+
+		// Reload MachineProfile with new theme's CustomLoadFunction
+		if( PROFILEMAN != NULL )
+		{
+			Profile* pProfile = PROFILEMAN->GetMachineProfile();
+			pProfile->LoadCustomFunction( "/Save/MachineProfile/" );
+		}
 	}
 
 	// Use theme metrics for localization.


### PR DESCRIPTION
This should make the custom load functions a lot more useful, including fixing the issue with local profile speedmod.txt's not working.
