### PR TITLE
Per-chart music files.

### DIFF
--- a/Themes/_fallback/Languages/en.ini
+++ b/Themes/_fallback/Languages/en.ini
@@ -1115,6 +1115,7 @@ Modify Attacks at current beat=Modify attacks at current beat
 MoveRandomToEnd=Random At&nbsp;End
 More Options=More Options
 MovieColorDepth=Movie Color
+Music File=Music File
 MusicWheelSwitchSpeed=Wheel Speed
 MusicWheelUsesSections=Wheel Sections
 Network Options=Network Options
@@ -1512,6 +1513,7 @@ Enter a new preview start.=Enter when the music sample starts.
 Enter a new preview length.=Enter how long the music sample lasts.
 Enter a new min BPM.=Enter the minimum displayed BPM.
 Enter a new max BPM.=Enter the maximum displayed BPM.
+Enter the music file for this chart.=Enter the music file for this chart.  Leave blank to use the song music.
 Enter the new track mapping.=Enter the new track mapping.
 Entry %d, '%d', is out of range 1 to %d.=Entry %d, '%d', is out of range 1 to %d.
 More than %d notes per measure is not allowed.  This change has been reverted.=More than %d notes per measure is not allowed.  This change has been reverted.
@@ -1997,6 +1999,7 @@ The name you chose conflicts with another edit. Please use a different name.=The
 The chart name cannot contain any of the following characters: %s=The chart name cannot contain any of the following characters: %s
 The edit name cannot contain any of the following characters: %s=The edit name can not contain any of the following characters: %s
 The step author's name cannot contain any of the following characters: %s=The step author's name cannot contain any of the following characters: %s
+The music file '%s' does not exist.=The music file '%s' does not exist.
 
 [SongSort]
 FewestPlays=Fewest Plays

--- a/src/AutoKeysounds.cpp
+++ b/src/AutoKeysounds.cpp
@@ -127,7 +127,7 @@ void AutoKeysounds::LoadTracks( const Song *pSong, RageSoundReader *&pShared, Ra
 	pShared = NULL;
 
 	vector<RString> vsMusicFile;
-	const RString sMusicPath = pSong->GetMusicPath();
+	const RString sMusicPath = GAMESTATE->m_pCurSteps[GAMESTATE->GetMasterPlayerNumber()]->GetMusicPath();
 
 	if( !sMusicPath.empty() )
 		vsMusicFile.push_back( sMusicPath );

--- a/src/GameState.h
+++ b/src/GameState.h
@@ -76,6 +76,7 @@ public:
 	bool CanSafelyEnterGameplay(RString& reason);
 	void SetCompatibleStylesForPlayers();
 	void ForceSharedSidesMatch();
+	void ForceOtherPlayersToCompatibleSteps(PlayerNumber main);
 
 	void Update( float fDelta );
 

--- a/src/NotesLoaderSSC.cpp
+++ b/src/NotesLoaderSSC.cpp
@@ -722,6 +722,11 @@ bool SSCLoader::LoadFromSimfile( const RString &sPath, Song &out, bool bFromCach
 					pNewNotes->SetFilename(sPath);
 					out.AddSteps( pNewNotes );
 				}
+
+				else if(sValueName == "MUSIC")
+				{
+					pNewNotes->SetMusicFile(sParams[1]);
+				}
 				
 				else if( sValueName=="BPMS" )
 				{

--- a/src/NotesWriterSSC.cpp
+++ b/src/NotesWriterSSC.cpp
@@ -358,6 +358,12 @@ static RString GetSSCNoteData( const Song &song, const Steps &in, bool bSavingCa
 	lines.push_back( ssprintf( "#DIFFICULTY:%s;", DifficultyToString(in.GetDifficulty()).c_str() ) );
 	lines.push_back( ssprintf( "#METER:%d;", in.GetMeter() ) );
 
+	const RString& music= in.GetMusicFile();
+	if(!music.empty())
+	{
+		lines.push_back(ssprintf("#MUSIC:%s;", music.c_str()));
+	}
+
 	vector<RString> asRadarValues;
 	FOREACH_PlayerNumber( pn )
 	{

--- a/src/ScreenEdit.cpp
+++ b/src/ScreenEdit.cpp
@@ -105,6 +105,7 @@ AutoScreenMessage( SM_BackFromSpeedWaitChange );
 AutoScreenMessage( SM_BackFromSpeedModeChange );
 AutoScreenMessage( SM_BackFromScrollChange );
 AutoScreenMessage( SM_BackFromFakeChange );
+AutoScreenMessage( SM_BackFromStepMusicChange );
 AutoScreenMessage( SM_DoEraseStepTiming );
 AutoScreenMessage( SM_DoSaveAndExit );
 AutoScreenMessage( SM_DoExit );
@@ -914,7 +915,9 @@ static MenuDef g_StepsInformation(
 		true, EditMode_Full, true, true, 0, NULL ),
     MenuRowDef(ScreenEdit::step_max_bpm,
 		"Max BPM",
-		true, EditMode_Full, true, true, 0, NULL )
+		true, EditMode_Full, true, true, 0, NULL ),
+	MenuRowDef(ScreenEdit::step_music,
+		"Music File", true, EditMode_Full,true, true, 0, NULL)
 );
 
 static MenuDef g_StepsData(
@@ -2339,6 +2342,9 @@ bool ScreenEdit::InputEdit( const InputEventPlus &input, EditButton EditB )
 				int(vSteps.size()) );
 			SCREENMAN->SystemMessage( s );
 			m_soundSwitchSteps.Play();
+			// Reload the music because it can be different for every steps. -Kyz
+			m_AutoKeysounds.FinishLoading();
+			m_pSoundMusic = m_AutoKeysounds.GetSound();
 			
 			ScrollTo( GetAppropriateTiming().GetBeatFromElapsedTime(curSecond) );
 		}
@@ -3659,7 +3665,12 @@ void ScreenEdit::HandleScreenMessage( const ScreenMessage SM )
 			SetDirty( true );
 		}
 	}
