### PR TITLE
Add "PlayAnnouncer" in theme metric

### DIFF
--- a/Themes/_fallback/metrics.ini
+++ b/Themes/_fallback/metrics.ini
@@ -3580,6 +3580,7 @@ Class="ScreenEvaluation"
 Fallback="ScreenWithMenuElements"
 NextScreen=Branch.AfterEvaluation()
 PrevScreen=Branch.AfterEvaluation()
+PlayAnnouncer=true
 TimerSeconds=20
 LightsMode="LightsMode_MenuStartOnly"
 #


### PR DESCRIPTION
In some cases, ScreenEvaluationNormal and ScreenEvaluationSummary may want to have it's own preference about playing announcer. Fallback defaults to true.