### PR TITLE
Allow NoteField Board to be an AutoActor

### DIFF
--- a/src/NoteField.cpp
+++ b/src/NoteField.cpp
@@ -362,19 +362,22 @@ void NoteField::DrawBeatBar( const float fBeat, BeatBarType type, int iMeasureIn
 
 void NoteField::DrawBoard( int iDrawDistanceAfterTargetsPixels, int iDrawDistanceBeforeTargetsPixels )
 {
-	// Draw the board centered on fYPosAt0 so that the board doesn't slide as
-	// the draw distance changes with modifiers.
-	const float fYPosAt0 = ArrowEffects::GetYPos( m_pPlayerState, 0, 0, m_fYReverseOffsetPixels );
-
 	// todo: make this an AutoActor instead? -aj
 	Sprite *pSprite = dynamic_cast<Sprite *>( (Actor*)m_sprBoard );
 	if( pSprite == NULL )
-		RageException::Throw( "Board must be a Sprite" );
-
-	RectF rect = *pSprite->GetCurrentTextureCoordRect();
-	const float fBoardGraphicHeightPixels = pSprite->GetUnzoomedHeight();
-	float fTexCoordOffset = m_fBoardOffsetPixels / fBoardGraphicHeightPixels;
 	{
+		m_sprBoard->Draw();
+	}
+	else
+	{
+		// Draw the board centered on fYPosAt0 so that the board doesn't slide as
+		// the draw distance changes with modifiers.
+		const float fYPosAt0 = ArrowEffects::GetYPos( m_pPlayerState, 0, 0, m_fYReverseOffsetPixels );
+
+		RectF rect = *pSprite->GetCurrentTextureCoordRect();
+		const float fBoardGraphicHeightPixels = pSprite->GetUnzoomedHeight();
+		float fTexCoordOffset = m_fBoardOffsetPixels / fBoardGraphicHeightPixels;
+
 		// top half
 		const float fHeight = iDrawDistanceBeforeTargetsPixels - iDrawDistanceAfterTargetsPixels;
 		const float fY = fYPosAt0 - ((iDrawDistanceBeforeTargetsPixels + iDrawDistanceAfterTargetsPixels) / 2.0f);

--- a/src/Player.cpp
+++ b/src/Player.cpp
@@ -249,6 +249,7 @@ Player::Player( NoteData &nd, bool bVisibleParts ) : m_NoteData(nd)
 	{
 		m_pNoteField = new NoteField;
 		m_pNoteField->SetName( "NoteField" );
+		this->AddChild( m_pNoteField );
 	}
 	m_pJudgedRows = new JudgedRows;
 


### PR DESCRIPTION
NoteField board was already an AutoActor, but code was requiring it to
be a derivative of Sprite. Allow any ActorClass to be used.

NoteField could already be accessed from below, using GetParent() on the
NoteField Board. For ease of allowing the board to be used for player
specific purposes, make notefield an actual child of Player, so the
Board can be accessed per player from the top down.