-	
+	else if ( SM == SM_BackFromStepMusicChange && !ScreenTextEntry::s_bCancelledLast )
+	{
+		// Reload the music because it just changed. -Kyz
+		m_AutoKeysounds.FinishLoading();
+		m_pSoundMusic = m_AutoKeysounds.GetSound();
+	}
 	else if( SM == SM_BackFromBGChange )
 	{
 		HandleBGChangeChoice( (BGChangeChoice)ScreenMiniMenu::s_iLastRowCode, ScreenMiniMenu::s_viLastAnswers );
@@ -4288,6 +4299,12 @@ static void ChangeStepMeter( const RString &sNew )
 	GAMESTATE->m_pCurSteps[PLAYER_1]->SetMeter(max(diff, 1));
 }
 
+static void ChangeStepMusic(const RString& sNew)
+{
+	Steps* pSteps = GAMESTATE->m_pCurSteps[PLAYER_1];
+	pSteps->SetMusicFile(sNew);
+}
+
 static void ChangeMainTitle( const RString &sNew )
 {
 	Song* pSong = GAMESTATE->m_pCurSong;
@@ -4571,6 +4588,8 @@ void ScreenEdit::HandleMainMenuChoice( MainMenuChoice c, const vector<int> &iAns
 				g_StepsInformation.rows[step_display_bpm].iDefaultChoice = pSteps->GetDisplayBPM();
 				g_StepsInformation.rows[step_min_bpm].SetOneUnthemedChoice( FloatToString(pSteps->GetMinBPM()));
 				g_StepsInformation.rows[step_max_bpm].SetOneUnthemedChoice( FloatToString(pSteps->GetMaxBPM()));
+				g_StepsInformation.rows[step_music].bEnabled = (EDIT_MODE.GetValue() >= EditMode_Full);
+				g_StepsInformation.rows[step_music].SetOneUnthemedChoice( pSteps->GetMusicFile() );
 				EditMiniMenu( &g_StepsInformation, SM_BackFromStepsInformation, SM_None );
 			}
 			break;
@@ -5328,6 +5347,7 @@ static LocalizedString ENTER_NEW_STEP_AUTHOR( "ScreenEdit", "Enter the author wh
 static LocalizedString ENTER_NEW_METER( "ScreenEdit", "Enter a new meter." );
 static LocalizedString ENTER_MIN_BPM			("ScreenEdit","Enter a new min BPM.");
 static LocalizedString ENTER_MAX_BPM			("ScreenEdit","Enter a new max BPM.");
+static LocalizedString ENTER_NEW_STEP_MUSIC("ScreenEdit", "Enter the music file for this chart.");
 void ScreenEdit::HandleStepsInformationChoice( StepsInformationChoice c, const vector<int> &iAnswers )
 {
 	Steps* pSteps = GAMESTATE->m_pCurSteps[PLAYER_1];
@@ -5406,6 +5426,17 @@ void ScreenEdit::HandleStepsInformationChoice( StepsInformationChoice c, const v
 									   FloatToString(pSteps->GetMaxBPM()), 20,
 									   ScreenTextEntry::FloatValidate,
 									   ChangeStepsMaxBPM, NULL);
+			break;
+		}
+		case step_music:
+		{
+			ScreenTextEntry::TextEntry(SM_BackFromStepMusicChange,
+									   ENTER_NEW_STEP_MUSIC,
+									   m_pSteps->GetMusicFile(),
+									   255,
+									   SongUtil::ValidateCurrentStepsMusic,
+									   ChangeStepMusic,
+									   NULL);
 			break;
 		}
 	default:

--- a/src/ScreenEdit.h
+++ b/src/ScreenEdit.h
@@ -537,6 +537,7 @@ public:
 		step_display_bpm,
 		step_min_bpm,
 		step_max_bpm,
+		step_music,
 		NUM_STEPS_INFORMATION_CHOICES
 	};
 	void HandleStepsInformationChoice( StepsInformationChoice c, const vector<int> &iAnswers );

--- a/src/ScreenSelectMusic.cpp
+++ b/src/ScreenSelectMusic.cpp
@@ -1039,6 +1039,7 @@ void ScreenSelectMusic::ChangeSteps( PlayerNumber pn, int dir )
 		m_soundDifficultyHarder.SetProperty( "Pan", fBalance );
 		m_soundDifficultyHarder.PlayCopy();
 	}
