### PR TITLE
Provide initial cpack support. Mainly for devs.

### DIFF
--- a/Build/INSTALL.md
+++ b/Build/INSTALL.md
@@ -2,7 +2,7 @@ Warning
 ==
 Make sure you read README.md first if you have not.
 
-Installing StepMania
+Compiling StepMania
 ==
 To use StepMania on your computer, it is first assumed that cmake is run (see README.md for more information). Then, follow the guide based on your operating system.
 
@@ -17,4 +17,21 @@ Using Xcode, simply build in Xcode and it will place the .app file in the correc
 Linux
 ===
 Using the command line, simply type make and it will place stepmania and GtkModule.so (if requested) in the root StepMania directory. There is no more need to symlink the files.
+
+Installing StepMania
+==
+Installing in this context refers to placing the folders and generated binary in a standard location based on your operating system.
+This guide assumes default install locations. If you want to change the initial location, pass in `-DCMAKE_INSTALL_PREFIX=/new/path/here` when configuring your local setup.
+
+Windows
+===
+The default installation directory is `C:\Program Files (x86)\Stepmania 5`.
+
+Mac OS X
+===
+The `StepMania.app` package can be copied to `/Applications` and it will work as expected.
+
+Linux
+===
+After installing, run `sudo make install`. The files will be placed in the location specified: by default, that is now `/usr/local/stepmania-5.0`.
 

