### PR TITLE
Allow building against system PCRE library

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -388,6 +388,21 @@ AC_SUBST(RESFLAGS)
 dnl Add these after all tests are done as they don't exist just yet.
 LIBS="$LIBS $FFMPEG_LIBS"
 
+# Selection between bundled pcre and system pcre
+AC_ARG_WITH(system-pcre, AS_HELP_STRING([--with-system-pcre],[Disable building of bundled libpcre]), with_system_pcre=$withval, with_system_pcre=no)
+AM_CONDITIONAL(USE_SYSTEM_PCRE, test "$with_system_pcre" == "yes")
+
+if test "$with_system_pcre" == "yes"; then
+	have_libpcre=yes
+	AC_CHECK_HEADER(pcre.h, , have_libpcre=no)
+	if test "$have_libpcre" = "no"; then
+		AC_MSG_ERROR([If you want to use system libpcre, please make sure that it is installed. Otherwise please configure with --without-system-pcre.])
+	else
+		AC_DEFINE([USE_SYSTEM_PCRE], 1, [Build with system libpcre])
+		LIBS="$LIBS -lpcre"
+	fi
+fi
+
 AC_CONFIG_FILES(Makefile)
 AC_CONFIG_FILES(bundle/Makefile)
 AC_CONFIG_FILES(src/Makefile)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -486,8 +486,13 @@ ScoreDisplayNormal.cpp ScoreDisplayNormal.h ScoreDisplayOni.cpp ScoreDisplayOni.
 ScoreDisplayPercentage.cpp ScoreDisplayPercentage.h ScoreDisplayRave.cpp ScoreDisplayRave.h \
 SongPosition.cpp SongPosition.h
 
-PCRE = ../extern/pcre/get.c ../extern/pcre/internal.h ../extern/pcre/maketables.c ../extern/pcre/pcre.c ../extern/pcre/pcre.h ../extern/pcre/study.c
+Rage =
+all_test_SOURCES =
+if !USE_SYSTEM_PCRE
+Rage += ../extern/pcre/get.c ../extern/pcre/internal.h ../extern/pcre/maketables.c ../extern/pcre/pcre.c ../extern/pcre/pcre.h ../extern/pcre/study.c
+all_test_SOURCES += ../extern/pcre/get.c ../extern/pcre/internal.h ../extern/pcre/maketables.c ../extern/pcre/pcre.c ../extern/pcre/pcre.h ../extern/pcre/study.c
 EXTRA_DIST += ../extern/pcre/chartables.c
+endif
 
 Lua = ../extern/lua-5.1/src/lapi.c ../extern/lua-5.1/src/lauxlib.c ../extern/lua-5.1/src/lbaselib.c ../extern/lua-5.1/src/lcode.c ../extern/lua-5.1/src/ldblib.c \
 ../extern/lua-5.1/src/ldebug.c ../extern/lua-5.1/src/ldo.c ../extern/lua-5.1/src/ldump.c ../extern/lua-5.1/src/lfunc.c ../extern/lua-5.1/src/lgc.c ../extern/lua-5.1/src/linit.c \
@@ -523,7 +528,7 @@ RageFileDriverReadAhead.cpp RageFileDriverReadAhead.h \
 RageFileDriverSlice.cpp RageFileDriverSlice.h \
 RageFileDriverTimeout.cpp RageFileDriverTimeout.h
 
-Rage = $(PCRE) $(Lua) $(jsoncpp) $(RageFile) $(RageSoundFileReaders) \
+Rage += $(Lua) $(jsoncpp) $(RageFile) $(RageSoundFileReaders) \
 CubicSpline.cpp CubicSpline.h \
 RageBitmapTexture.cpp RageBitmapTexture.h \
 RageDisplay.cpp RageDisplay.h \
@@ -769,9 +774,8 @@ if HAVE_GTK
  GtkModule_so_SOURCES = arch/LoadingWindow/LoadingWindow_GtkModule.cpp
 endif
 
-all_test_SOURCES = \
+all_test_SOURCES += \
 		$(ArchUtils) \
-		$(PCRE) \
 		$(RageFile) \
 		$(Lua) \
 		$(ArchHooks) \

--- a/src/RageUtil.cpp
+++ b/src/RageUtil.cpp
@@ -1342,7 +1342,11 @@ bool GetFileContents( const RString &sFile, vector<RString> &asOut )
 	return true;
 }
 
+#ifndef USE_SYSTEM_PCRE
 #include "../extern/pcre/pcre.h"
+#else
+#include <pcre.h>
+#endif
 void Regex::Compile()
 {
 	const char *error;


### PR DESCRIPTION
As @shakesoda +1'd.

Steps to use:

1. Pull this branch
2. Run `./autogen.sh` and `./configure --with-system-pcre`. `make` should build successfully.