### PR TITLE
ancient NoteData::ClearRangeForTrack bug fix

### DIFF
--- a/src/NoteData.cpp
+++ b/src/NoteData.cpp
@@ -89,7 +89,7 @@ void NoteData::ClearRangeForTrack( int rowBegin, int rowEnd, int iTrack )
 	{
 		NoteData::TrackMap::iterator prev = lEnd;
 		--prev;
-		TapNote tn = lBegin->second;
+		TapNote tn = prev->second;
 		int iRow = prev->first;
 		if( tn.type == TapNoteType_HoldHead && iRow + tn.iDuration > rowEnd )
 		{


### PR DESCRIPTION
When clearing a range, if the first note in any track in the range was a
hold note, it would place it a hold the end of the cleared range.