### PR TITLE
Fix P2 input when PlayerAutoplay in P1

### DIFF
--- a/src/ScreenGameplay.cpp
+++ b/src/ScreenGameplay.cpp
@@ -2369,7 +2369,7 @@ bool ScreenGameplay::Input( const InputEventPlus &input )
 		{
 			AbortGiveUp( true );
 
-			if( GamePreferences::m_AutoPlay == PC_HUMAN && GAMESTATE->m_pPlayerState[PLAYER_1]->m_PlayerOptions.GetCurrent().m_fPlayerAutoPlay == 0 )
+			if( GamePreferences::m_AutoPlay == PC_HUMAN && GAMESTATE->m_pPlayerState[input.pn]->m_PlayerOptions.GetCurrent().m_fPlayerAutoPlay == 0 )
 			{
 				PlayerInfo& pi = GetPlayerInfoForInput( input );
 


### PR DESCRIPTION
When PlayerAutoplay is enabled in P1, no note in P2 could be hit. (except HoldCheckpoints)
