### PR TITLE
add distinct coin input debounce preference

### DIFF
--- a/src/PrefsManager.cpp
+++ b/src/PrefsManager.cpp
@@ -254,6 +254,7 @@ PrefsManager::PrefsManager() :
 	m_bAllowMultipleHighScoreWithSameName	( "AllowMultipleHighScoreWithSameName",	true ),
 	m_bCelShadeModels		( "CelShadeModels",			false ),	// Work-In-Progress.. disable by default.
 	m_bPreferredSortUsesGroups	( "PreferredSortUsesGroups",		true ),
+	m_fDebounceCoinInputTime	( "DebounceCoinInputTime",		0 ),
 
 	m_fPadStickSeconds		( "PadStickSeconds",			0 ),
 	m_bForceMipMaps			( "ForceMipMaps",			false ),

--- a/src/PrefsManager.h
+++ b/src/PrefsManager.h
@@ -245,6 +245,7 @@ public:
 	Preference<bool>	m_bAllowMultipleHighScoreWithSameName;
 	Preference<bool>	m_bCelShadeModels;
 	Preference<bool>	m_bPreferredSortUsesGroups;
+	Preference<float>	m_fDebounceCoinInputTime; // allow users to apply a distinct debounce to coin input
 
 	// Number of seconds it takes for a button on the controller to release
 	// after pressed.


### PR DESCRIPTION
This commit adds a preference, DebounceCoinInputTime (defaults is 0), which allows coin input to be debounced via a float value separate from other input.
