### PR TITLE
Tweening for mmods.

### DIFF
--- a/src/ArrowEffects.cpp
+++ b/src/ArrowEffects.cpp
@@ -282,10 +282,17 @@ float ArrowEffects::GetYOffset( const PlayerState* pPlayerState, int iCol, float
 	// TODO: If we allow noteskins to have metricable row spacing
 	// (per issue 24), edit this to reflect that. -aj
 	fYOffset *= ARROW_SPACING;
+
+	// Factor in scroll speed
+	float fScrollSpeed = pPlayerState->m_PlayerOptions.GetCurrent().m_fScrollSpeed;
+	if(pPlayerState->m_PlayerOptions.GetCurrent().m_fMaxScrollBPM != 0)
+	{
+		fScrollSpeed= pPlayerState->m_PlayerOptions.GetCurrent().m_fMaxScrollBPM / pPlayerState->m_fReadBPM;
+	}
 	
 	// don't mess with the arrows after they've crossed 0
 	if( fYOffset < 0 )
-		return fYOffset * pPlayerState->m_PlayerOptions.GetCurrent().m_fScrollSpeed;
+		return fYOffset * fScrollSpeed;
 
 	const float* fAccels = pPlayerState->m_PlayerOptions.GetCurrent().m_fAccels;
 	//const float* fEffects = pPlayerState->m_PlayerOptions.GetCurrent().m_fEffects;
@@ -326,9 +333,6 @@ float ArrowEffects::GetYOffset( const PlayerState* pPlayerState, int iCol, float
 		fYOffset = (-1*fYOffset*fYOffset/SCREEN_HEIGHT) + 1.5f*fYOffset;
 	}
 
-	// Factor in scroll speed
-	float fScrollSpeed = pPlayerState->m_PlayerOptions.GetCurrent().m_fScrollSpeed;
-	
 	if( pPlayerState->m_PlayerOptions.GetCurrent().m_fRandomSpeed > 0 && !bAbsolute )
 	{
 		// Generate a deterministically "random" speed for each arrow.

--- a/src/Player.cpp
+++ b/src/Player.cpp
@@ -402,7 +402,7 @@ void Player::Init(
 
 	// calculate M-mod speed here, so we can adjust properly on a per-song basis.
 	// XXX: can we find a better location for this?
-	if( m_pPlayerState->m_PlayerOptions.GetCurrent().m_fMaxScrollBPM != 0 )
+	// Always calculate the reading bpm, to allow switching to an mmod mid-song.
 	{
 		DisplayBpms bpms;
 
@@ -464,10 +464,7 @@ void Player::Init(
 		}
 
 		ASSERT( fMaxBPM > 0 );
-
-		// set an X-mod equal to Mnum / fMaxBPM (e.g. M600 with 150 becomes 4x)	
-		PO_GROUP_ASSIGN(m_pPlayerState->m_PlayerOptions, ModsLevel_Preferred, m_fScrollSpeed,
-				m_pPlayerState->m_PlayerOptions.GetPreferred().m_fMaxScrollBPM / fMaxBPM);
+		m_pPlayerState->m_fReadBPM= fMaxBPM;
 	}
 
 	float fBalance = GameSoundManager::GetPlayerBalance( pn );

--- a/src/PlayerOptions.cpp
+++ b/src/PlayerOptions.cpp
@@ -66,7 +66,7 @@ void PlayerOptions::Approach( const PlayerOptions& other, float fDeltaSeconds )
 
 	APPROACH( fTimeSpacing );
 	APPROACH( fScrollSpeed );
-	//APPROACH( fMaxScrollBPM ); // if uncommented, causes crashes. -aj
+	APPROACH( fMaxScrollBPM );
 	fapproach( m_fScrollBPM, other.m_fScrollBPM, fDeltaSeconds * other.m_SpeedfScrollBPM*150 );
 	for( int i=0; i<NUM_ACCELS; i++ )
 		APPROACH( fAccels[i] );
@@ -365,7 +365,6 @@ bool PlayerOptions::FromOneModString( const RString &sOneMod, RString &sErrorOut
 		m_fMaxScrollBPM = 0;
 	}
 	// oITG's m-mods
-	// XXX: will not properly tween, I don't think.
 	else if( sscanf( sBit, "m%f", &level ) == 1 )
 	{
 		// OpenITG doesn't have this block:

--- a/src/PlayerState.h
+++ b/src/PlayerState.h
@@ -136,6 +136,9 @@ public:
 	int		m_iTapsHitSinceLastHasteUpdate;
 	int		m_iTapsMissedSinceLastHasteUpdate;
 
+	// Stores the bpm that was picked for reading the chart if the player is using an mmod.
+	float m_fReadBPM;
+
 	// Used in Rave
 	float	m_fSuperMeter;	// between 0 and NUM_ATTACK_LEVELS
 	float	m_fSuperMeterGrowthScale;


### PR DESCRIPTION
This makes mmods tweenable by always calculating a "Read BPM" and using that inside ArrowEffects instead of the xmod if the player is using an mmod.
