### PR TITLE
Travis: add apt-get update and -y to dependency installation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,24 +9,25 @@ notifications:
     irc: "chat.freenode.net#stepmania-devs"
 
 before_script:
-    - sudo apt-get install nasm
-    - sudo apt-get install libmad0-dev
-    - sudo apt-get install libgtk2.0-dev
-    - sudo apt-get install binutils-dev
-    - sudo apt-get install libasound-dev
-    - sudo apt-get install libpulse-dev
-    - sudo apt-get install libjack-dev
-    - sudo apt-get install libc6-dev
-    - sudo apt-get install libogg-dev
-    - sudo apt-get install libvorbis-dev
-    - sudo apt-get install libbz2-dev
-    - sudo apt-get install zlib1g-dev
-    - sudo apt-get install libjpeg8-dev
-    - sudo apt-get install libpng12-dev
-    - sudo apt-get install libxtst-dev libxrandr-dev
-    - sudo apt-get install libglu1-mesa-dev
-    - sudo apt-get install mesa-common-dev
-    - sudo apt-get install libglew-dev
+    - sudo apt-get update -qq
+    - sudo apt-get install -y nasm
+    - sudo apt-get install -y libmad0-dev
+    - sudo apt-get install -y libgtk2.0-dev
+    - sudo apt-get install -y binutils-dev
+    - sudo apt-get install -y libasound-dev
+    - sudo apt-get install -y libpulse-dev
+    - sudo apt-get install -y libjack-dev
+    - sudo apt-get install -y libc6-dev
+    - sudo apt-get install -y libogg-dev
+    - sudo apt-get install -y libvorbis-dev
+    - sudo apt-get install -y libbz2-dev
+    - sudo apt-get install -y zlib1g-dev
+    - sudo apt-get install -y libjpeg8-dev
+    - sudo apt-get install -y libpng12-dev
+    - sudo apt-get install -y libxtst-dev libxrandr-dev
+    - sudo apt-get install -y libglu1-mesa-dev
+    - sudo apt-get install -y mesa-common-dev
+    - sudo apt-get install -y libglew-dev
 
 script:
     - ./autogen.sh


### PR DESCRIPTION
Hopefully will fix Travis for us.  I'm not sure how to test this on my own.

Recommended by Travis docs: http://docs.travis-ci.com/user/installing-dependencies/

We may eventually want to look into whether the before_install/install hooks are supposed to be used for this rather than before_script.  The documentation examples aren't entirely clear themselves (and it doesn't look like there is much distinction between steps besides the order they come in).