### PR TITLE
X11 fullscreen revamp

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,24 +9,25 @@ notifications:
     irc: "chat.freenode.net#stepmania-devs"
 
 before_script:
-    - sudo apt-get install nasm
-    - sudo apt-get install libmad0-dev
-    - sudo apt-get install libgtk2.0-dev
-    - sudo apt-get install binutils-dev
-    - sudo apt-get install libasound-dev
-    - sudo apt-get install libpulse-dev
-    - sudo apt-get install libjack-dev
-    - sudo apt-get install libc6-dev
-    - sudo apt-get install libogg-dev
-    - sudo apt-get install libvorbis-dev
-    - sudo apt-get install libbz2-dev
-    - sudo apt-get install zlib1g-dev
-    - sudo apt-get install libjpeg8-dev
-    - sudo apt-get install libpng12-dev
-    - sudo apt-get install libxtst-dev libxxf86vm-dev
-    - sudo apt-get install libglu1-mesa-dev
-    - sudo apt-get install mesa-common-dev
-    - sudo apt-get install libglew-dev
+    - sudo apt-get update -qq
+    - sudo apt-get install -y nasm
+    - sudo apt-get install -y libmad0-dev
+    - sudo apt-get install -y libgtk2.0-dev
+    - sudo apt-get install -y binutils-dev
+    - sudo apt-get install -y libasound-dev
+    - sudo apt-get install -y libpulse-dev
+    - sudo apt-get install -y libjack-dev
+    - sudo apt-get install -y libc6-dev
+    - sudo apt-get install -y libogg-dev
+    - sudo apt-get install -y libvorbis-dev
+    - sudo apt-get install -y libbz2-dev
+    - sudo apt-get install -y zlib1g-dev
+    - sudo apt-get install -y libjpeg8-dev
+    - sudo apt-get install -y libpng12-dev
+    - sudo apt-get install -y libxtst-dev libxxf86vm-dev
+    - sudo apt-get install -y libglu1-mesa-dev
+    - sudo apt-get install -y mesa-common-dev
+    - sudo apt-get install -y libglew-dev
 
 script:
     - ./autogen.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_script:
     - sudo apt-get install zlib1g-dev
     - sudo apt-get install libjpeg8-dev
     - sudo apt-get install libpng12-dev
-    - sudo apt-get install libxtst-dev libxrandr-dev
+    - sudo apt-get install libxtst-dev libxxf86vm-dev
     - sudo apt-get install libglu1-mesa-dev
     - sudo apt-get install mesa-common-dev
     - sudo apt-get install libglew-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_script:
     - sudo apt-get install -y zlib1g-dev
     - sudo apt-get install -y libjpeg8-dev
     - sudo apt-get install -y libpng12-dev
-    - sudo apt-get install -y libxtst-dev libxxf86vm-dev
+    - sudo apt-get install -y libxtst-dev libxrandr-dev libxxf86vm-dev
     - sudo apt-get install -y libglu1-mesa-dev
     - sudo apt-get install -y mesa-common-dev
     - sudo apt-get install -y libglew-dev

