### PR TITLE
fix issue #225

### DIFF
--- a/Themes/_fallback/BGAnimations/ScreenTestInput underlay.lua
+++ b/Themes/_fallback/BGAnimations/ScreenTestInput underlay.lua
@@ -3,12 +3,12 @@ return Def.ActorFrame {
 	--	InitCommand=cmd(LoadGameController,
 	--};
 	Def.DeviceList {
-		Font="Common normal";
+		Font=THEME:GetPathF("Common","Normal");
 		InitCommand=cmd(x,SCREEN_LEFT+20;y,SCREEN_TOP+80;zoom,0.8;halign,0);
 	};
 
 	Def.InputList {
-		Font="Common normal";
+		Font=THEME:GetPathF("Common","Normal");
 		InitCommand=cmd(x,SCREEN_CENTER_X-250;y,SCREEN_CENTER_Y;zoom,1;halign,0;vertspacing,8);
 	};
 };


### PR DESCRIPTION
This fixes issue #225 which was caused by incorrect font paths for the DeviceList and InputList in _fallback's ScreenTestInput.

I apologize if there is a better way to fix this.
