### PR TITLE
debounce coin input separately

### DIFF
--- a/src/InputFilter.cpp
+++ b/src/InputFilter.cpp
@@ -7,6 +7,8 @@
 #include "RageThreads.h"
 #include "Preference.h"
 #include "Foreach.h"
+#include "GameInput.h"
+#include "InputMapper.h"
 // for mouse stuff: -aj
 #include "PrefsManager.h"
 #include "ScreenDimensions.h"
@@ -230,10 +232,18 @@ void InputFilter::CheckButtonChange( ButtonState &bs, DeviceInput di, const Rage
 	if( bs.m_BeingHeld == bs.m_bLastReportedHeld )
 		return;
 
-	/* If the last IET_FIRST_PRESS or IET_RELEASE event was sent too recently,
-	 * wait a while before sending it. */
-	if( now - bs.m_LastReportTime < g_fInputDebounceTime )
-		return;
+	GameInput gi;
+
+	// Apply debounce; check DebounceCoinInput preference to see if coins should be debounced, too.
+	if ( PREFSMAN->m_bDebounceCoinInput || ! INPUTMAPPER->DeviceToGame(di, gi) || gi.button != GAME_BUTTON_COIN )
+	{
+		/* If the last IET_FIRST_PRESS or IET_RELEASE event was sent too recently,
+		 * wait a while before sending it. */
+		if( now - bs.m_LastReportTime < g_fInputDebounceTime )
+		{
+			return;
+		}
+	}
 
 	bs.m_LastReportTime = now;
 	bs.m_bLastReportedHeld = bs.m_BeingHeld;

--- a/src/PrefsManager.cpp
+++ b/src/PrefsManager.cpp
@@ -254,6 +254,7 @@ PrefsManager::PrefsManager() :
 	m_bAllowMultipleHighScoreWithSameName	( "AllowMultipleHighScoreWithSameName",	true ),
 	m_bCelShadeModels		( "CelShadeModels",			false ),	// Work-In-Progress.. disable by default.
 	m_bPreferredSortUsesGroups	( "PreferredSortUsesGroups",		true ),
+	m_bDebounceCoinInput	( "DebounceCoinInput",			true ),
 
 	m_fPadStickSeconds		( "PadStickSeconds",			0 ),
 	m_bForceMipMaps			( "ForceMipMaps",			false ),

--- a/src/PrefsManager.h
+++ b/src/PrefsManager.h
@@ -245,6 +245,7 @@ public:
 	Preference<bool>	m_bAllowMultipleHighScoreWithSameName;
 	Preference<bool>	m_bCelShadeModels;
 	Preference<bool>	m_bPreferredSortUsesGroups;
+	Preference<bool>	m_bDebounceCoinInput; // allow users to not debounce input for coins
 
 	// Number of seconds it takes for a button on the controller to release
 	// after pressed.


### PR DESCRIPTION
This commit adds a preference, DebounceCoinInput, which defaults to true.  If set to false, debouncing is not applied to coin input.

There was a question about the CheckButtonChange() function being called 500+ times per second; that doesn't seem to be the case (I tested with various traces).  Additionally, the outer if statement was written to short-circuit as efficiently as possible.
