### PR TITLE
prevent OS X Desktop directory from being created

### DIFF
--- a/src/arch/ArchHooks/ArchHooks_MacOSX.cpp
+++ b/src/arch/ArchHooks/ArchHooks_MacOSX.cpp
@@ -443,8 +443,8 @@ void ArchHooks::MountUserFilesystems( const RString &sDirOfExecutable )
 	FILEMAN->Mount( "dir", ssprintf("%s/Logs/" PRODUCT_ID, dir), "/Logs" );
 
 	// /Desktop -> /Users/<user>/Desktop/PRODUCT_ID
-	PathForFolderType( dir, kDesktopFolderType );
-	FILEMAN->Mount( "dir", ssprintf("%s/" PRODUCT_ID, dir), "/Desktop" );
+	// PathForFolderType( dir, kDesktopFolderType );
+	// FILEMAN->Mount( "dir", ssprintf("%s/" PRODUCT_ID, dir), "/Desktop" );
 }
 
 static inline int GetIntValue( CFTypeRef r )


### PR DESCRIPTION
As of commit dd0896d3eb89dfec7fca77fe6688400fd31078b6, a "StepMania 5" directory is searched for at ~/Desktop and created if one is not found.  It doesn't seem that directory is ever used in any way, however, causing confusion and annoyance for OS X users.

See: http://www.stepmania.com/forums/general-questions/show/1893