### PR TITLE
Fixing the missing ffmpeg libraries

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -29,6 +29,9 @@ dist-hook: SMData
 install-exec-hook:
 	mkdir -p "$(DESTDIR)$(prefix)/$(productID)"
 	$(INSTALL) $(installFiles) "$(DESTDIR)$(prefix)/$(productID)"
+	$(INSTALL) "bundle/ffmpeg/libavutil/libavutil.so.52" "$(DESTDIR)$(prefix)/$(productID)"
+	$(INSTALL) "bundle/ffmpeg/libavcodec/libavcodec.so.55" "$(DESTDIR)$(prefix)/$(productID)"
+	$(INSTALL) "bundle/ffmpeg/libavformat/libavformat.so.55" $(DESTDIR)$(prefix)/$(productID)"
 
 install-data-local:
 	mkdir -p "$(DESTDIR)$(prefix)/$(productID)/Songs"


### PR DESCRIPTION
if a user were to run 'sudo make install' and attempt to run the game out of its installed directory, stepmania would fail due to missing ffmpeg libraries.

this resolves that issue by copying the files into stepmania's root directory at install time.