### PR TITLE
make internal diffuse apply to bmt attributes

### DIFF
--- a/src/Actor.cpp
+++ b/src/Actor.cpp
@@ -288,7 +288,7 @@ void Actor::Draw()
 	
 	this->PreDraw();
 	ASSERT( m_pTempState != NULL );
-	if( m_pTempState->diffuse[0].a != 0 || m_pTempState->diffuse[1].a != 0 || m_pTempState->diffuse[2].a != 0 || m_pTempState->diffuse[3].a != 0 || m_pTempState->glow.a != 0 ) // This Actor is not fully transparent
+	if( m_pTempState->diffuse[0].a > 0 || m_pTempState->diffuse[1].a > 0 || m_pTempState->diffuse[2].a > 0 || m_pTempState->diffuse[3].a > 0 || m_pTempState->glow.a > 0 ) // This Actor is not fully transparent
 	{	
 		// call the most-derived versions
 		this->BeginDraw();	
@@ -296,7 +296,14 @@ void Actor::Draw()
 		this->EndDraw();
 	}
 	
+	this->PostDraw();
 	m_pTempState = NULL;
+}
+
+void Actor::PostDraw() // reset internal diffuse and glow
+{
+	m_internalDiffuse = RageColor(1, 1, 1, 1);
+	m_internalGlow.a = 0;
 }
 
 void Actor::PreDraw() // calculate actor properties
@@ -468,7 +475,6 @@ void Actor::PreDraw() // calculate actor properties
 		{
 			tempState.diffuse[i] *= m_internalDiffuse;
 		}
-		m_internalDiffuse = RageColor(1, 1, 1, 1);
 	}
 
 	if( m_internalGlow.a > 0 )
@@ -481,10 +487,9 @@ void Actor::PreDraw() // calculate actor properties
 
 		// Blend using Screen mode
 		tempState.glow = tempState.glow + m_internalGlow - m_internalGlow * tempState.glow;
-		m_internalGlow.a = 0;
 	}
 }
-	
+
 void Actor::BeginDraw() // set the world matrix
 {
 	DISPLAY->PushMatrix();

--- a/src/Actor.h
+++ b/src/Actor.h
@@ -244,6 +244,8 @@ public:
 	virtual bool EarlyAbortDraw() const { return false; }
 	/** @brief Calculate values that may be needed  for drawing. */
 	virtual void PreDraw();
+	/** @brief Reset internal diffuse and glow. */
+	virtual void PostDraw();
 	/** @brief Start the drawing and push the transform on the world matrix stack. */
 	virtual void BeginDraw();
 	/**

--- a/src/BitmapText.cpp
+++ b/src/BitmapText.cpp
@@ -659,10 +659,20 @@ void BitmapText::DrawPrimitives()
 				iEnd = min( iEnd, m_aVertices.size() );
 				for( ; i < iEnd; i += 4 )
 				{
-					m_aVertices[i+0].c = attr.diffuse[0];	// top left
-					m_aVertices[i+1].c = attr.diffuse[2];	// bottom left
-					m_aVertices[i+2].c = attr.diffuse[3];	// bottom right
-					m_aVertices[i+3].c = attr.diffuse[1];	// top right
+					if( m_internalDiffuse != RageColor(1, 1, 1, 1) )
+					{
+						m_aVertices[i+0].c = attr.diffuse[0] * m_internalDiffuse;
+						m_aVertices[i+1].c = attr.diffuse[2] * m_internalDiffuse;
+						m_aVertices[i+2].c = attr.diffuse[3] * m_internalDiffuse;
+						m_aVertices[i+3].c = attr.diffuse[1] * m_internalDiffuse;
+					}
+					else
+					{
+						m_aVertices[i+0].c = attr.diffuse[0];	// top left
+						m_aVertices[i+1].c = attr.diffuse[2];	// bottom left
+						m_aVertices[i+2].c = attr.diffuse[3];	// bottom right
+						m_aVertices[i+3].c = attr.diffuse[1];	// top right
+					}
 				}
 			}
 		}
@@ -729,7 +739,16 @@ void BitmapText::DrawPrimitives()
 				iEnd = i + attr.length*4;
 			iEnd = min( iEnd, m_aVertices.size() );
 			for( ; i < iEnd; ++i )
-				m_aVertices[i].c = attr.glow;
+			{
+				if( m_internalGlow.a > 0 )
+				{
+					m_aVertices[i].c = attr.glow * m_internalGlow;
+				}
+				else
+				{
+					m_aVertices[i].c = attr.glow;
+				}
+			}
 		}
 		/* Draw glow using the base texture and the glow texture. Otherwise,
 		 * glow looks too tame on BitmapText that has a stroke. - Chris Danford */


### PR DESCRIPTION
diffuse from BitmapText attributes were not receiving internal diffuse
from their parent ActorFrames. This change waits until after the draw
cycle to reset the internal diffuse and glow, so any color applications
separate from generic diffuse can use the internal diffuse when desired.
