### PR TITLE
'Exit' option in 'select game' menu returns user to main options menu unless the game mode was changed

### DIFF
--- a/Themes/_fallback/metrics.ini
+++ b/Themes/_fallback/metrics.ini
@@ -3122,7 +3122,7 @@ Fallback="ScreenOptionsServiceChild"
 [ScreenSelectGame]
 Fallback="ScreenOptionsServiceChild"
 PrevScreen="ScreenOptionsService"
-NextScreen=Branch.TitleMenu()
+NextScreen="ScreenOptionsService"
 LineNames="1"
 Line1="conf,Game"
 


### PR DESCRIPTION
This fixes some of the inconsistent menu behavior observed in #525. 

Everything is still correctly reloaded in the same way as before when the game mode is changed, but when the mode isn't changed, the 'exit' button behaves the same as the exit button in every other menu by returning the user to parent options menu.