### PR TITLE
Use legal printf format strings when logging.

### DIFF
--- a/src/LuaManager.cpp
+++ b/src/LuaManager.cpp
@@ -807,7 +807,7 @@ Dialog::Result LuaHelpers::ReportScriptError(RString const& Error, RString Error
 		ScriptErrorMessage(Error);
 		InReportScriptError= false;
 	}
-	LOG->Warn(Error.c_str());
+	LOG->Warn( "%s", Error.c_str());
 	if(UseAbort)
 	{
 		RString with_correct= Error + "  Correct this and click Retry, or Cancel to break.";

--- a/src/ThemeManager.cpp
+++ b/src/ThemeManager.cpp
@@ -816,12 +816,12 @@ try_element_again:
 		goto try_element_again;
 	case Dialog::ignore:
 		{
-			RString error= sCategory + '/' + sFileName +
-				" could not be found in \"" +
-				GetThemeDirFromName(m_sCurThemeName).c_str() + "\" or \"" +
-				GetThemeDirFromName(SpecialFiles::BASE_THEME_NAME).c_str() + "\".";
-			LOG->UserLog("Theme element", "%s", error.c_str());
-			LOG->Warn(error.c_str());
+			RString element = sCategory + '/' + sFileName;
+			RString error = "could not be found in \"" +
+				GetThemeDirFromName(m_sCurThemeName) + "\" or \"" +
+				GetThemeDirFromName(SpecialFiles::BASE_THEME_NAME) + "\".";
+			LOG->UserLog("Theme element", element.c_str(), "%s", error.c_str());
+			LOG->Warn( "%s %s", element.c_str(), error.c_str());
 			LuaHelpers::ScriptErrorMessage(error);
 		}
 


### PR DESCRIPTION
Building with debian packaging tools failed due to logging calls with incorrect printf-style arguments. Here are some fixes.
