### PR TITLE
Allow OnlyShowActiveSection wheel to include current section title

### DIFF
--- a/Themes/_fallback/metrics.ini
+++ b/Themes/_fallback/metrics.ini
@@ -906,6 +906,7 @@ SwitchSeconds=0.10
 RandomPicksLockedSongs=true
 UseSectionsWithPreferredGroup=false
 OnlyShowActiveSection=false
+HideActiveSectionTitle=true
 RemindWheelPositions=false
 #
 RouletteSwitchSeconds=0.05

--- a/src/MusicWheel.cpp
+++ b/src/MusicWheel.cpp
@@ -87,6 +87,7 @@ void MusicWheel::Load( RString sType )
 	SHOW_EASY_FLAG			.Load(sType,"UseEasyMarkerFlag");
 	USE_SECTIONS_WITH_PREFERRED_GROUP		.Load(sType,"UseSectionsWithPreferredGroup");
 	HIDE_INACTIVE_SECTIONS		.Load(sType,"OnlyShowActiveSection");
+	HIDE_ACTIVE_SECTION_TITLE		.Load(sType,"HideActiveSectionTitle");
 	REMIND_WHEEL_POSITIONS		.Load(sType,"RemindWheelPositions");
 	vector<RString> vsModeChoiceNames;
 	split( MODE_MENU_CHOICE_NAMES, ",", vsModeChoiceNames );
@@ -1358,14 +1359,21 @@ void MusicWheel::SetOpenSection( RString group )
 	for( unsigned i = 0; i < from.size(); ++i )
 	{
 		MusicWheelItemData &d = *from[i];
-		// Don't show songs outside the current group
+
+		// Hide songs/courses which are not in the active section
 		if( (d.m_Type == WheelItemDataType_Song || d.m_Type == WheelItemDataType_Course) && !d.m_sText.empty() &&
 			 d.m_sText != group )
 			 continue;
-		// In certain situations (e.g. simulating Pump it Up), themes may
-		// want to hide inactive group headings as well.
-		if( HIDE_INACTIVE_SECTIONS && d.m_Type == WheelItemDataType_Section && group != "" )
-			continue;
+
+		// In certain situations (e.g. simulating Pump it Up or IIDX),
+		// themes may want to hide inactive section headings as well.
+		if( HIDE_INACTIVE_SECTIONS && d.m_Type == WheelItemDataType_Section && group != "" ) {
+			// Based on the HideActiveSectionTitle metric, we either
+			// hide all section titles, or only those which are not
+			// currently open.
+			if ( HIDE_ACTIVE_SECTION_TITLE || d.m_sText != group )
+				continue;
+		}
 
 		// If AUTO_SET_STYLE, hide courses that prefer a style that isn't available.
 		if( d.m_Type == WheelItemDataType_Course && CommonMetrics::AUTO_SET_STYLE )

--- a/src/MusicWheel.h
+++ b/src/MusicWheel.h
@@ -90,6 +90,7 @@ protected:
 	// sm-ssc additions:
 	ThemeMetric<bool>		USE_SECTIONS_WITH_PREFERRED_GROUP;
 	ThemeMetric<bool>		HIDE_INACTIVE_SECTIONS;
+	ThemeMetric<bool>		HIDE_ACTIVE_SECTION_TITLE;
 	ThemeMetric<bool>		REMIND_WHEEL_POSITIONS;
 	ThemeMetric<RageColor>	ROULETTE_COLOR;
 	ThemeMetric<RageColor>	RANDOM_COLOR;


### PR DESCRIPTION
IIDX hides inactive sections, but unlike the current behavior of our
OnlyShowActiveSection metric (based on certain Pumps according to
DaisukeMaster's comment), it retains the section title so that the
section can be closed normally.

New metric: MusicWheel.HideActiveSectionTitle, defaulting to true in
_fallback.  A bit unfortunate, but keeps backward compatibility with the
existing behavior of OnlyShowActiveSection.

If neither metric is true, wheel displays all titles plus the contents
of the active section (if any).

If OSAS is true but HAST is false, wheel displays the active section
title plus its contents, or all titles if no section is active.

If both are true, wheel displays only the active section's contents, or
all titles if no section is active.