### PR TITLE
initialize key/button mappings in the editor

### DIFF
--- a/src/ScreenEdit.cpp
+++ b/src/ScreenEdit.cpp
@@ -117,6 +117,13 @@ LuaXType( EditState );
 void ScreenEdit::InitEditMappings()
 {
 	m_EditMappingsDeviceInput.Clear();
+	m_PlayMappingsDeviceInput.Clear();
+	m_RecordMappingsDeviceInput.Clear();
+	m_RecordPausedMappingsDeviceInput.Clear();
+	m_EditMappingsMenuButton.Clear();
+	m_PlayMappingsMenuButton.Clear();
+	m_RecordMappingsMenuButton.Clear();
+	m_RecordPausedMappingsMenuButton.Clear();
 
 	// Common mappings:
 	switch( EDIT_MODE.GetValue() )


### PR DESCRIPTION
Only one of the maps was initialized, and I suspect the uninitialized
ones were leading to weird behavior when other keys were pressed (e.g. a
modifier like Control by itself).  Probably couldn't hurt to actually
initialize these...