--- a/Build/license_install.txt
+++ b/Build/license_install.txt
@@ -1,0 +1,8 @@
+LICENSE
+=======
+
+StepMania's source code and resulting binary is licensed under the MIT license. Go to http://opensource.org/licenses/MIT for more information.
+
+A few sample songs were provided that can be distributed. They are under the CC-NC (Creative Commons Non-Commercial) license. Go to https://creativecommons.org/ for more information.
+
+The FFMPEG codes (see https://www.ffmpeg.org/ for more) and the MAD library (see http://www.underbit.com/products/mad/ for more) use the GPL license. Go to http://www.gnu.org for more information.

--- a/CMake/CPackSetup.cmake
+++ b/CMake/CPackSetup.cmake
@@ -1,0 +1,27 @@
+set(CPACK_PACKAGE_NAME "${SM_EXE_NAME}")
+set(CPACK_PACKAGE_VENDOR "StepMania")
+set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Rhythm Game Simulator")
+set(CPACK_PACKAGE_VERSION_MAJOR "${SM_VERSION_MAJOR}")
+set(CPACK_PACKAGE_VERSION_MINOR "${SM_VERSION_MINOR}")
+set(CPACK_PACKAGE_VERSION_PATCH "${SM_VERSION_PATCH}")
+set(CPACK_PACKAGE_VERSION "${SM_VERSION_TRADITIONAL}")
+set(CPACK_NSIS_HELP_LINK "https://github.com/stepmania/stepmania/issues")
+set(CPACK_NSIS_URL_INFO_ABOUT "http://www.stepmania.com/")
+set(CPACK_RESOURCE_FILE_README "${SM_ROOT_DIR}/README.md")
+set(CPACK_RESOURCE_FILE_LICENSE "${SM_BUILD_DIR}/license_install.txt")
+set(CPACK_PACKAGE_EXECUTABLES
+  "${SM_EXE_NAME}" "StepMania ${SM_VERSION_MAJOR}" 
+)
+
+if(WIN32)
+
+  # By setting these install keys manually,
+  # The default directory of "StepMania major.minor.patch" is lost.
+  # This is currently done to maintain backwards compatibility.
+  # However, removing these two will allow for multiple versions of StepMania
+  # to be installed relatively cleanly.
+  set(CPACK_PACKAGE_INSTALL_DIRECTORY "StepMania ${SM_VERSION_MAJOR}")
+  set(CPACK_PACKAGE_INSTALL_REGISTRY_KEY "StepMania ${SM_VERSION_MAJOR}")
+endif()
+
+include(CPack)

--- a/CMake/DefineOptions.cmake
+++ b/CMake/DefineOptions.cmake
@@ -26,6 +26,7 @@ else()
     option(WITH_FFMPEG "Build with FFMPEG." ON)
     # Builder beware: later versions of ffmpeg may break!
     option(WITH_SYSTEM_FFMPEG "Build with the system's FFMPEG." OFF)
+    option(WITH_LIBVA "Build with libVa support for Video Acceleration." OFF)
     option(WITH_TTY "Build with Linux TTY Input Support." OFF)
     option(WITH_PROFILING "Build with Profiling Support." OFF)
     option(WITH_GLES2 "Build with OpenGL ES 2.0 Support." ON)

--- a/CMake/DefineOptions.cmake
+++ b/CMake/DefineOptions.cmake
@@ -1,0 +1,38 @@
+# Prep options that are needed for each platform.
+option(WITH_NETWORKING "Build with networking support." ON)
+
+# This option quiets warnings that are a part of external projects.
+option(WITH_EXTERNAL_WARNINGS "Build with warnings for all components, not just StepMania." OFF)
+
+# This option is not yet working, but will likely default to ON in the future.
+option(WITH_LTO "Build with Link Time Optimization (LTO)/Whole Program Optimization." OFF)
+
+# This option handles if we use SSE2 processing.
+option(WITH_SSE2 "Build with SSE2 Optimizations." ON)
+
+# This option may go away in the future: if it does, JPEG will always be required.
+option(WITH_JPEG "Build with JPEG Image Support." ON)
+
+# Turn this on to set this to a specific release mode.
+option(WITH_FULL_RELEASE "Build as a proper, full release." OFF)
+
+# Turn this option off to not use the GPL exclusive components.
+option(WITH_GPL_LIBS "Build with GPL libraries." ON)
+
+if(WIN32)
+  option(WITH_MINIMAID "Build with Mimimaid Lights Support." OFF)
+else()
+  if(LINUX)
+    option(WITH_FFMPEG "Build with FFMPEG." ON)
+    # Builder beware: later versions of ffmpeg may break!
+    option(WITH_SYSTEM_FFMPEG "Build with the system's FFMPEG." OFF)
+    option(WITH_TTY "Build with Linux TTY Input Support." OFF)
+    option(WITH_PROFILING "Build with Profiling Support." OFF)
+    option(WITH_GLES2 "Build with OpenGL ES 2.0 Support." ON)
+    option(WITH_GTK2 "Build with GTK2 Support." ON)
+    option(WITH_OGG "Build with OGG/Vorbis Support." ON)
+    option(WITH_MP3 "Build with MP3 Support." ON)
+    option(WITH_PARALLEL_PORT "Build with Parallel Lights I/O Support." OFF)
+    option(WITH_CRASH_HANDLER "Build with Crash Handler Support." ON)
+  endif()
+endif()

--- a/CMake/DefineOptions.cmake
+++ b/CMake/DefineOptions.cmake
@@ -16,6 +16,13 @@ option(WITH_JPEG "Build with JPEG Image Support." ON)
 # Turn this on to set this to a specific release mode.
 option(WITH_FULL_RELEASE "Build as a proper, full release." OFF)
 
+# Turn this on to compile tomcrypt with no assembly data. This is a portable mode.
+option(WITH_PORTABLE_TOMCRYPT "Build with assembly/free tomcrypt, making it portable." OFF)
+
+# Turn this on to not use the ROLC assembly featurs of tomcrypt.
+# If WITH_PORTABLE_TOMCRYPT is ON, this will automatically have no effect.
+option(WITH_NO_ROLC_TOMCRYPT "Build without the ROLC assembly instructions for tomcrypt. (Ignored by Apple builds)" OFF)
+
 # Turn this option off to not use the GPL exclusive components.
 option(WITH_GPL_LIBS "Build with GPL libraries." ON)
 

--- a/CMake/Modules/FindVa.cmake
+++ b/CMake/Modules/FindVa.cmake
@@ -1,0 +1,17 @@
+# Find the Video Acceleration library.
+
+# The following will be set:
+
+# VA_INCLUDE_DIR
+# VA_LIBRARY
+# VA_FOUND
+
+find_path(VA_INCLUDE_DIR NAMES va/va.h)
+
+set(VA_NAMES "${VA_NAMES}" "va" "libva")
+find_library(VA_LIBRARY NAMES ${VA_NAMES})
+
+include(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(VA DEFAULT_MSG VA_LIBRARY VA_INCLUDE_DIR)
+
+mark_as_advanced(VA_LIBRARY VA_INCLUDE_DIR)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -257,7 +257,7 @@ elseif(LINUX)
 
   if(WITH_FFMPEG)
     if(WITH_LIBVA)
-      find_package(VA)
+      find_package("Va")
     endif()
 
     if (WITH_SYSTEM_FFMPEG)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -256,6 +256,10 @@ elseif(LINUX)
   endif()
 
   if(WITH_FFMPEG)
+    if(WITH_LIBVA)
+      find_package(VA)
+    endif()
+
     if (WITH_SYSTEM_FFMPEG)
       find_package("FFMPEG")
       if(NOT FFMPEG_FOUND)
@@ -290,6 +294,12 @@ elseif(LINUX)
       if (NOT WITH_EXTERNAL_WARNINGS)
         list(APPEND FFMPEG_CONFIGURE
           "--extra-cflags=-w"
+        )
+      endif()
+
+      if(WITH_LIBVA AND VA_FOUND)
+        list(APPEND FFMPEG_CONFIGURE
+          "--extra-ldflags=-lva"
         )
       endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -297,12 +297,6 @@ elseif(LINUX)
         )
       endif()
 
-      if(WITH_LIBVA AND VA_FOUND)
-        list(APPEND FFMPEG_CONFIGURE
-          "--extra-ldflags=-lva"
-        )
-      endif()
-
       if (IS_DIRECTORY "${SM_FFMPEG_SRC_DIR}")
         externalproject_add("ffmpeg"
           SOURCE_DIR "${SM_FFMPEG_SRC_DIR}"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,13 @@ set(SM_BUILD_DIR "${CMAKE_CURRENT_SOURCE_DIR}/Build")
 set(SM_SRC_DIR "${CMAKE_CURRENT_SOURCE_DIR}/src")
 set(SM_ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
 
+# TODO: Reconsile the OS dependent naming scheme.
+if (WIN32 OR APPLE)
+  set(SM_EXE_NAME "StepMania")
+else()
+  set(SM_EXE_NAME "stepmania")
+endif()
+
 # Some OS specific helpers.
 if (CMAKE_SYSTEM_NAME MATCHES "Linux")
   set(LINUX TRUE)
@@ -34,48 +41,10 @@ else()
   set(BSD FALSE)
 endif()
 
-# Some eventual distribution stuff.
-set(CPACK_PACKAGE_NAME "StepMania")
-set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Rhythm Game Simulator")
+# Allow for finding our libraries in a standard location.
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}" "${CMAKE_CURRENT_SOURCE_DIR}/CMake/Modules/")
 
-# Prep options that are needed for each platform.
-option(WITH_NETWORKING "Build with networking support." ON)
-
-# This option quiets warnings that are a part of external projects.
-option(WITH_EXTERNAL_WARNINGS "Build with warnings for all components, not just StepMania." OFF)
-
-# This option is not yet working, but will likely default to ON in the future.
-option(WITH_LTO "Build with Link Time Optimization (LTO)/Whole Program Optimization." OFF)
-
-# This option handles if we use SSE2 processing.
-option(WITH_SSE2 "Build with SSE2 Optimizations." ON)
-
-# This option may go away in the future: if it does, JPEG will always be required.
-option(WITH_JPEG "Build with JPEG Image Support." ON)
-
-# Turn this on to set this to a specific release mode.
-option(WITH_FULL_RELEASE "Build as a proper, full release." OFF)
-
-# Turn this option off to not use the GPL exclusive components.
-option(WITH_GPL_LIBS "Build with GPL libraries." ON)
-
-if(WIN32)
-  option(WITH_MINIMAID "Build with Mimimaid Lights Support." OFF)
-else()
-  if(LINUX)
-    option(WITH_FFMPEG "Build with FFMPEG." ON)
-    # Builder beware: later versions of ffmpeg may break!
-    option(WITH_SYSTEM_FFMPEG "Build with the system's FFMPEG." OFF)
-    option(WITH_TTY "Build with Linux TTY Input Support." OFF)
-    option(WITH_PROFILING "Build with Profiling Support." OFF)
-    option(WITH_GLES2 "Build with OpenGL ES 2.0 Support." ON)
-    option(WITH_GTK2 "Build with GTK2 Support." ON)
-    option(WITH_OGG "Build with OGG/Vorbis Support." ON)
-    option(WITH_MP3 "Build with MP3 Support." ON)
-    option(WITH_PARALLEL_PORT "Build with Parallel Lights I/O Support." OFF)
-    option(WITH_CRASH_HANDLER "Build with Crash Handler Support." ON)
-  endif()
-endif()
+include("CMake/DefineOptions.cmake")
 
 # Set up version numbers according to the new scheme.
 set(SM_VERSION_MAJOR 5)
@@ -96,9 +65,6 @@ if(NOT (ret STREQUAL "0"))
 else()
   set(SM_VERSION_FULL "${SM_VERSION_MAJOR}.${SM_VERSION_MINOR}-git-${SM_VERSION_GIT_HASH}")
 endif()
-
-# Allow for finding our libraries in a standard location.
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}" "${CMAKE_CURRENT_SOURCE_DIR}/CMake/Modules/")
 
 # Put the predefined targets in separate groups.
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
@@ -377,3 +343,5 @@ add_subdirectory(extern)
 # The internal libraries and eventual executable to be used.
 add_subdirectory(src)
 
+# Define installer based items for cpack.
+include("CMake/CPackSetup.cmake")

--- a/extern/CMakeProject-tomcrypt.cmake
+++ b/extern/CMakeProject-tomcrypt.cmake
@@ -269,6 +269,12 @@ add_library("tomcrypt" ${TOMCRYPT_SRC} ${TOMCRYPT_HPP})
 
 set_property(TARGET "tomcrypt" PROPERTY FOLDER "External Libraries")
 
+if (WITH_PORTABLE_TOMCRYPT)
+  sm_add_compile_definition("tomcrypt" LTC_NO_ASM)
+elseif(WITH_NO_ROLC_TOMCRYPT AND NOT APPLE)
+  sm_add_compile_definition("tomcrypt" LTC_NO_ROLC)
+endif()
+
 if (APPLE)
   sm_add_compile_definition("tomcrypt" LTC_NO_ROLC)
   sm_append_simple_target_property("tomcrypt" XCODE_ATTRIBUTE_GCC_NO_COMMON_BLOCKS "YES")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -456,6 +456,10 @@ else() # Unix / Linux
         "${SM_FFMPEG_ROOT}/libavutil/libavutil.a"
       )
     endif()
