### PR TITLE
Unduplicate file extension lists.

### DIFF
--- a/src/ActorUtil.h
+++ b/src/ActorUtil.h
@@ -30,15 +30,16 @@ Actor *CreateActor() { return new T; }
 
 enum FileType
 {
-	FT_Bitmap, 
+	FT_Bitmap,
 	FT_Sprite,
-	FT_Sound, 
-	FT_Movie, 
-	FT_Directory, 
+	FT_Sound,
+	FT_Movie,
+	FT_Directory,
 	FT_Xml,
-	FT_Model, 
-	FT_Lua, 
-	NUM_FileType, 
+	FT_Model,
+	FT_Lua,
+	FT_Ini,
+	NUM_FileType,
 	FileType_Invalid
 };
 const RString& FileTypeToString( FileType ft );
@@ -46,6 +47,10 @@ const RString& FileTypeToString( FileType ft );
 /** @brief Utility functions for creating and manipulating Actors. */
 namespace ActorUtil
 {
+	void InitFileTypeLists();
+	vector<RString> const& GetTypeExtensionList(FileType ft);
+	void AddTypeExtensionsToList(FileType ft, vector<RString>& add_to);
+
 	// Every screen should register its class at program initialization.
 	void Register( const RString& sClassName, CreateActorFn pfn );
 

--- a/src/BackgroundUtil.cpp
+++ b/src/BackgroundUtil.cpp
@@ -7,6 +7,8 @@
 #include "RageLog.h"
 #include <set>
 #include "Background.h"
+#include "RageFileManager.h"
+#include "ActorUtil.h"
 
 
 bool BackgroundDef::operator<( const BackgroundDef &other ) const
@@ -194,15 +196,8 @@ void BackgroundUtil::GetSongMovies( const Song *pSong, const RString &sMatch, ve
 	vsPathsOut.clear();
 	if( sMatch.empty() )
 	{
-		GetDirListing( pSong->GetSongDir()+sMatch+"*.ogv",	vsPathsOut, false, true );
-		GetDirListing( pSong->GetSongDir()+sMatch+"*.avi",	vsPathsOut, false, true );
-		GetDirListing( pSong->GetSongDir()+sMatch+"*.mpg",	vsPathsOut, false, true );
-		GetDirListing( pSong->GetSongDir()+sMatch+"*.mpeg", vsPathsOut, false, true );
-		GetDirListing( pSong->GetSongDir()+sMatch+"*.mp4", vsPathsOut, false, true );
-		GetDirListing( pSong->GetSongDir()+sMatch+"*.flv", vsPathsOut, false, true );
-		GetDirListing( pSong->GetSongDir()+sMatch+"*.f4v", vsPathsOut, false, true );
-		GetDirListing( pSong->GetSongDir()+sMatch+"*.mov", vsPathsOut, false, true );
-		GetDirListing( pSong->GetSongDir()+sMatch+"*.mkv", vsPathsOut, false, true );		
+		FILEMAN->GetDirListingWithMultipleExtensions(pSong->GetSongDir()+sMatch,
+			ActorUtil::GetTypeExtensionList(FT_Movie), vsPathsOut, false, true);
 	}
 	else
 	{
@@ -221,11 +216,8 @@ void BackgroundUtil::GetSongBitmaps( const Song *pSong, const RString &sMatch, v
 	vsPathsOut.clear();
 	if( sMatch.empty() )
 	{
-		GetDirListing( pSong->GetSongDir()+sMatch+"*.png",	vsPathsOut, false, true );
-		GetDirListing( pSong->GetSongDir()+sMatch+"*.jpg",	vsPathsOut, false, true );
-		GetDirListing( pSong->GetSongDir()+sMatch+"*.jpeg",	vsPathsOut, false, true );
-		GetDirListing( pSong->GetSongDir()+sMatch+"*.gif",	vsPathsOut, false, true );
-		GetDirListing( pSong->GetSongDir()+sMatch+"*.bmp",	vsPathsOut, false, true );
+		FILEMAN->GetDirListingWithMultipleExtensions(pSong->GetSongDir()+sMatch,
+			ActorUtil::GetTypeExtensionList(FT_Bitmap), vsPathsOut, false, true);
 	}
 	else
 	{

--- a/src/NotesLoaderBMS.cpp
+++ b/src/NotesLoaderBMS.cpp
@@ -15,6 +15,8 @@
 #include "NotesLoader.h"
 #include "PrefsManager.h"
 #include "BackgroundUtil.h"
+#include "ActorUtil.h"
+#include "RageFileManager.h"
 
 /* BMS encoding:	tap-hold
  * 4&8panel:	Player1		Player2
@@ -328,8 +330,8 @@ int BMSSong::AllocateKeysound( RString filename, RString path )
 
 	if( !IsAFile(dir + normalizedFilename) )
 	{
-		const char *exts[] = { "oga", "ogg", "wav", "mp3", NULL }; // XXX: stop duplicating these everywhere
-		for( unsigned i = 0; exts[i] != NULL; ++i )
+		vector<RString> const& exts= ActorUtil::GetTypeExtensionList(FT_Sound);
+		for(size_t i = 0; i < exts.size(); ++i)
 		{
 			RString fn = SetExtension( normalizedFilename, exts[i] );
 			if( IsAFile(dir + fn) )
@@ -393,8 +395,10 @@ bool BMSSong::GetBackground( RString filename, RString path, RString &bgfile )
 	
 	if( !IsAFile(dir + normalizedFilename) )
 	{
-		const char *exts[] = { "ogv", "avi", "mpg", "mpeg", "bmp", "png", "jpeg", NULL }; // XXX: stop duplicating these everywhere
-		for( unsigned i = 0; exts[i] != NULL; ++i )
+		vector<RString> exts;
+		ActorUtil::AddTypeExtensionsToList(FT_Movie, exts);
+		ActorUtil::AddTypeExtensionsToList(FT_Bitmap, exts);
+		for(size_t i = 0; i < exts.size(); ++i)
 		{
 			RString fn = SetExtension( normalizedFilename, exts[i] );
 			if( IsAFile(dir + fn) )
@@ -424,12 +428,10 @@ void BMSSong::PrecacheBackgrounds(const RString &dir)
 	backgroundsPrecached = true;
 	vector<RString> arrayPossibleFiles;
 	
-	const char *exts[] = { "ogv", "avi", "mpg", "mpeg", "bmp", "png", "jpeg", NULL }; // XXX: stop duplicating these everywhere
-	
-	for( unsigned i = 0; exts[i] != NULL; ++i )
-	{
-		GetDirListing( dir + RString("*.") + RString(exts[i]), arrayPossibleFiles );
-	}
+	vector<RString> exts;
+	ActorUtil::AddTypeExtensionsToList(FT_Movie, exts);
+	ActorUtil::AddTypeExtensionsToList(FT_Bitmap, exts);
+	FILEMAN->GetDirListingWithMultipleExtensions(dir + RString("*."), exts, arrayPossibleFiles);
 	
 	for( unsigned i = 0; i < arrayPossibleFiles.size(); i++ )
 	{

--- a/src/RageFileManager.cpp
+++ b/src/RageFileManager.cpp
@@ -397,6 +397,15 @@ void RageFileManager::GetDirListing( const RString &sPath_, vector<RString> &Add
 	}
 }
 
+void RageFileManager::GetDirListingWithMultipleExtensions( const RString &sPath, vector<RString> const& ExtensionList, vector<RString> &AddTo, bool bOnlyDirs, bool bReturnPathToo )
+{
+	for(vector<RString>::const_iterator curr_ext= ExtensionList.begin();
+		curr_ext != ExtensionList.end(); ++curr_ext)
+	{
+		GetDirListing(sPath + (*curr_ext), AddTo, bOnlyDirs, bReturnPathToo);
+	}
+}
+
 /* Files may only be moved within the same file driver. */
 bool RageFileManager::Move( const RString &sOldPath_, const RString &sNewPath_ )
 {

--- a/src/RageFileManager.h
+++ b/src/RageFileManager.h
@@ -24,6 +24,9 @@ public:
 	void MountUserFilesystems();
 
 	void GetDirListing( const RString &sPath, vector<RString> &AddTo, bool bOnlyDirs, bool bReturnPathToo );
+	void GetDirListingWithMultipleExtensions(const RString &sPath,
+		vector<RString> const& ExtensionList, vector<RString> &AddTo,
+		bool bOnlyDirs= false, bool bReturnPathToo= false);
 	bool Move( const RString &sOldPath, const RString &sNewPath );
 	bool Remove( const RString &sPath );
 	void CreateDir( const RString &sDir );

--- a/src/RageSoundReader_FileReader.cpp
+++ b/src/RageSoundReader_FileReader.cpp
@@ -2,6 +2,7 @@
 #include "RageSoundReader_FileReader.h"
 #include "RageUtil.h"
 #include "RageLog.h"
+#include "ActorUtil.h"
 
 #include <set>
 #ifndef NO_WAV_SUPPORT
@@ -122,10 +123,12 @@ RageSoundReader_FileReader *RageSoundReader_FileReader::OpenFile( RString filena
 		}
 	}
 	set<RString> FileTypes;
-	FileTypes.insert("oga");
-	FileTypes.insert("ogg");
-	FileTypes.insert("mp3");
-	FileTypes.insert("wav");
+	vector<RString> const& sound_exts= ActorUtil::GetTypeExtensionList(FT_Sound);
+	for(vector<RString>::const_iterator curr= sound_exts.begin();
+			curr != sound_exts.end(); ++curr)
+	{
+		FileTypes.insert(*curr);
+	}
 
 	RString format = GetExtension( filename );
 	format.MakeLower();

--- a/src/RageSurface_Load.cpp
+++ b/src/RageSurface_Load.cpp
@@ -1,4 +1,5 @@
 #include "global.h"
+#include "ActorUtil.h"
 #include "RageSurface_Load.h"
 #include "RageSurface_Load_PNG.h"
 #include "RageSurface_Load_JPEG.h"
@@ -85,11 +86,12 @@ RageSurface *RageSurfaceUtils::LoadFile( const RString &sPath, RString &error, b
 	}
 
 	set<RString> FileTypes;
-	FileTypes.insert("png");
-	FileTypes.insert("jpg");
-	FileTypes.insert("jpeg");
-	FileTypes.insert("gif");
-	FileTypes.insert("bmp");
+	vector<RString> const& exts= ActorUtil::GetTypeExtensionList(FT_Bitmap);
+	for(vector<RString>::const_iterator curr= exts.begin();
+			curr != exts.end(); ++curr)
+	{
+		FileTypes.insert(*curr);
+	}
 
 	RString format = GetExtension(sPath);
 	format.MakeLower();

--- a/src/RageTextureManager.cpp
+++ b/src/RageTextureManager.cpp
@@ -26,6 +26,7 @@
 #include "RageLog.h"
 #include "RageDisplay.h"
 #include "Foreach.h"
+#include "ActorUtil.h"
 
 #include <map>
 
@@ -147,17 +148,13 @@ RageTexture* RageTextureManager::LoadTextureInternal( RageTextureID ID )
 	}
 
 	// The texture is not already loaded.  Load it.
-	RString sExt = GetExtension( ID.filename );
-	sExt.MakeLower();
 
 	RageTexture* pTexture;
 	if( ID.filename == g_sDefaultTextureName )
 	{
 		pTexture = new RageTexture_Default;
 	}
-	else if(sExt == "ogv" || sExt == "avi" || sExt == "mpg" ||
-		sExt == "mpeg" || sExt == "mp4" || sExt == "mkv" || sExt == "mov" ||
-		sExt == "flv" || sExt == "f4v")
+	else if(ActorUtil::GetFileType(ID.filename) == FT_Movie)
 	{
 		pTexture = RageMovieTexture::Create( ID );
 	}

--- a/src/Song.cpp
+++ b/src/Song.cpp
@@ -32,6 +32,7 @@
 #include "NotesWriterSSC.h"
 #include "UnlockManager.h"
 #include "LyricsLoader.h"
+#include "ActorUtil.h"
 
 #include <time.h>
 #include <set>
@@ -516,10 +517,8 @@ void Song::TidyUpData( bool fromCache, bool /* duringCache */ )
 	if( !HasMusic() )
 	{
 		vector<RString> arrayPossibleMusic;
-		GetDirListing( m_sSongDir + RString("*.mp3"), arrayPossibleMusic );
-		GetDirListing( m_sSongDir + RString("*.oga"), arrayPossibleMusic );
-		GetDirListing( m_sSongDir + RString("*.ogg"), arrayPossibleMusic );
-		GetDirListing( m_sSongDir + RString("*.wav"), arrayPossibleMusic );
+		FILEMAN->GetDirListingWithMultipleExtensions(m_sSongDir,
+			ActorUtil::GetTypeExtensionList(FT_Sound), arrayPossibleMusic);
 
 		if( !arrayPossibleMusic.empty() )
 		{
@@ -854,15 +853,8 @@ void Song::TidyUpData( bool fromCache, bool /* duringCache */ )
 	if( (!HasBGChanges() && !fromCache) )
 	{
 		vector<RString> arrayPossibleMovies;
-		GetDirListing( m_sSongDir + RString("*.ogv"), arrayPossibleMovies );
-		GetDirListing( m_sSongDir + RString("*.avi"), arrayPossibleMovies );
-		GetDirListing( m_sSongDir + RString("*.mpg"), arrayPossibleMovies );
-		GetDirListing( m_sSongDir + RString("*.mpeg"), arrayPossibleMovies );
-		GetDirListing( m_sSongDir + RString("*.mp4"), arrayPossibleMovies );
-		GetDirListing( m_sSongDir + RString("*.mkv"), arrayPossibleMovies );
-		GetDirListing( m_sSongDir + RString("*.flv"), arrayPossibleMovies );
-		GetDirListing( m_sSongDir + RString("*.f4v"), arrayPossibleMovies );
-		GetDirListing( m_sSongDir + RString("*.mov"), arrayPossibleMovies );
+		FILEMAN->GetDirListingWithMultipleExtensions(m_sSongDir,
+			ActorUtil::GetTypeExtensionList(FT_Movie), arrayPossibleMovies);
 
 		/* Use this->GetBeatFromElapsedTime(0) instead of 0 to start when the
 		 * music starts. */

--- a/src/StepMania.cpp
+++ b/src/StepMania.cpp
@@ -67,6 +67,7 @@
 #include "GameLoop.h"
 #include "SpecialFiles.h"
 #include "Profile.h"
+#include "ActorUtil.h"
 
 #if defined(WIN32)
 #include <windows.h>
@@ -950,6 +951,10 @@ int main(int argc, char* argv[])
 	HOOKS->Init();
 
 	LUA		= new LuaManager;
+
+	// Initialize the file extension type lists so everything can ask ActorUtil
+	// what the type of a file is.
+	ActorUtil::InitFileTypeLists();
 
 	// Almost everything uses this to read and write files.  Load this early.
 	FILEMAN = new RageFileManager( argv[0] );

--- a/src/ThemeManager.cpp
+++ b/src/ThemeManager.cpp
@@ -616,45 +616,51 @@ bool ThemeManager::GetPathInfoToRaw( PathInfo &out, const RString &sThemeName_, 
 		for( unsigned p = 0; p < asPaths.size(); ++p )
 		{
 			// BGAnimations, Fonts, Graphics, Sounds, Other
-			static const char *masks[NUM_ElementCategory][15] = {
-				{ "redir", "lua", "xml", "png", "jpg", "jpeg", "bmp", "gif", "ogv", "avi", "mpg", "mpeg", "txt", "", NULL},
-				{ "redir", "ini", NULL },
-				{ "redir", "lua", "xml", "png", "jpg", "jpeg", "bmp", "gif", "ogv", "avi", "mpg", "mpeg", "txt", "", NULL},
-				{ "redir", "lua", "mp3", "oga", "ogg", "wav", NULL },
-				{ "*", NULL },
-			};
-			const char **asset_masks = masks[category];
-
-			const RString ext = GetExtension( asPaths[p] );
-
-			for( int i = 0; asset_masks[i]; ++i )
+			const RString ext = GetExtension(asPaths[p]);
+			bool matches= category == EC_OTHER || ext == "redir";
+			if(!matches)
 			{
-				// No extension means directories.
-				if( asset_masks[i][0] == 0 )
+				FileType ft= ActorUtil::GetFileType(asPaths[p]);
+				switch(ft)
 				{
-					if( !IsADirectory(asPaths[p]) )
-						continue;
-
-					RString sXMLPath = asPaths[p] + "/default.xml";
-					if( DoesFileExist(sXMLPath) )
-					{
-						asElementPaths.push_back( sXMLPath );
+					case FT_Bitmap:
+					case FT_Sprite:
+					case FT_Movie:
+					case FT_Xml:
+					case FT_Model:
+					case FT_Lua:
+						matches= category == EC_BGANIMATIONS || category == EC_GRAPHICS;
 						break;
-					}
-
-					RString sLuaPath = asPaths[p] + "/default.lua";
-					if( DoesFileExist(sLuaPath) )
-					{
-						asElementPaths.push_back( sLuaPath );
+					case FT_Ini:
+						matches= category == EC_FONTS;
 						break;
-					}
+					case FT_Directory:
+						{
+							RString sXMLPath = asPaths[p] + "/default.xml";
+							if(DoesFileExist(sXMLPath))
+							{
+								asElementPaths.push_back(sXMLPath);
+								break;
+							}
+							RString sLuaPath = asPaths[p] + "/default.lua";
+							if(DoesFileExist(sLuaPath))
+							{
+								asElementPaths.push_back(sLuaPath);
+								break;
+							}
+						}
+						break;
+					case FT_Sound:
+						matches= category == EC_SOUNDS;
+						break;
+					default:
+						matches= false;
+						break;
 				}
-
-				if( ext == asset_masks[i] || !strcmp(asset_masks[i], "*") )
-				{
-					asElementPaths.push_back( asPaths[p] );
-					break;
-				}
+			}
+			if(matches)
+			{
+				asElementPaths.push_back(asPaths[p]);
 			}
 		}
 	}


### PR DESCRIPTION
Several different places in the code had lists of recognized file extensions, which is just a problem waiting to happen if/when a new type is added down the line.  This moves most of the file extension checking to ActorUtil and instead has other things use the FileType enum.
Exceptions to this are RageSurfaceLoad and RageSoundReader which have to check the extension to know how to load a file.
This also adds FT_Ini to the FileType enum, and adds webm and wmv to the list of video files to load.
