### PR TITLE
Revert 84903fc: "FFMpeg: Fix uninitialized AVFrame"

### DIFF
--- a/src/arch/MovieTexture/MovieTexture_FFMpeg.cpp
+++ b/src/arch/MovieTexture/MovieTexture_FFMpeg.cpp
@@ -112,7 +112,6 @@ MovieDecoder_FFMpeg::MovieDecoder_FFMpeg()
 	m_fctx = NULL;
 	m_pStream = NULL;
 	m_iCurrentPacketOffset = -1;
-	m_Frame = avcodec::av_frame_alloc();
 
 	Init();
 }
@@ -140,7 +139,6 @@ MovieDecoder_FFMpeg::~MovieDecoder_FFMpeg()
     {
         avcodec::av_free(m_buffer);
     }
-    avcodec::av_frame_free(&m_Frame);
 }
 
 void MovieDecoder_FFMpeg::Init()
@@ -269,7 +267,7 @@ int MovieDecoder_FFMpeg::DecodePacket( float fTargetTime )
 		m_Packet.data = m_Packet.size ? m_Packet.data : NULL;
 		int len = avcodec::avcodec_decode_video2(
 				m_pStream->codec, 
-				m_Frame, &iGotFrame,
+				&m_Frame, &iGotFrame,
 				&m_Packet );
 		CHECKPOINT;
 
@@ -288,9 +286,9 @@ int MovieDecoder_FFMpeg::DecodePacket( float fTargetTime )
 			continue;
 		}
 
-		if( m_Frame->pkt_dts != AV_NOPTS_VALUE )
+		if( m_Frame.pkt_dts != AV_NOPTS_VALUE )
 		{
-			m_fTimestamp = (float) (m_Frame->pkt_dts * av_q2d(m_pStream->time_base));
+			m_fTimestamp = (float) (m_Frame.pkt_dts * av_q2d(m_pStream->time_base));
 		}
 		else
 		{
@@ -301,7 +299,7 @@ int MovieDecoder_FFMpeg::DecodePacket( float fTargetTime )
 
 		/* Length of this frame: */
 		m_fLastFrameDelay = (float) av_q2d(m_pStream->time_base);
-		m_fLastFrameDelay += m_Frame->repeat_pict * (m_fLastFrameDelay * 0.5f);
+		m_fLastFrameDelay += m_Frame.repeat_pict * (m_fLastFrameDelay * 0.5f);
 
 		++m_iFrameNumber;
 
@@ -352,7 +350,7 @@ void MovieDecoder_FFMpeg::GetFrame( RageSurface *pSurface )
 	}
 
 	avcodec::sws_scale( m_swsctx,
-			m_Frame->data, m_Frame->linesize, 0, GetHeight(),
+			m_Frame.data, m_Frame.linesize, 0, GetHeight(),
 			pict.data, pict.linesize );
 }
 

--- a/src/arch/MovieTexture/MovieTexture_FFMpeg.h
+++ b/src/arch/MovieTexture/MovieTexture_FFMpeg.h
@@ -63,7 +63,7 @@ private:
 	int DecodePacket( float fTargetTime );
 
 	avcodec::AVStream *m_pStream;
-	avcodec::AVFrame *m_Frame;
+	avcodec::AVFrame m_Frame;
 	avcodec::PixelFormat m_AVTexfmt; /* PixelFormat of output surface */
 	avcodec::SwsContext *m_swsctx;
 


### PR DESCRIPTION
this reverts pr#112. stepmania crashes on linux every time a video banner shows up, or after playing a video bg.

this affects multiple users {at least two, anyway: me and kyzentun}