+	GAMESTATE->ForceOtherPlayersToCompatibleSteps(pn);
 
 	Message msg( "ChangeSteps" );
 	msg.SetParam( "Player", pn );

--- a/src/Song.cpp
+++ b/src/Song.cpp
@@ -1394,7 +1394,7 @@ vector<RString> Song::GetInstrumentTracksToVectorString() const
 	return ret;
 }
 
-RString GetSongAssetPath( RString sPath, const RString &sSongPath )
+RString Song::GetSongAssetPath( RString sPath, const RString &sSongPath )
 {
 	if( sPath == "" )
 		return RString();

--- a/src/Song.cpp
+++ b/src/Song.cpp
@@ -43,7 +43,7 @@
  * @brief The internal version of the cache for StepMania.
  *
  * Increment this value to invalidate the current cache. */
-const int FILE_CACHE_VERSION = 222;
+const int FILE_CACHE_VERSION = 223;
 
 /** @brief How long does a song sample last by default? */
 const float DEFAULT_MUSIC_SAMPLE_LENGTH = 12.f;

--- a/src/Song.h
+++ b/src/Song.h
@@ -247,6 +247,7 @@ public:
 	AttackArray m_Attacks;
 	vector<RString>	m_sAttackString;
 
+	static RString GetSongAssetPath( RString sPath, const RString &sSongPath );
 	RString GetMusicPath() const;
 	RString GetInstrumentTrackPath( InstrumentTrack it ) const;
 	RString GetBannerPath() const;

--- a/src/SongUtil.cpp
+++ b/src/SongUtil.cpp
@@ -899,6 +899,24 @@ bool SongUtil::ValidateCurrentStepsCredit( const RString &sAnswer, RString &sErr
 	return true;
 }
 
+static LocalizedString MUSIC_DOES_NOT_EXIST("SongUtil", "The music file '%s' does not exist.");
+bool SongUtil::ValidateCurrentStepsMusic(const RString &answer, RString &error)
+{
+	if(answer.empty())
+		return true;
+	Steps *pSteps = GAMESTATE->m_pCurSteps[PLAYER_1];
+	RString real_file= pSteps->GetMusicFile();
+	pSteps->SetMusicFile(answer);
+	RString path= pSteps->GetMusicPath();
+	bool valid= DoesFileExist(path);
+	pSteps->SetMusicFile(real_file);
+	if(!valid)
+	{
+		error= ssprintf(MUSIC_DOES_NOT_EXIST.GetValue(), answer.c_str());
+	}
+	return valid;
+}
+
 void SongUtil::GetAllSongGenres( vector<RString> &vsOut )
 {
 	set<RString> genres;

--- a/src/SongUtil.h
+++ b/src/SongUtil.h
@@ -165,6 +165,7 @@ namespace SongUtil
 	bool ValidateCurrentStepsDescription( const RString &sAnswer, RString &sErrorOut );
 	bool ValidateCurrentStepsCredit( const RString &sAnswer, RString &sErrorOut );
 	bool ValidateCurrentStepsChartName(const RString &answer, RString &error);
+	bool ValidateCurrentStepsMusic(const RString &answer, RString &error);
 
 	void GetAllSongGenres( vector<RString> &vsOut );
 	/**

--- a/src/Steps.cpp
+++ b/src/Steps.cpp
@@ -589,6 +589,23 @@ bool Steps::HasSignificantTimingChanges() const
 	return false;
 }
 
+const RString Steps::GetMusicPath() const
+{
+	return Song::GetSongAssetPath(
+		m_MusicFile.empty() ? m_pSong->m_sMusicFile : m_MusicFile,
+		m_pSong->GetSongDir());
+}
+
+const RString& Steps::GetMusicFile() const
+{
+	return m_MusicFile;
+}
+
+void Steps::SetMusicFile(const RString& file)
+{
+	m_MusicFile= file;
+}
+
 void Steps::SetCachedRadarValues( const RadarValues v[NUM_PLAYERS] )
 {
 	DeAutogen();

--- a/src/Steps.h
+++ b/src/Steps.h
@@ -173,6 +173,10 @@ public:
 	 * @return true if it does, or false otherwise. */
 	bool HasAttacks() const;
 
+	const RString GetMusicPath() const; // Returns the path for loading.
+	const RString& GetMusicFile() const; // Returns the filename for the simfile.
+	void SetMusicFile(const RString& file);
+
 	// Lua
 	void PushSelf( lua_State *L );
 
@@ -218,7 +222,9 @@ private:
 	/** @brief The name of the file where these steps are stored. */
 	RString				m_sFilename;
 	/** @brief true if these Steps were loaded from or saved to disk. */
-	bool				m_bSavedToDisk;	
+	bool				m_bSavedToDisk;
+	/** @brief allows the steps to specify their own music file. */
+	RString m_MusicFile;
 	/** @brief What profile was used? This is ProfileSlot_Invalid if not from a profile. */
 	ProfileSlot			m_LoadedFromProfile;
 


### PR DESCRIPTION
This adds a tag to the note data section of the ssc file that can be set to make that chart load a different music file.
GameState::ForceOtherPlayersToCompatibleSteps() is called whenever ScreenSelectMusic changes the steps for a player to ensure that all players are on steps that use the same music file.  That function also checks the styletype, so it should resolve the disagreeing steps problem in #30 by not allowing the steps to ever disagree.  So if per-chart music is rejected by other devs, I'll put GameState::ForceOtherPlayersToCompatibleSteps() in its own pull request.