### PR TITLE
allow button messages in SSM's SelectMenu

### DIFF
--- a/src/ScreenSelectMusic.cpp
+++ b/src/ScreenSelectMusic.cpp
@@ -572,7 +572,7 @@ bool ScreenSelectMusic::Input( const InputEventPlus &input )
 				default: break;
 			}
 		}
-		else if( input.type == IET_FIRST_PRESS && input.MenuI != GAME_BUTTON_SELECT )
+		if( input.type == IET_FIRST_PRESS && input.MenuI != GAME_BUTTON_SELECT )
 		{
 			Message msg("SelectMenuInput");
 			msg.SetParam( "Player", input.pn );


### PR DESCRIPTION
This allows themers to make use of SelectMenuInputMessageCommand even
if they have SelectMenuChangesDifficulty set to true in their Metrics.

Neither _fallback nor Default use SelectMenuInputMessageCommand and,
for that matter, no theme I'm aware of does (perhaps because it's
essentially inaccessible as it is).

I use this to detect if a player presses START while holding SELECT on
SSM.  This is possible with the existing code system, but that
CodeMessage does not fire until the player lets go of both buttons.
This allows the themer to check for that button combination more imm
ediately.
