### PR TITLE
fix OS X bundle scripts

### DIFF
--- a/Xcode/scripts/mkrelease.rb
+++ b/Xcode/scripts/mkrelease.rb
@@ -22,15 +22,21 @@ end
 
 # open ProductInfo.h in read-only mode
 File.open("#{Dir.pwd}/ProductInfo.h", "r") do |f|
-	# read each line, matching for product family and version
+	# read each line, matching for product family
 	f.each do |line|
 		if line.match( /^#define\s+PRODUCT_FAMILY_BARE\s+(.*?)\s*$/ )
-			family = $1;
-		
-		elsif line.match( /^#define\s+PRODUCT_VER_BARE\s+(.*?)\s*$/ )
-			version = $1;
+			family = $1
 		end
-	end	
+	end
+end
+# open ver.h in read-only mode
+File.open("#{Dir.pwd}/ver.h", "r") do |f|
+	# read each line, matching for product version
+	f.each do |line|
+		if line.match( /^#define\s+product_version\s+"(.*?)"/ )
+			version = $1
+		end
+	end
 end
 
 # replace whitespace with hyphens in the version string
@@ -54,12 +60,12 @@ Dir.chdir ".."
 
 # create a temp directory; this will be automatically deleted when the block completes
 Dir.mktmpdir {|temp|
-		
+
 	# nest two directories named by family and version within the temp directory
 	# the outer will become the root of the dmg
 	# the inner will neatly tidy all the contents together so users can easily drag/drop everything at once
 	FileUtils.mkdir_p("#{temp}/#{name}/#{name}/")
-	
+
 	# loop through the directories array
 	directories.each do |directory|
 		# recursively copy each directory into our temp directory


### PR DESCRIPTION
ProductInfo.h used to contain both Family and Version information.  This is no longer the case.

Family (StepMania) is now grabbed out of ProductInfo.h, and
Version (5.0.x) is now grabbed out of ver.h