### PR TITLE
changed dead link in manual

### DIFF
--- a/Manual/index.html
+++ b/Manual/index.html
@@ -89,7 +89,7 @@ in Applications/, then put StepMania 5 in there, and make folders as needed. Tha
 probably isn't the best way to do it, but it is <strong><em>A</em></strong> way.</p>
 
 <h4>Linux</h4>
-<p>Linux users are typically expected to build from source. See <a href="http://code.google.com/p/sm-ssc/wiki/Compiling">Compiling</a>
+<p>Linux users are typically expected to build from source. See <a href="http://beta.stepmania.com/wiki/compiling-stepmania/">Compiling</a>
 on the StepMania wiki for more information.</p>
 <hr/>
 

--- a/Manual/index.html
+++ b/Manual/index.html
@@ -89,7 +89,7 @@ in Applications/, then put StepMania 5 in there, and make folders as needed. Tha
 probably isn't the best way to do it, but it is <strong><em>A</em></strong> way.</p>
 
 <h4>Linux</h4>
-<p>Linux users are typically expected to build from source. See <a href="http://beta.stepmania.com/wiki/compiling-stepmania/">Compiling</a>
+<p>Linux users are typically expected to build from source. See <a href="http://stepmania.com/wiki/compiling-stepmania/">Compiling</a>
 on the StepMania wiki for more information.</p>
 <hr/>
 


### PR DESCRIPTION
The link to compiling stepmania in the manual index went to a dead google page. Replaced it with a link to compiling stepmania in the wiki.