### PR TITLE
Change RadarValues internal implementation to make sense

### DIFF
--- a/src/NotesLoaderJson.cpp
+++ b/src/NotesLoaderJson.cpp
@@ -128,7 +128,7 @@ static void Deserialize( RadarValues &o, const Json::Value &root )
 {
 	FOREACH_ENUM( RadarCategory, rc )
 	{
-		o.m_Values.f[rc] = (float)root[ RadarCategoryToString(rc) ].asDouble();
+		o[rc] = (float)root[ RadarCategoryToString(rc) ].asDouble();
 	}
 }
 

--- a/src/NotesWriterJson.cpp
+++ b/src/NotesWriterJson.cpp
@@ -100,7 +100,7 @@ static void Serialize( const RadarValues &o, Json::Value &root )
 {
 	FOREACH_ENUM( RadarCategory, rc )
 	{
-		root[ RadarCategoryToString(rc) ] = o.m_Values.f[rc];
+		root[ RadarCategoryToString(rc) ] = o[rc];
 	}
 }
 

--- a/src/PlayerStageStats.cpp
+++ b/src/PlayerStageStats.cpp
@@ -316,7 +316,9 @@ int PlayerStageStats::GetLessonScoreNeeded() const
 	float fScore = 0;
 
 	FOREACH_CONST( Steps*, m_vpPossibleSteps, steps )
-		fScore += (*steps)->GetRadarValues( PLAYER_1 ).m_Values.v.fNumTapsAndHolds;
+	{
+		fScore += (*steps)->GetRadarValues(PLAYER_1)[RadarCategory_TapsAndHolds];
+	}
 
 	return lrintf( fScore * LESSON_PASS_THRESHOLD );
 }

--- a/src/RadarValues.cpp
+++ b/src/RadarValues.cpp
@@ -16,13 +16,17 @@ RadarValues::RadarValues()
 void RadarValues::MakeUnknown()
 {
 	FOREACH_ENUM( RadarCategory, rc )
-		m_Values.f[rc] = RADAR_VAL_UNKNOWN;
+	{
+		(*this)[rc] = RADAR_VAL_UNKNOWN;
+	}
 }
 
 void RadarValues::Zero()
 {
 	FOREACH_ENUM( RadarCategory, rc )
-		m_Values.f[rc] = 0;
+	{
+		(*this)[rc] = 0;
+	}
 }
 
 XNode* RadarValues::CreateNode( bool bIncludeSimpleValues, bool bIncludeComplexValues ) const
@@ -35,12 +39,16 @@ XNode* RadarValues::CreateNode( bool bIncludeSimpleValues, bool bIncludeComplexV
 		if( rc >= RadarCategory_TapsAndHolds )
 		{
 			if( bIncludeSimpleValues )
-				pNode->AppendChild( RadarCategoryToString(rc),	(int)m_Values.f[rc] );
+			{
+				pNode->AppendChild(RadarCategoryToString(rc),	(int)((*this)[rc]));
+			}
 		}
 		else
 		{
 			if( bIncludeComplexValues )
-				pNode->AppendChild( RadarCategoryToString(rc),	m_Values.f[rc] );
+			{
+				pNode->AppendChild(RadarCategoryToString(rc),	(*this)[rc]);
+			}
 		}
 	}
 
@@ -54,7 +62,9 @@ void RadarValues::LoadFromNode( const XNode* pNode )
 	Zero();
 
 	FOREACH_ENUM( RadarCategory, rc )
-		pNode->GetChildValue( RadarCategoryToString(rc),	m_Values.f[rc] );
+	{
+		pNode->GetChildValue( RadarCategoryToString(rc),	(*this)[rc] );
+	}
 }
 
 /* iMaxValues is only used for writing compatibility fields in non-cache
@@ -67,7 +77,9 @@ RString RadarValues::ToString( int iMaxValues ) const
 
 	vector<RString> asRadarValues;
 	for( int r=0; r < iMaxValues; r++ )
-		asRadarValues.push_back( ssprintf("%.3f", m_Values.f[r]) );
+	{
+		asRadarValues.push_back(ssprintf("%.3f", (*this)[r]));
+	}
 
 	return join( ",",asRadarValues );
 }
@@ -84,7 +96,9 @@ void RadarValues::FromString( RString sRadarValues )
 	}
 
 	FOREACH_ENUM( RadarCategory, rc )
-		m_Values.f[rc] = StringToFloat( saValues[rc] );
+	{
+		(*this)[rc] = StringToFloat(saValues[rc]);
+	}
     
 }
 

--- a/src/RadarValues.h
+++ b/src/RadarValues.h
@@ -12,29 +12,13 @@ struct lua_State;
 /** @brief Cached song statistics. */
 struct RadarValues
 {
-	union Values
-	{
-		struct
-		{
-			float fStream;
-			float fVoltage;
-			float fAir;
-			float fFreeze;
-			float fChaos;
-			float fNumTapsAndHolds;
-			float fNumJumps;
-			float fNumHolds;
-			float fNumMines;
-			float fNumHands;
-			float fNumRolls;
-			float fNumLifts;
-			float fNumFakes;
-		} v;
-		float f[NUM_RadarCategory];
-	} m_Values;
-
-	operator const float* () const	{ return m_Values.f; };
-	operator float* ()		{ return m_Values.f; };
+private:
+	float m_Values[NUM_RadarCategory];
+public:
+	float operator[](RadarCategory cat) const { return m_Values[cat]; }
+	float& operator[](RadarCategory cat) { return m_Values[cat]; }
+	float operator[](int cat) const { return m_Values[cat]; }
+	float& operator[](int cat) { return m_Values[cat]; }
 
 	RadarValues();
 	void MakeUnknown();
@@ -48,7 +32,9 @@ struct RadarValues
 	RadarValues& operator+=( const RadarValues& other )
 	{
 		FOREACH_ENUM( RadarCategory, rc )
-			m_Values.f[rc] += other.m_Values.f[rc];
+		{
+			(*this)[rc] += other[rc];
+		}
 		return *this;
 	}
 	/**
@@ -60,8 +46,10 @@ struct RadarValues
 	{
 		FOREACH_ENUM( RadarCategory, rc )
 		{
-			if( m_Values.f[rc] != other.m_Values.f[rc] )
+			if((*this)[rc] != other[rc])
+			{
 				return false;
+			}
 		}
 		return true;
 	}

--- a/src/ScreenDebugOverlay.cpp
+++ b/src/ScreenDebugOverlay.cpp
@@ -865,7 +865,9 @@ static HighScore MakeRandomHighScore( float fPercentDP )
 		hs.SetHoldNoteScore( hns, RandomInt(100) );
 	RadarValues rv;
 	FOREACH_ENUM( RadarCategory, rc )
-		rv.m_Values.f[rc] = randomf( 0, 1 );
+	{
+		rv[rc] = randomf( 0, 1 );
+	}
 	hs.SetRadarValues( rv );
 
 	return hs;


### PR DESCRIPTION
Why provide subscripting through the float\* operator instead of the [] operator?
Why have a second list that every new RadarCategory must be added to?
