### PR TITLE
Disabled pad codes that change modifiers in dance game mode.

### DIFF
--- a/Themes/_fallback/Scripts/03 Gameplay.lua
+++ b/Themes/_fallback/Scripts/03 Gameplay.lua
@@ -264,35 +264,35 @@ local CodeDetectorCodes = {
 	--- specific modifiers
 	Mirror = {
 		default = "",
-		dance = "Up,Left,Right,Left,Right",
+		dance = "",
 		pump = "DownRight,DownLeft,UpRight,UpLeft,DownRight,DownLeft,UpRight,UpLeft,Center",
 	},
 	Left = {
 		default = "",
-		dance = "Up,Down,Right,Left",
+		dance = "",
 	},
 	Right = {
 		default = "",
-		dance = "Up,Down,Left,Right",
+		dance = "",
 	},
 	Shuffle = {
 		default = "",
-		dance = "Down,Up,Down,Up",
+		dance = "",
 		pump = "UpLeft,UpRight,UpLeft,UpRight,DownLeft,DownRight,DownLeft,DownRight,Center", -- random
 	},
 	SuperShuffle = {
 		default = "",
-		dance = "Down,Up,Left,Right",
+		dance = "",
 		pump = "UpLeft,UpRight,DownLeft,DownRight,UpLeft,UpRight,DownLeft,DownRight,Center"
 	},
 	Reverse = {
 		default = "",
-		dance = "Down,Left,Right,Left,Right",
+		dance = "",
 		pump = "UpLeft,DownLeft,UpRight,DownRight,UpLeft,DownLeft,UpRight,DownRight,DownRight", -- drop
 	},
 	HoldNotes = {
 		default = "",
-		dance = "Right,Left,Down,Up",
+		dance = "",
 	},
 	Mines = {
 		default = "",
@@ -314,25 +314,25 @@ local CodeDetectorCodes = {
 	},
 	NextScrollSpeed = {
 		default = "",
-		dance = "Up,Left,Down,Left,Up",
+		dance = "",
 		pump = "UpLeft,UpRight,UpLeft,UpRight,Center",
 	},
 	PreviousScrollSpeed = {
 		default = "",
-		dance = "Down,Right,Up,Right,Down",
+		dance = "",
 		pump = "UpRight,UpLeft,UpRight,UpLeft,Center",
 	},
 	NextAccel = {
 		default = "",
-		dance = "Left,Right,Down,Up",
+		dance = "",
 	},
 	NextEffect = {
 		default = "",
-		dance = "Left,Down,Right",
+		dance = "",
 	},
 	NextAppearance = {
 		default = "",
-		dance = "Left,Up,Right",
+		dance = "",
 	},
 	NextTurn = {
 		default = "",


### PR DESCRIPTION
Issue #108.  These are specifically the pad codes that set modifiers that are often harmful and have codes that are short enough to be easily triggered on accident.  Commonly intentionally used things like changing the difficulty/sort are unchanged.
Requires approval from 3 other devs to merge, since there has been some contention over this issue.
