### PR TITLE
Fix CloseCurrentFolder with OnlyShowActiveSection

### DIFF
--- a/src/MusicWheel.cpp
+++ b/src/MusicWheel.cpp
@@ -677,10 +677,7 @@ void MusicWheel::BuildWheelItemDatas( vector<MusicWheelItemData *> &arrayWheelIt
 						// todo: preferred sort section color handling? -aj
 						RageColor colorSection = (so==SORT_GROUP) ? SONGMAN->GetSongGroupColor(pSong->m_sGroupName) : SECTION_COLORS.GetValue(iSectionColorIndex);
 						iSectionColorIndex = (iSectionColorIndex+1) % NUM_SECTION_COLORS;
-						// In certain situations (e.g. simulating Pump it Up), themes may
-						// want to only show one group at a time.
-						if( !HIDE_INACTIVE_SECTIONS )
-							arrayWheelItemDatas.push_back( new MusicWheelItemData(WheelItemDataType_Section, NULL, sThisSection, NULL, colorSection, iSectionCount) );
+						arrayWheelItemDatas.push_back( new MusicWheelItemData(WheelItemDataType_Section, NULL, sThisSection, NULL, colorSection, iSectionCount) );
 						sLastSection = sThisSection;
 					}
 				}
@@ -1361,9 +1358,14 @@ void MusicWheel::SetOpenSection( RString group )
 	for( unsigned i = 0; i < from.size(); ++i )
 	{
 		MusicWheelItemData &d = *from[i];
+		// Don't show songs outside the current group
 		if( (d.m_Type == WheelItemDataType_Song || d.m_Type == WheelItemDataType_Course) && !d.m_sText.empty() &&
 			 d.m_sText != group )
 			 continue;
+		// In certain situations (e.g. simulating Pump it Up), themes may
+		// want to hide inactive group headings as well.
+		if( HIDE_INACTIVE_SECTIONS && d.m_Type == WheelItemDataType_Section && group != "" )
+			continue;
 
 		// If AUTO_SET_STYLE, hide courses that prefer a style that isn't available.
 		if( d.m_Type == WheelItemDataType_Course && CommonMetrics::AUTO_SET_STYLE )

--- a/src/WheelBase.cpp
+++ b/src/WheelBase.cpp
@@ -290,7 +290,7 @@ bool WheelBase::Select()	// return true if this selection can end the screen
 	{
 	case WheelItemDataType_Generic:
 		m_LastSelection = m_CurWheelItemData[m_iSelection];
-		break;
+		return true;
 	case WheelItemDataType_Section:
 		{
 			RString sThisItemSectionName = m_CurWheelItemData[m_iSelection]->m_sText;
@@ -305,12 +305,11 @@ bool WheelBase::Select()	// return true if this selection can end the screen
 				m_soundExpand.Play();
 			}
 		}
-		break;
+		// Opening/closing sections cannot end the screen
+		return false;
 	default:
-		break;
+		return true;
 	}
-
-	return true;
 }
 
 WheelItemBaseData* WheelBase::GetItem( unsigned int iIndex )


### PR DESCRIPTION
Currently if a theme enables OnlyShowActiveSection for its MusicWheel, closing the active group (e.g. using Lua or the CloseCurrentFolder code) will result in an empty wheel.  This patchset fixes this so that when the active group is closed, all of the group titles are shown, and they are hidden again when a new group is selected.

The existing code was throwing out group titles when the cache for the Group sort order was being built, preventing us from ever displaying them in that sort, so the patches move that logic into SetOpenSection where we already have filtering code based on the active group.

This introduced an odd behavior where selecting a group could actually end ScreenSelectMusic and hang the program, which is where the fix in WheelBase comes in.  Thanks to whoever left that single comment explaining what the return value should be. :smile: