### PR TITLE
Minor performance enhancement

### DIFF
--- a/src/RageSoundPosMap.cpp
+++ b/src/RageSoundPosMap.cpp
@@ -53,7 +53,7 @@ pos_map_queue &pos_map_queue::operator=( const pos_map_queue &rhs )
 
 void pos_map_queue::Insert( int64_t iSourceFrame, int iFrames, int64_t iDestFrame, float fSourceToDestRatio )
 {
-	if( m_pImpl->m_Queue.size() )
+	if( !m_pImpl->m_Queue.empty() )
 	{
 		/* Optimization: If the last entry lines up with this new entry, just merge them. */
 		pos_map_t &last = m_pImpl->m_Queue.back();


### PR DESCRIPTION
`list.empty()` runs in constant time; `list.size` can run in linear time.

Sources:
http://www.cplusplus.com/reference/list/list/size/
http://www.cplusplus.com/reference/list/list/empty/
