### PR TITLE
Band-aid fix for Mac OS X fullscreen issues (only when compiled with 10.6 SDK)

### DIFF
--- a/src/arch/MemoryCard/MemoryCardDriverThreaded_MacOSX.cpp
+++ b/src/arch/MemoryCard/MemoryCardDriverThreaded_MacOSX.cpp
@@ -60,8 +60,25 @@ MemoryCardDriverThreaded_MacOSX::~MemoryCardDriverThreaded_MacOSX()
 
 void MemoryCardDriverThreaded_MacOSX::Unmount( UsbStorageDevice *pDevice )
 {
+#if defined(SYNC_VOLUME_FULLSYNC) && defined(SYNC_VOLUME_WAIT)
+	
 	if( sync_volume_np( pDevice->sOsMountDir.c_str(), SYNC_VOLUME_FULLSYNC | SYNC_VOLUME_WAIT ) != 0 )
 		LOG->Warn( "Failed to flush the memory card." );
+#else
+	ParamBlockRec pb;
+	Str255 name; // A pascal string.
+	const RString& base = Basename( pDevice->sOsMountDir );
+	
+	memset( &pb, 0, sizeof(pb) );
+	name[0] = min( base.length(), size_t(255) );
+	strncpy( (char *)&name[1], base, name[0] );
+	pb.volumeParam.ioNamePtr = name;
+	pb.volumeParam.ioVolIndex = -1; // Use ioNamePtr to find the volume.
+	
+	if( PBFlushVolSync(&pb) != noErr )
+		LOG->Warn( "Failed to flush the memory card." );
+	
+#endif
 }
 
 bool MemoryCardDriverThreaded_MacOSX::USBStorageDevicesChanged()


### PR DESCRIPTION
Building against newer Mac OS X SDKs causes fullscreen not to work (see: Issue #224). Building with the 10.6 SDK allows fullscreen to work.

A recent change to MemoryCardDriverThreaded_MacOSX::Unmount causes Stepmania to not compile under the 10.6 SDK. The new implementation of the method relies on a function called sync_volume_np, which was not introduced until 10.8.

This pull request uses the function if it's available, and falls back to the old logic if it's not. This allows compilation with the 10.6 SDK and the newer SDKs. When compiling with the 10.6 SDK, fullscreen works again.