--- a/autoconf/m4/x11.m4
+++ b/autoconf/m4/x11.m4
@@ -32,14 +32,12 @@ AC_DEFUN([SM_X11],
 	AC_DEFINE(HAVE_X11, 1, [X11 libraries present])
 	fi
 
-	# Check for Xrandr
-	# Can someone fix this for me? This is producing bizarre warnings from
-	# configure... I have no clue what I'm doing -Ben
-	AC_CHECK_LIB(Xrandr, XRRSizes,
+	# Check for Xxf86vm
+	AC_CHECK_LIB(Xxf86vm, XF86VidModeSwitchToMode,
 		have_xrandr=yes,
 		have_xrandr=no,
 		[$XLIBS])
-	AC_CHECK_HEADER(X11/extensions/Xrandr.h, have_xrandr_header=yes, have_xrandr_header=no, [#include <X11/Xlib.h>])
+	AC_CHECK_HEADER(X11/extensions/xf86vmode.h, have_xrandr_header=yes, have_xrandr_header=no, [#include <X11/Xlib.h>])
 
 	if test "$have_xrandr_header" = "no"; then
 		have_xrandr=no

--- a/autoconf/m4/x11.m4
+++ b/autoconf/m4/x11.m4
@@ -34,23 +34,23 @@ AC_DEFUN([SM_X11],
 
 	# Check for Xxf86vm
 	AC_CHECK_LIB(Xxf86vm, XF86VidModeSwitchToMode,
-		have_xrandr=yes,
-		have_xrandr=no,
+		have_xf86vm=yes,
+		have_xf86vm=no,
 		[$XLIBS])
-	AC_CHECK_HEADER(X11/extensions/xf86vmode.h, have_xrandr_header=yes, have_xrandr_header=no, [#include <X11/Xlib.h>])
+	AC_CHECK_HEADER(X11/extensions/xf86vmode.h, have_xf86vm_header=yes, have_xf86vm_header=no, [#include <X11/Xlib.h>])
 
-	if test "$have_xrandr_header" = "no"; then
-		have_xrandr=no
+	if test "$have_xf86vm_header" = "no"; then
+		have_xf86vm=no
 	fi
 
-	if test "$have_xrandr" = "no"; then
+	if test "$have_xf86vm" = "no"; then
 		if test "$unix" = "yes"; then
 			AC_MSG_ERROR("Couldn't find X11 libraries.")
 		else
 			no_x=yes
 		fi
 	else
-		XLIBS="$XLIBS -lXrandr"
+		XLIBS="$XLIBS -lXxf86vm"
 	fi
 
 	AM_CONDITIONAL(HAVE_X11, test "$no_x" != "yes")

--- a/src/RageDisplay_OGL.cpp
+++ b/src/RageDisplay_OGL.cpp
@@ -685,7 +685,9 @@ void SetupExtensions()
 	const float fGLUVersion = StringToFloat( (const char *) gluGetString(GLU_VERSION) );
 	g_gluVersion = lrintf( fGLUVersion * 10 );
 
+#ifndef HAVE_X11 // LLW_X11 needs to init GLEW early for GLX exts
 	glewInit();
+#endif
 	
 	g_iMaxTextureUnits = 1;
 	if (GLEW_ARB_multitexture)

--- a/src/arch/LowLevelWindow/LowLevelWindow_X11.cpp
+++ b/src/arch/LowLevelWindow/LowLevelWindow_X11.cpp
@@ -14,7 +14,7 @@ using namespace X11Helper;
 
 #include <stack>
 #include <math.h>	// ceil()
-#include <GL/glew.h>
+#include <GL/glxew.h>
 #define GLX_GLXEXT_PROTOTYPES
 #include <GL/glx.h>	// All sorts of stuff...
 #include <X11/Xlib.h>

--- a/src/arch/LowLevelWindow/LowLevelWindow_X11.cpp
+++ b/src/arch/LowLevelWindow/LowLevelWindow_X11.cpp
@@ -18,7 +18,11 @@ using namespace X11Helper;
 #include <GL/glx.h>	// All sorts of stuff...
 #include <X11/Xlib.h>
 #include <X11/Xatom.h>
+// !!DANGER!! We are using preprocessor macros to modify structure definitions
+// of interfaces that are not ours! Because fuck C++, right?
+#define private private_
 #include <X11/extensions/xf86vmode.h>
+#endif
 
 #if defined(HAVE_LIBXTST)
 #include <X11/extensions/XTest.h>
@@ -54,7 +58,7 @@ LowLevelWindow_X11::~LowLevelWindow_X11()
 	// Reset the display
 	if( !m_bWasWindowed )
 	{
-		XF86VidModeSwitchToMode( Dpy, DefaultScreen( Dpy ), g_originalMode );
+		XF86VidModeSwitchToMode( Dpy, DefaultScreen( Dpy ), &g_originalMode );
 
 		XUngrabKeyboard( Dpy, CurrentTime );
 	}
@@ -69,8 +73,7 @@ LowLevelWindow_X11::~LowLevelWindow_X11()
 		g_pBackgroundContext = NULL;
 	}
 
-	extern "C" { // Why the fuck is it called "private" when C++ exists?
-		if( g_originalMode.privsize > 0 ) XFree( g_originalMode.private );
+		if( g_originalMode.privsize > 0 ) XFree( g_originalMode.private_ );
 	}
 
 	XDestroyWindow( Dpy, Win );
@@ -184,9 +187,7 @@ RString LowLevelWindow_X11::TryVideoMode( const VideoModeParams &p, bool &bNewDe
 	{
 		if( m_bWasWindowed )
 		{
-			extern "C" { // Why the fuck is it called "private" when C++ exists?
-				if( g_originalMode.privsize > 0 ) XFree( g_originalMode.private );
-			}
+			if( g_originalMode.privsize > 0 ) XFree( g_originalMode.private_ );
 
 			// If the user changed the resolution while StepMania was windowed we overwrite the resolution to restore with it at exit.
 			// XXX: I don't know what this returns, or whether it *can* fail.
@@ -214,9 +215,7 @@ RString LowLevelWindow_X11::TryVideoMode( const VideoModeParams &p, bool &bNewDe
 			g_originalMode.vtotal = tempMode.vtotal;
 			g_originalMode.flags = tempMode.flags;
 			g_originalMode.privsize = tempMode.privsize;
-			extern "C" { // Why the fuck is it called "private" when C++ exists?
-				g_originalMode.private = tempMode.private;
-			}
+			g_originalMode.private_ = tempMode.private_;
 			
 			m_bWasWindowed = false;
 		}
@@ -256,9 +255,7 @@ RString LowLevelWindow_X11::TryVideoMode( const VideoModeParams &p, bool &bNewDe
 		rate = (int) aModes[i].dotclock / ( (float) aModes[i].htotal * aModes[i].vtotal );
 
 		for( int i = 0; i < iNumModes; ++i )
-			extern "C" { // Why the fuck is it called "private" when C++ exists?
-				if( aModes[i].privsize > 0 ) XFree( aModes[i].private );
-			}
+			if( aModes[i].privsize > 0 ) XFree( aModes[i].private_ );
 
 		XFree( aModes );
 
@@ -402,9 +399,7 @@ void LowLevelWindow_X11::GetDisplayResolutions( DisplayResolutions &out ) const
 		DisplayResolution res = { aModes[i].hdisplay, aModes[i].vdisplay, true };
 		out.insert( res );
 
-		extern "C" { // Why the fuck is it called "private" when C++ exists?
-			if( aModes[i].privsize > 0 ) XFree( aModes.private );
-		}
+		if( aModes[i].privsize > 0 ) XFree( aModes.private_ );
 	}
 
 	XFree( aModes );

--- a/src/arch/LowLevelWindow/LowLevelWindow_X11.cpp
+++ b/src/arch/LowLevelWindow/LowLevelWindow_X11.cpp
@@ -102,6 +102,7 @@ RString LowLevelWindow_X11::TryVideoMode( const VideoModeParams &p, bool &bNewDe
 {
 	if( g_pContext == NULL || p.bpp != CurrentParams.bpp || m_bWasWindowed != p.windowed )
 	{
+		bool bFirstRun = g_pContext == NULL;
 		// Different depth, or we didn't make a window before. New context.
 		bNewDeviceOut = true;
 
@@ -170,6 +171,9 @@ RString LowLevelWindow_X11::TryVideoMode( const VideoModeParams &p, bool &bNewDe
 
 		// Set the event mask back to what it was
 		XSelectInput( Dpy, Win, winAttrib.your_event_mask );
+
+		GLenum err = glewInit();
+		ASSERT( err == GLEW_OK );
 	}
 	else
 	{
@@ -352,6 +356,12 @@ RString LowLevelWindow_X11::TryVideoMode( const VideoModeParams &p, bool &bNewDe
 	// Set our V-sync hint.
 	if(GLXEW_EXT_swap_control)
 		glXSwapIntervalEXT( Dpy, Win, CurrentParams.vsync ? 1 : 0 );
+	// XXX: These two might be server-global. I should look into whether
+	// to try to preserve the original value on exit.
+	else if(GLXEW_MESA_swap_control)
+		glXSwapIntervalMESA( CurrentParams.vsync ? 1 : 0 );
+	else if(GLXEW_SGI_swap_control) // DRI Intel needs this
+		glXSwapIntervalSGI( CurrentParams.vsync ? 1 : 0 );
 	else
 		CurrentParams.vsync = false; // Assuming it's not on
 

--- a/src/arch/LowLevelWindow/LowLevelWindow_X11.cpp
+++ b/src/arch/LowLevelWindow/LowLevelWindow_X11.cpp
@@ -172,8 +172,13 @@ RString LowLevelWindow_X11::TryVideoMode( const VideoModeParams &p, bool &bNewDe
 		// Set the event mask back to what it was
 		XSelectInput( Dpy, Win, winAttrib.your_event_mask );
 
-		GLenum err = glewInit();
-		ASSERT( err == GLEW_OK );
+		// I can't find official docs saying what happens if you re-init GLEW.
+		// I'll just assume the behavior is undefined.
+		if(bFirstRun)
+		{
+			GLenum err = glewInit();
+			ASSERT( err == GLEW_OK );
+		}
 	}
 	else
 	{

--- a/src/arch/LowLevelWindow/LowLevelWindow_X11.cpp
+++ b/src/arch/LowLevelWindow/LowLevelWindow_X11.cpp
@@ -18,6 +18,7 @@ using namespace X11Helper;
 #include <GL/glx.h>	// All sorts of stuff...
 #include <X11/Xlib.h>
 #include <X11/Xatom.h>
+#include <X11/extensions/xf86vmode.h>
 
 #if defined(HAVE_LIBXTST)
 #include <X11/extensions/XTest.h>

--- a/src/arch/LowLevelWindow/LowLevelWindow_X11.cpp
+++ b/src/arch/LowLevelWindow/LowLevelWindow_X11.cpp
@@ -363,8 +363,10 @@ RString LowLevelWindow_X11::TryVideoMode( const VideoModeParams &p, bool &bNewDe
 		glXSwapIntervalEXT( Dpy, Win, CurrentParams.vsync ? 1 : 0 );
 	// XXX: These two might be server-global. I should look into whether
 	// to try to preserve the original value on exit.
+#ifdef GLXEW_MESA_swap_control // Added in 1.7. 1.6 is still common out there apparently.
 	else if(GLXEW_MESA_swap_control)
 		glXSwapIntervalMESA( CurrentParams.vsync ? 1 : 0 );
+#endif
 	else if(GLXEW_SGI_swap_control) // DRI Intel needs this
 		glXSwapIntervalSGI( CurrentParams.vsync ? 1 : 0 );
 	else

--- a/src/arch/LowLevelWindow/LowLevelWindow_X11.cpp
+++ b/src/arch/LowLevelWindow/LowLevelWindow_X11.cpp
@@ -68,10 +68,10 @@ LowLevelWindow_X11::~LowLevelWindow_X11()
 		glXDestroyContext( Dpy, g_pBackgroundContext );
 		g_pBackgroundContext = NULL;
 	}
-		// We're supposed to XFree() the private bits of XF86VidModeModeInfo
-		// structs. This isn't actually possible from C++. At all. Period.
-		// Let it leak.
-	}
+	// We're supposed to XFree() the private bits of XF86VidModeModeInfo
+	// structs. This isn't actually possible from C++. At all. Period.
+	// Let it leak.
+
 
 	XDestroyWindow( Dpy, Win );
 	Win = None;
@@ -223,9 +223,10 @@ RString LowLevelWindow_X11::TryVideoMode( const VideoModeParams &p, bool &bNewDe
 
 		// Find a matching mode.
 		int iNumModes;
-		XF86VidModeModeInfo aModes[];
-		XF86VidModeGetAllModeLines( Dpy, DefaultScreen(Dpy), &iNumModes, &aModes );
+		XF86VidModeModeInfo **aModes_;
+		XF86VidModeGetAllModeLines( Dpy, DefaultScreen(Dpy), &iNumModes, &aModes_ );
 		ASSERT_M( iNumModes > 0, "Couldn't get resolution list from X server" );
+		XF86VidModeModeInfo *aModes = *aModes_;
 
 		int iSizeMatch = -1;
 		float fRefreshCloseness;
@@ -253,7 +254,7 @@ RString LowLevelWindow_X11::TryVideoMode( const VideoModeParams &p, bool &bNewDe
 		// XXX How do we detect failure?
 		XF86VidModeSwitchToMode( Dpy, DefaultScreen(Dpy), &( aModes[iSizeMatch] ) );
 
-		rate = (int) aModes[i].dotclock / ( (float) aModes[i].htotal * aModes[i].vtotal );
+		rate = (int) aModes[iSizeMatch].dotclock / ( (float) aModes[iSizeMatch].htotal * aModes[iSizeMatch].vtotal );
 
 		// We're supposed to XFree() the private bits of XF86VidModeModeInfo
 		// structs. This isn't actually possible from C++. At all. Period.
@@ -279,7 +280,7 @@ RString LowLevelWindow_X11::TryVideoMode( const VideoModeParams &p, bool &bNewDe
 			m_bWasWindowed = true;
 
 			// Read the desktop refresh rate, because why not
-			rate = (int) g_originalMode[i].dotclock / ( (float) g_originalMode[i].htotal * g_originalMode[i].vtotal );
+			rate = (int) g_originalMode.dotclock / ( (float) g_originalMode.htotal * g_originalMode.vtotal );
 
 		}
 		// XXX: How important is windowed refresh rate to us? We could query it
@@ -391,9 +392,10 @@ void LowLevelWindow_X11::SwapBuffers()
 void LowLevelWindow_X11::GetDisplayResolutions( DisplayResolutions &out ) const
 {
 	int iNumModes = 0;
-	XF86VidModeInfo aModes[];
-	XF86VidModeGetAllModeLines( Dpy, DefaultScreen( Dpy ), &iNumModes, &aModes );
+	XF86VidModeModeInfo **aModes_;
+	XF86VidModeGetAllModeLines( Dpy, DefaultScreen( Dpy ), &iNumModes, &aModes_ );
 	ASSERT_M( iNumModes != 0, "Couldn't get resolution list from X server" );
+	XF86VidModeModeInfo *aModes = *aModes_;
 
 	for( int i = 0; i < iNumModes; ++i )
 	{

--- a/src/arch/LowLevelWindow/LowLevelWindow_X11.cpp
+++ b/src/arch/LowLevelWindow/LowLevelWindow_X11.cpp
@@ -96,6 +96,9 @@ LowLevelWindow_X11::~LowLevelWindow_X11()
 			XRRScreenResources *res = XRRGetScreenResources(Dpy, Win);
 			XRRCrtcInfo *conf = XRRGetCrtcInfo(Dpy, res, g_usedCrtc);
 			XRRSetCrtcConfig(Dpy, res, g_usedCrtc, conf->timestamp, conf->x, conf->y, g_originalRandRMode, conf->rotation, conf->outputs, conf->noutput);
+
+			XRRFreeScreenResources(res);
+			XRRFreeCrtcInfo(conf);
 		}
 		else
 #ifndef HAVE_XF86VIDMODE
@@ -338,6 +341,11 @@ RString LowLevelWindow_X11::TryVideoMode( const VideoModeParams &p, bool &bNewDe
 			// We don't move to absolute 0,0 because that may be in the area of a different output.
 			// Instead we preserved the corner of our CRTC; go to that.
 			XMoveWindow(Dpy, Win, oldConf->x, oldConf->y);
+
+			// Final cleanup
+			XRRFreeScreenResources(scrRes);
+			XRRFreeOutputInfo(outInfo);
+			XRRFreeCrtcInfo(oldConf);
 		}
 		else
 #ifndef HAVE_XF86VIDMODE
@@ -448,6 +456,9 @@ RString LowLevelWindow_X11::TryVideoMode( const VideoModeParams &p, bool &bNewDe
 				XRRScreenResources *res = XRRGetScreenResources(Dpy, Win);
 				XRRCrtcInfo *conf = XRRGetCrtcInfo(Dpy, res, g_usedCrtc);
 				XRRSetCrtcConfig(Dpy, res, g_usedCrtc, conf->timestamp, conf->x, conf->y, g_originalRandRMode, conf->rotation, conf->outputs, conf->noutput);
+
+				XRRFreeScreenResources(res);
+				XRRFreeCrtcInfo(conf);
 			}
 			else
 #ifndef HAVE_XF86VIDMODE
@@ -614,6 +625,10 @@ void LowLevelWindow_X11::GetDisplayResolutions( DisplayResolutions &out ) const
 				}
 #undef REAL_WIDTH
 #undef REAL_HEIGHT
+
+		XRRFreeScreenResources(scrRes);
+		XRRFreeOutputInfo(outInfo);
+		XRRFreeCrtcInfo(conf);
 	}
 	else
 #ifndef HAVE_XF86VIDMODE

--- a/src/arch/LowLevelWindow/LowLevelWindow_X11.cpp
+++ b/src/arch/LowLevelWindow/LowLevelWindow_X11.cpp
@@ -204,11 +204,10 @@ RString LowLevelWindow_X11::TryVideoMode( const VideoModeParams &p, bool &bNewDe
 
 		// Wait until we actually have a mapped window before trying to
 		// use it!
-		// DANGER! This drops ALL events before the MapNotify. Use XMaskEvent()
 		XEvent event;
 		do
 		{
-			XNextEvent( Dpy, &event );
+			XMaskEvent( Dpy, StructureNotifyMask, &event );
 		} while (event.type != MapNotify);
 
 		// Set the event mask back to what it was

--- a/src/archutils/Win32/SpecialDirs.cpp
+++ b/src/archutils/Win32/SpecialDirs.cpp
@@ -6,8 +6,8 @@ static RString GetSpecialFolderPath( int csidl )
 {
 	RString sDir;
 	TCHAR szDir[MAX_PATH] = "";
-	BOOL bResult = SHGetSpecialFolderPath( NULL, szDir, csidl, FALSE );
-	ASSERT( bResult );
+	HRESULT hResult = SHGetFolderPath( NULL, csidl, NULL, SHGFP_TYPE_CURRENT, szDir );
+	ASSERT( hResult == S_OK );
 	sDir = szDir;
 	sDir += "/";
 	return sDir;


### PR DESCRIPTION
This implements a newer XRandR resolution-changing method, and also a legacy XFree86-VidMode method for X11 servers or drivers that don't implement XRandR 1.2. The latter probably isn't necessary; every impl I've inspected, including very old nvidia blobs that support the GeForce FX series, appear to support at least 1.4. However, it's written, and I gave it a bit of testing, so why not.

Now, in one (common) edge case, this is likely to have undesired side effects; the nvidia binary driver only exposes the native resolution of a laptop's display. [This is a deliberate decision on nvidia's part and will not be changed.](https://devtalk.nvidia.com/default/topic/525287/linux/non-native-resolutions-not-available-in-3xx-drivers-on-8700m-gt/post/3720159/#3720159) This means that we cannot change resolutions on affected systems, and this implementation will only expose the native resolution as a valid resolution, even for windowed mode. (SDL2 appears to be either unaware of or ignoring the problem.) We have a few options:

* Manually add extra resolutions for windowed mode that aren't reported by the platform. This could take the form of only giving those resolutions as an option when the windowed setting is active, or alternately, implementing them in fullscreen by using the next largest resolution supported, and undersampling at the OpenGL level.
* Have LLW_X11 inject fake resolutions, and implement them by going to the next largest real resolution available, and using XRRSetCrtcTransform() to have the X server do the scaling for us. XRandR 1.3 will be required. (For this to work correctly, the fake resolutions must be the same aspect ratio as the native resolution.)
* Check for nvidia blob and whether an LVDS output is present; if so, disable XRandR and use the legacy XFree86 method, regardless of how new the X server or driver is. (This is what WINE does.)