### PR TITLE
make ThemePrefsRows system actually save Prefs

### DIFF
--- a/Themes/_fallback/Scripts/02 ThemePrefsRows.lua
+++ b/Themes/_fallback/Scripts/02 ThemePrefsRows.lua
@@ -57,7 +57,11 @@ local function DefaultSave( pref, choices, values )
 
 	return function(self, list, pn)
 		for i=1, #choices do
-			if list[i] then ThemePrefs.Set( pref, values[i] ) break end
+			if list[i] then
+				ThemePrefs.Set( pref, values[i] )
+				ThemePrefs.Save()
+				break
+			end
 			MESSAGEMAN:Broadcast( msg, params )
 		end
 	end


### PR DESCRIPTION
This adds one function call to _fallback/Scripts/02 ThemePrefsRows.lua:  the call that saves the preferences.  The only reason ThemePrefs had been working in default theme (as far as I can tell) is because the same function was called from ScreenTitleMenu decorations.

That particular instance can be removed or left alone; this change does not interfere with it.  This change does allow other themers to use ThemePrefs and ThemePrefRows without figuring that out.
