### PR TITLE
WheelItemBase:IsLoaded

### DIFF
--- a/Docs/Luadoc/Lua.xml
+++ b/Docs/Luadoc/Lua.xml
@@ -1770,6 +1770,7 @@
 			<Function name='GetColor'/>
 			<Function name='GetText'/>
 			<Function name='GetType'/>
+			<Function name='IsLoaded'/>
 		</Class>
 		<Class base='ActorFrame' name='WorkoutGraph'>
 			<Function name='SetFromCurrentWorkout'/>

--- a/Docs/Luadoc/LuaDocumentation.xml
+++ b/Docs/Luadoc/LuaDocumentation.xml
@@ -4995,6 +4995,10 @@ save yourself some time, copy this for undocumented things:
 	<Function name='GetType' return='WheelItemDataType' arguments=''>
 		Returns the type of this wheel item.
 	</Function>
+	<Function name='IsLoaded' return='bool' arguments=''>
+		Returns whether the wheel item has been loaded yet.  If this function returns false, calling any other WheelItemBase function will result in an error. <br />
+		A specific case where this is known to happen is commands that trigger on CurrentSongChanged because the music wheel clears the current song before it finishes loading if the current song is longer than the number of stages remaining.
+	</Function>
 </Class>
 <Class name='WorkoutGraph'>
 	<Function name='SetFromCurrentWorkout' return='void' arguments=''>

--- a/src/WheelItemBase.cpp
+++ b/src/WheelItemBase.cpp
@@ -87,11 +87,36 @@ void WheelItemBase::DrawPrimitives()
 class LunaWheelItemBase: public Luna<WheelItemBase>
 {
 public:
-	DEFINE_METHOD( GetColor, GetColor() )
-	DEFINE_METHOD( GetText, GetText() )
+#define IS_LOADED_CHECK \
+	if(!p->IsLoaded()) \
+	{ \
+		luaL_error(L, "Wheel item is not loaded yet.  Use WheelItem:IsLoaded() to check."); \
+	}
+
+	static int GetColor(T* p, lua_State *L)
+	{
+		IS_LOADED_CHECK;
+		LuaHelpers::Push(L, p->GetColor());
+		return 1;
+	}
+
+	static int GetText(T* p, lua_State *L)
+	{
+		IS_LOADED_CHECK;
+		LuaHelpers::Push(L, p->GetText());
+		return 1;
+	}
 	
-	static int GetType( T* p, lua_State *L ) {
-		lua_pushnumber( L, p->GetType() );
+	static int GetType(T* p, lua_State *L)
+	{
+		IS_LOADED_CHECK;
+		lua_pushnumber(L, p->GetType());
+		return 1;
+	}
+
+	static int IsLoaded(T* p, lua_State *L)
+	{
+		lua_pushboolean(L, p->IsLoaded());
 		return 1;
 	}
 
@@ -100,6 +125,7 @@ public:
 		ADD_METHOD( GetColor );
 		ADD_METHOD( GetText );
 		ADD_METHOD( GetType );
+		ADD_METHOD( IsLoaded );
 	}
 };
 LUA_REGISTER_DERIVED_CLASS( WheelItemBase, ActorFrame )

--- a/src/WheelItemBase.h
+++ b/src/WheelItemBase.h
@@ -51,9 +51,10 @@ public:
 
 	RageColor m_colorLocked;
 
-	const RString GetText(){ return m_pData->m_sText; }
-	const RageColor GetColor(){ return m_pData->m_color; }
-	WheelItemDataType GetType(){ return m_pData->m_Type; }
+	const RString GetText(){ ASSERT(m_pData != NULL); return m_pData->m_sText; }
+	const RageColor GetColor(){ ASSERT(m_pData != NULL); return m_pData->m_color; }
+	WheelItemDataType GetType(){ ASSERT(m_pData != NULL); return m_pData->m_Type; }
+	bool IsLoaded(){ return m_pData != NULL; }
 
 	// Lua
 	void PushSelf( lua_State *L );


### PR DESCRIPTION
I encountered a segfault in a theme caused by the theme calling functions on a wheel item that was not yet loaded.

This theme seg faulted because the music wheel set the current song to null on loading because the current song was too long for the stages remaining.
The theme's behavior when the current song is null it to check the wheel item that has focus and use its type to set a piece of text, which is perfectly reasonable.
The problem is, the music wheel sets the song to null before the wheel items are built, so checking the type caused a seg fault.

This PR fixes the segfault problem by making unloaded wheel items emit an error when used and adding a function that can be used to check their status.
