### PR TITLE
Fix OSX key translation crash (#504)

### DIFF
--- a/src/arch/InputHandler/InputHandler_MacOSX_HID.cpp
+++ b/src/arch/InputHandler/InputHandler_MacOSX_HID.cpp
@@ -380,7 +380,7 @@ static wchar_t KeyCodeToChar(CGKeyCode keyCode, unsigned int modifierFlags)
 {
 	TISInputSourceRef currentKeyboard = TISCopyCurrentKeyboardInputSource();
 	CFDataRef uchr = (CFDataRef)TISGetInputSourceProperty(currentKeyboard, kTISPropertyUnicodeKeyLayoutData);
-	const UCKeyboardLayout *keyboardLayout = (const UCKeyboardLayout*)CFDataGetBytePtr(uchr);
+	const UCKeyboardLayout *keyboardLayout = uchr ? (const UCKeyboardLayout*)CFDataGetBytePtr(uchr) : NULL;
 	
 	if( keyboardLayout )
 	{


### PR DESCRIPTION
This should fix #504.

This is slightly different than the patch that serynth verified in that thread. I modified it so that it will still log an error message when translation fails. I excpect this minor change should compile and work just fine, but I was unable to test that as I lack access to a Mac.

