### PR TITLE
update OSX mkrelease scripts

### DIFF
--- a/Xcode/scripts/README.md
+++ b/Xcode/scripts/README.md
@@ -1,15 +1,35 @@
 StepMania Scripts For OS X
 =========
 
-This script can be used to bundle a .dmg installer of StepMania.
+These scripts can be used to bundle a .dmg installer of StepMania.
 It assumes you have already built a StepMania.app using Xcode and
-that your stepmania directory structure is intact as you cloned it.
+that your *stepmania* directory structure is intact as you cloned it.
 
-To use this script, open a terminal and cd to your stepmania directory,
-then run the following commands:
 
+Bundling a Release:
+-------------------
+To bundle a release version of StepMania open a terminal and cd to
+your *stepmania* directory, then run the following commands:
+
+```
 cd Xcode/scripts  
 ruby mkrelease.rb
+```
 
-You'll see output as each stepmania sub-directory is copied into a tmp directory.
-If all goes well, you'll be notified that the dmg was created in your stepmania directory.
+This will create a disk image like *StepMania-v5.0-beta-4-mac.dmg*
+in the root of your *stepmania* directory.
+
+
+
+Bundling a Nightly:
+-------------------
+To bundle an intermediate or "nightly" .dmg installer, cd to your
+*stepmania* directory, and run the following commands:
+
+```
+cd Xcode/scripts  
+ruby mkrelease.rb nightly
+```
+
+This will create a disk image like *StepMania-v5.0-31-8-2014-mac.dmg*
+in the root of your *stepmania* directory.

--- a/Xcode/scripts/mkrelease.rb
+++ b/Xcode/scripts/mkrelease.rb
@@ -6,8 +6,19 @@ require 'tmpdir'
 # cd to the StepMania 5 src directory
 Dir.chdir "../../src"
 
+# check the command line for the presence of the "nightly" option, used
+# if we are bundling a nightly build as opposed to an official release
+nightly = (true and ARGV[0] == "nightly") or false
+
 # initialize empty strings
-family, version = ""
+family, version, date = ""
+
+# if this is to be a nightly build, store the system date;
+# we'll use it below to name the bundle
+if nightly
+	time = time = Time.new
+	date = "#{time.day}-#{time.month}-#{time.year}"
+end
 
 # open ProductInfo.h in read-only mode
 File.open("#{Dir.pwd}/ProductInfo.h", "r") do |f|
@@ -15,43 +26,48 @@ File.open("#{Dir.pwd}/ProductInfo.h", "r") do |f|
 	f.each do |line|
 		if line.match( /^#define\s+PRODUCT_FAMILY_BARE\s+(.*?)\s*$/ )
 			family = $1;
-
+		
 		elsif line.match( /^#define\s+PRODUCT_VER_BARE\s+(.*?)\s*$/ )
 			version = $1;
 		end
 	end	
 end
 
-# replace whitespace with hyphens in version string
+# replace whitespace with hyphens in the version string
 version.gsub!(/\s+/,"-")
 
-# the name of the .dmg file
-name = "#{family}-#{version}-mac.dmg"
+# the name of what we are bundling
+if nightly
+	version = version.partition("-")[0]
+	name = "#{family}-#{version}-#{date}"
+else
+	name = "#{family}-#{version}"
+end
 
 # a list of directories we want to include in our .dmg
 directories = [ "Announcers", "BackgroundEffects", "BackgroundTransitions",
-		 		"BGAnimations", "Characters", "Courses", "Data", "Docs", "Manual",
-				"NoteSkins", "Scripts", "Songs", "StepMania.app", "Themes" ]
+		"BGAnimations", "Characters", "Courses", "Data", "Docs", "Manual",
+		"NoteSkins", "Scripts", "Songs", "StepMania.app", "Themes" ]
 
 # cd back to the root of the StepMania 5 directory
 Dir.chdir ".."
 
 # create a temp directory; this will be automatically deleted when the block completes
 Dir.mktmpdir {|temp|
-	
+		
 	# nest two directories named by family and version within the temp directory
 	# the outer will become the root of the dmg
 	# the inner will neatly tidy all the contents together so users can easily drag/drop everything at once
-	FileUtils.mkdir_p("#{temp}/#{family}-#{version}/#{family}-#{version}/")
+	FileUtils.mkdir_p("#{temp}/#{name}/#{name}/")
 	
 	# loop through the directories array
 	directories.each do |directory|
 		# recursively copy each directory into our temp directory
-		FileUtils.cp_r directory, "#{temp}/#{family}-#{version}/#{family}-#{version}/", :verbose => true
+		FileUtils.cp_r directory, "#{temp}/#{name}/#{name}/", :verbose => true
 	end
 
 	#construct the shell command that will create the dmg
-	cmd = "hdiutil create #{Dir.pwd}/#{name} -srcfolder #{temp}/#{family}-#{version} -ov"
+	cmd = "hdiutil create #{Dir.pwd}/#{name}-mac.dmg -srcfolder #{temp}/#{name} -ov"
 
 	#execute the command in a subshell
 	system( cmd )


### PR DESCRIPTION
This allows OS X devs to bundle either a release or a nightly disk image.  See the updated readme for more information.
