### PR TITLE
Fix memory leak in RageSurfaceUtils::Palettize

### DIFF
--- a/src/RageSurfaceUtils_Palettize.cpp
+++ b/src/RageSurfaceUtils_Palettize.cpp
@@ -298,6 +298,7 @@ void RageSurfaceUtils::Palettize( RageSurface *&pImg, int iColors, bool bDither 
 		}
 	}
 
+	delete acolormap
 	delete [] thiserr;
 	delete [] nexterr;
 


### PR DESCRIPTION
[mediancut( acolorhist_item *achv, int colors, int sum, int maxval, int newcolors )](https://github.com/stepmania/stepmania/edit/master/src/RageSurfaceUtils_Palettize.cpp#L326) returns a newly-allocated `acolorhist_item` which is stored as [`acolormap`](https://github.com/stepmania/stepmania/edit/master/src/RageSurfaceUtils_Palettize.cpp#L145)

However, that memory is never freed.
