### PR TITLE
Add option --with-ffmpeg-rpath

### DIFF
--- a/autoconf/m4/video.m4
+++ b/autoconf/m4/video.m4
@@ -3,6 +3,7 @@ AC_DEFUN([SM_VIDEO], [
 AC_REQUIRE([SM_STATIC])
 
 AC_ARG_WITH(ffmpeg, AS_HELP_STRING([--without-ffmpeg],[Disable ffmpeg support]), with_ffmpeg=$withval, with_ffmpeg=yes)
+AC_ARG_WITH(ffmpeg-rpath, AS_HELP_STRING([--with-ffmpeg-rpath],[Specify RPATH for ffmpeg]), ffmpeg_rpath=$withval, ffmpeg_rpath=no)
 AC_ARG_WITH(static-ffmpeg, AS_HELP_STRING([--with-static-ffmpeg],[Statically link ffmpeg libraries]), with_static_ffmpeg=$withval, with_static_ffmpeg=no)
 AM_CONDITIONAL(STATIC_FFMPEG, test "$with_static_ffmpeg" = "yes")
 AC_ARG_WITH(system-ffmpeg, AS_HELP_STRING([--with-system-ffmpeg], [Use system instead of bundled ffmpeg (UNSUPPORTED)]), system_ffmpeg=yes, system_ffmpeg=no)
@@ -94,7 +95,11 @@ dnl It's NOT autoconf-based, so AC_CONFIG_SUBDIRS does not work.
 		CFLAGS="$CFLAGS -I$PWD/bundle/ffmpeg"
 		CXXFLAGS="$CXXFLAGS -I$PWD/bundle/ffmpeg"
 dnl Make the binary find our bundled libs
-		LDFLAGS="$LDFLAGS -Wl,-rpath=. -Wl,-rpath=bundle/ffmpeg/libavutil,-rpath=bundle/ffmpeg/libavformat,-rpath=bundle/ffmpeg/libavcodec,-rpath=bundle/ffmpeg/libswscale"
+		if test "$ffmpeg_rpath" = "no"; then
+			LDFLAGS="$LDFLAGS -Wl,-rpath=. -Wl,-rpath=bundle/ffmpeg/libavutil,-rpath=bundle/ffmpeg/libavformat,-rpath=bundle/ffmpeg/libavcodec,-rpath=bundle/ffmpeg/libswscale"
+		else
+			LDFLAGS="$LDFLAGS -Wl,-rpath=$ffmpeg_rpath"
+		fi
 dnl Classic autoconf. This CANNOT be broken across multiple lines.
 		VIDEO_LIBS="-L$PWD/bundle/ffmpeg/libavutil -lavutil -L$PWD/bundle/ffmpeg/libavformat -lavformat -L$PWD/bundle/ffmpeg/libavcodec -lavcodec -L$PWD/bundle/ffmpeg/libswscale -lswscale"
 		have_ffmpeg=yes


### PR DESCRIPTION
The reason for this change is general security consistency. Only really terrible apps should need relative RPATH values. Hard-coded as specified by the user (package curator or whatever) can alleviate this for now. The better way would be to use the prefix specified on configure (`--prefix`) to give a safe hard-coded path (after `make install` is fixed to properly install the libraries).

Note the error message from Gentoo Portage when attempting to install:

```
scanelf: rpath_security_checks(): Security problem with relative DT_RPATH '.:bundle/ffmpeg/libavutil:bundle/ffmpeg/libavformat:bundle/ffmpeg/libavcodec:bundle/ffmpeg/libswscale' in /var/tmp/portage/games-arcade/stepmania-5.9999/image/usr/share/games/stepmania/GtkModule.so
```

This happens for both `stepmania` and `GtkModule.so`.

To test this change, checkout the branch and do:

``` bash
./autogen.sh
configure --prefix=/my-safe-place --with-ffmpeg-rpath=/a-place-for-the-so-files
make install
```

Note that you have copy the ffmpeg so files as well as `GtkModule.so` to the RPATH you specify. With GNU `cp`: `find . -iname '*.so*' | egrep '\.so(\.[0-9]+)?$' | xargs cp -P --target /a-place-for-the-so-files/`. This is because `make install` does not yet install the object files for the bundled ffmpeg.

The nice thing is that package managers can put the ffmpeg and GtkModule.so files wherever they want, as long as that _full_ path is given with `--with-ffmpeg-rpath`. And the `stepmania` binary does not need a wrapper script or anything similar because it has the RPATH as well. So it can be in a standard place like `/usr/bin` or the more standard place for games `/usr/games/bin`.

The original functionality is retained if `--with-ffmpeg-rpath` is not specified. This is generally okay for users who install to a custom root such as `--prefix=$HOME/usr2` and they copy all the .so files in `$HOME/usr2/stepmania 5` (or just copy the entire `bundle` directory there and it should work too).

For general information on how Gentoo would install StepMania, please see https://github.com/Tatsh/tatsh-overlay/blob/master/games-arcade/stepmania/stepmania-5.9999.ebuild (my ebuild is based on older versions prior to general abandonment of Gentoo users).

After installation:

```
$ readelf -d /usr/games/bin/stepmania | grep rpath
 0x000000000000000f (RPATH)              Library rpath: [/usr/share/games/stepmania]
$ readelf -d /usr/share/games/stepmania/GtkModule.so | fgrep rpath
 0x000000000000000f (RPATH)              Library rpath: [/usr/share/games/stepmania]
```
