### PR TITLE
Fixed endless courses.

### DIFF
--- a/src/Course.cpp
+++ b/src/Course.cpp
@@ -404,6 +404,9 @@ bool Course::GetTrailUnsorted( StepsType st, CourseDifficulty cd, Trail &trail )
 	trail.Init();
 
 	// XXX: Why are beginner and challenge excluded here? -Wolfman2000
+	// No idea, probably an obsolete design decision from ITG, removing
+	// exclusion here, but there's some other area that prevents it too. -Kyz
+	/*
 	switch( cd )
 	{
 		case Difficulty_Beginner:
@@ -412,6 +415,7 @@ bool Course::GetTrailUnsorted( StepsType st, CourseDifficulty cd, Trail &trail )
 			return false;
 		default: break;
 	}
+	*/
 
 	// Construct a new Trail, add it to the cache, then return it.
 	// Different seed for each course, but the same for the whole round:
@@ -848,9 +852,9 @@ bool Course::CourseHasBestOrWorst() const
 {
 	FOREACH_CONST( CourseEntry, m_vEntries, e )
 	{
-		if( e->iChooseIndex == SongSort_MostPlays  &&  e->iChooseIndex != -1 )
+		if( e->songSort == SongSort_MostPlays  &&  e->iChooseIndex != -1 )
 			return true;
-		if( e->iChooseIndex == SongSort_FewestPlays  &&  e->iChooseIndex != -1 )
+		if( e->songSort == SongSort_FewestPlays  &&  e->iChooseIndex != -1 )
 			return true;
 	}
 

--- a/src/GameState.cpp
+++ b/src/GameState.cpp
@@ -2109,6 +2109,11 @@ Difficulty GameState::GetHardestStepsDifficulty() const
 	return dc;
 }
 
+void GameState::SetNewStageSeed()
+{
+	m_iStageSeed= rand();
+}
+
 bool GameState::IsEventMode() const
 {
 	return m_bTemporaryEventMode || PREFSMAN->m_bEventMode;

--- a/src/GameState.h
+++ b/src/GameState.h
@@ -117,6 +117,8 @@ public:
 	int			m_iGameSeed, m_iStageSeed;
 	RString		m_sStageGUID;
 
+	void SetNewStageSeed();
+
 	/**
 	 * @brief Determine if a second player can join in at this time.
 	 * @return true if a player can still enter the game, false otherwise. */


### PR DESCRIPTION
To make them repick on repeats and not crash on evaluation after repeating.
Fixes #250 and #304.
Also fixes what looked like obviously broken logic in Course::CourseHasBestOrWorst().