+
+    if(WITH_LIBVA AND VA_FOUND)
+      list(APPEND SMDATA_LINK_LIB ${VA_LIBRARY})
+    endif()
   endif()
 
   list(APPEND SMDATA_LINK_LIB
@@ -525,6 +529,7 @@ else() # Unix / Linux
   list(APPEND SMDATA_LINK_LIB
     ${XRANDR_LIBRARIES}
   )
+
   list(REMOVE_ITEM SMDATA_LINK_LIB "zlib")
 endif()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -151,13 +151,6 @@ if(NOT APPLE)
   source_group("" FILES "Main.cpp")
 endif()
 
-# TODO: Reconsile the OS dependent naming scheme.
-if (WIN32 OR APPLE)
-  set(SM_EXE_NAME "StepMania")
-else()
-  set(SM_EXE_NAME "stepmania")
-endif()
-
 # Configure generated files here.
 configure_file("${SM_XCODE_DIR}/Info.plist.in.xml" "${SM_XCODE_DIR}/Info.StepMania.plist")
 
@@ -213,6 +206,21 @@ set_target_properties("${SM_EXE_NAME}" PROPERTIES
   OUTPUT_NAME_DEBUG "${SM_NAME_DEBUG}"
   OUTPUT_NAME_MINSIZEREL "${SM_NAME_MINSIZEREL}"
   OUTPUT_NAME_RELWITHDEBINFO "${SM_RELWITHDEBINFO}"
+)
+
+list(APPEND SM_WINDOWS_PROGRAM_DLLS
+  "${SM_PROGRAM_DIR}/avcodec-53.dll"
+  "${SM_PROGRAM_DIR}/avformat-53.dll"
+  "${SM_PROGRAM_DIR}/avutil-51.dll"
+  "${SM_PROGRAM_DIR}/jpeg.dll"
+  "${SM_PROGRAM_DIR}/msvcp100.dll"
+  "${SM_PROGRAM_DIR}/msvcp110.dll"
+  "${SM_PROGRAM_DIR}/msvcr100.dll"
+  "${SM_PROGRAM_DIR}/msvcr110.dll"
+  "${SM_PROGRAM_DIR}/parallel_lights_io.dll"
+  "${SM_PROGRAM_DIR}/swscale-2.dll"
+  "${SM_PROGRAM_DIR}/vccorlib110.dll"
+  "${SM_PROGRAM_DIR}/zlib1.dll"
 )
 
 if(WIN32)
@@ -579,18 +587,34 @@ endif()
 target_include_directories("${SM_EXE_NAME}" PUBLIC ${SM_INCLUDE_DIRS})
 
 if(WIN32)
-  # TODO: Look forward to 64-bit builds. Also, Find a way to not need to hardcode this.
-  set(SM_INSTALL_DESTINATION "C:/Program Files (x86)/StepMania 5")
-elseif(APPLE)
-  # TODO: Confirm if anything special is needed. Most Mac apps are just portable .app folders.
-  set(SM_INSTALL_DESTINATION "")
+  set(SM_INSTALL_DESTINATION ".")
 else()
-  # TODO: Allow for a more flexible system. Good luck convincing old users of that.
-  set(SM_INSTALL_DESTINATION "/opt/stepmania-5.0")
+  set(SM_INSTALL_DESTINATION "stepmania-5.0")
 endif()
 
 if(NOT APPLE)
-  install(TARGETS "${SM_EXE_NAME}" DESTINATION "${SM_INSTALL_DESTINATION}")
+  if(WIN32)
+    # Hardcoding the values for now since the foreach loop is not working as intended.
+    install(TARGETS "${SM_EXE_NAME}" DESTINATION "${SM_INSTALL_DESTINATION}/bin")
+    install(FILES "${SM_PROGRAM_DIR}/avcodec-53.dll" DESTINATION "${SM_INSTALL_DESTINATION}/bin")
+    install(FILES "${SM_PROGRAM_DIR}/avformat-53.dll" DESTINATION "${SM_INSTALL_DESTINATION}/bin")
+    install(FILES "${SM_PROGRAM_DIR}/avutil-51.dll" DESTINATION "${SM_INSTALL_DESTINATION}/bin")
+    install(FILES "${SM_PROGRAM_DIR}/jpeg.dll" DESTINATION "${SM_INSTALL_DESTINATION}/bin")
+    install(FILES "${SM_PROGRAM_DIR}/msvcp100.dll" DESTINATION "${SM_INSTALL_DESTINATION}/bin")
+    install(FILES "${SM_PROGRAM_DIR}/msvcp110.dll" DESTINATION "${SM_INSTALL_DESTINATION}/bin")
+    install(FILES "${SM_PROGRAM_DIR}/msvcr100.dll" DESTINATION "${SM_INSTALL_DESTINATION}/bin")
+    install(FILES "${SM_PROGRAM_DIR}/msvcr110.dll" DESTINATION "${SM_INSTALL_DESTINATION}/bin")
+    install(FILES "${SM_PROGRAM_DIR}/parallel_lights_io.dll" DESTINATION "${SM_INSTALL_DESTINATION}/bin")
+    install(FILES "${SM_PROGRAM_DIR}/swscale-2.dll" DESTINATION "${SM_INSTALL_DESTINATION}/bin")
+    install(FILES "${SM_PROGRAM_DIR}/vccorlib110.dll" DESTINATION "${SM_INSTALL_DESTINATION}/bin")
+    install(FILES "${SM_PROGRAM_DIR}/zlib1.dll" DESTINATION "${SM_INSTALL_DESTINATION}/bin")
+
+    # foreach(SM_WINDOW_DLL "${SM_WINDOWS_PROGRAM_DLLS}")
+    #   install(FILES "${SM_WINDOW_DLL}" DESTINATION "${SM_INSTALL_DESTINATION}")
+    # endforeach()
+  else()
+    install(TARGETS "${SM_EXE_NAME}" DESTINATION "${SM_INSTALL_DESTINATION}")
+  endif()
   if (UNIX OR LINUX)
     install(FILES "${SM_ROOT_DIR}/GtkModule.so" LIBRARY DESTINATION "${SM_INSTALL_DESTINATION}" OPTIONAL)
   endif()


### PR DESCRIPTION
There are two targets you may not be familiar with, `install` and `package`.
* For Linux, `install` now defaults to `/usr/local`, but you can set it back to `/opt` with `cmake -DCMAKE_INSTALL_PREFIX=/opt` if you wish.
* For Windows, `install` may not work, but this is not a target you would want usually.
* For Linux, `package` has not been tested yet. It will likely create an archive file of what is installed.
* For Windows, `package` will create an NSIS package that can be used to install StepMania. One minor change as a result is that the binary and companion dlls will be placed in `bin` instead of `Program` now, but it makes no difference code-wise.

Mac OS X users: for now, use the `dmg` target instead.

This commit does *not* deprecate the original nsi script yet. The Texture Font Generator program has not been addressed yet.