### PR TITLE
Integer math for tweening

### DIFF
--- a/src/ActiveAttackList.cpp
+++ b/src/ActiveAttackList.cpp
@@ -16,14 +16,14 @@ void ActiveAttackList::Init( const PlayerState* pPlayerState )
 	m_pPlayerState = pPlayerState;
 }
 
-void ActiveAttackList::Update( float fDelta ) 
+void ActiveAttackList::UpdateInternal(int32_t tween_delta)
 {
 	bool bTimeToRefresh = 
 		IsFirstUpdate() || // check this before running Actor::Update()
 		m_pPlayerState->m_bAttackBeganThisUpdate ||
 		m_pPlayerState->m_bAttackEndedThisUpdate;
 
-	BitmapText::Update( fDelta ); 
+	BitmapText::UpdateInternal(tween_delta);
 
 	if( bTimeToRefresh )
 		Refresh();

--- a/src/ActiveAttackList.h
+++ b/src/ActiveAttackList.h
@@ -17,7 +17,7 @@ public:
 	/**
 	 * @brief Look into updating the list.
 	 * @param fDelta the present time. */
-	virtual void Update( float fDelta );
+	virtual void UpdateInternal(int32_t tween_delta);
 	/** @brief Refresh the list of attacks. */ 
 	void Refresh();
 

--- a/src/ActorFrame.h
+++ b/src/ActorFrame.h
@@ -64,7 +64,7 @@ public:
 	void RunCommandsOnChildren( const apActorCommands& cmds, const LuaReference *pParamTable = NULL ) { this->RunCommandsOnChildren( *cmds, pParamTable ); }	// convenience
 	virtual void RunCommandsOnLeaves( const LuaReference& cmds, const LuaReference *pParamTable = NULL ); /* but not on self */
 
-	virtual void UpdateInternal( float fDeltaTime );
+	virtual void UpdateInternal(int32_t tween_delta);
 	virtual void BeginDraw();
 	virtual void DrawPrimitives();
 	virtual void EndDraw();
@@ -89,7 +89,7 @@ public:
 	virtual void SetPropagateCommands( bool b );
 
 	/** @brief Amount of time until all tweens (and all children's tweens) have stopped: */
-	virtual float GetTweenTimeLeft() const;
+	virtual int64_t GetTweenTimeLeft() const;
 
 	virtual void HandleMessage( const Message &msg );
 	virtual void RunCommands( const LuaReference& cmds, const LuaReference *pParamTable = NULL );

--- a/src/ActorMultiVertex.cpp
+++ b/src/ActorMultiVertex.cpp
@@ -558,14 +558,14 @@ void ActorMultiVertex::EnableAnimation(bool bEnable)
 	}
 }
 
-void ActorMultiVertex::Update(float fDelta)
+void ActorMultiVertex::UpdateInternal(int32_t tween_delta)
 {
-	Actor::Update(fDelta); // do tweening
+	Actor::UpdateInternal(tween_delta); // do tweening
 	const bool skip_this_movie_update= _skip_next_update;
 	_skip_next_update= false;
 	if(!m_bIsAnimating) { return; }
 	if(!_Texture) { return; }
-	float time_passed = GetEffectDeltaTime();
+	float time_passed = GetEffectDelta();
 	_secs_into_state += time_passed;
 	if(_secs_into_state < 0)
 	{

--- a/src/ActorMultiVertex.h
+++ b/src/ActorMultiVertex.h
@@ -69,7 +69,7 @@ public:
 	const AMV_TweenState& AMV_DestTweenState() const { return const_cast<ActorMultiVertex*>(this)->AMV_DestTweenState(); }
 
 	virtual void EnableAnimation(bool bEnable);
-	virtual void Update(float fDelta);
+	virtual void UpdateInternal(int32_t tween_delta);
 	virtual bool EarlyAbortDraw() const;
 	virtual void DrawPrimitives();
 	virtual void DrawInternal( const AMV_TweenState *TS );

--- a/src/ActorScroller.cpp
+++ b/src/ActorScroller.cpp
@@ -163,14 +163,15 @@ void ActorScroller::LoadFromNode( const XNode *pNode )
 	pNode->GetAttrValue( "WrapScroller", m_bWrap );
 }
 
-void ActorScroller::UpdateInternal( float fDeltaTime )
+void ActorScroller::UpdateInternal(int32_t tween_delta)
 {
-	ActorFrame::UpdateInternal( fDeltaTime );
+	ActorFrame::UpdateInternal(tween_delta);
 
 	// If we have no children, the code below will busy loop.
 	if( !m_SubActors.size() )
 		return;
 
+	float fDeltaTime= tween_time_to_secs(tween_delta);
 	// handle pause
 	if( fDeltaTime > m_fPauseCountdownSeconds )
 	{

--- a/src/ActorScroller.h
+++ b/src/ActorScroller.h
@@ -21,7 +21,7 @@ public:
 	void EnableMask( float fWidth, float fHeight );
 	void DisableMask();
 
-	virtual void UpdateInternal( float fDelta );
+	virtual void UpdateInternal(int32_t tween_delta);
 	virtual void DrawPrimitives();	// handles drawing and doesn't call ActorFrame::DrawPrimitives
 
 	void PositionItems();

--- a/src/AttackDisplay.cpp
+++ b/src/AttackDisplay.cpp
@@ -66,9 +66,9 @@ void AttackDisplay::Init( const PlayerState* pPlayerState )
 }
 
 
-void AttackDisplay::Update( float fDelta )
+void AttackDisplay::UpdateInternal(int32_t tween_delta)
 {
-	ActorFrame::Update( fDelta );
+	ActorFrame::UpdateInternal(tween_delta);
 
 	if( GAMESTATE->m_PlayMode != PLAY_MODE_BATTLE &&
 		GAMESTATE->m_PlayMode != PLAY_MODE_RAVE )

--- a/src/AttackDisplay.h
+++ b/src/AttackDisplay.h
@@ -18,7 +18,7 @@ public:
 	void Init( const PlayerState* pPlayerState );
 	void SetAttack( const RString &mod );
 
-	virtual void Update( float fDelta );
+	virtual void UpdateInternal(int32_t tween_delta);
 
 protected:
 	const PlayerState* m_pPlayerState;

--- a/src/BGAnimationLayer.cpp
+++ b/src/BGAnimationLayer.cpp
@@ -541,11 +541,12 @@ void BGAnimationLayer::LoadFromNode( const XNode* pNode )
 	}
 }
 
-void BGAnimationLayer::UpdateInternal( float fDeltaTime )
+void BGAnimationLayer::UpdateInternal(int32_t tween_delta)
 {
-	ActorFrame::UpdateInternal( fDeltaTime );
+	ActorFrame::UpdateInternal(tween_delta);
 
-	fDeltaTime *= m_fUpdateRate;
+	tween_delta *= m_fUpdateRate;
+	float fDeltaTime= tween_time_to_secs(tween_delta);
 
 	switch( m_Type )
 	{

--- a/src/BGAnimationLayer.h
+++ b/src/BGAnimationLayer.h
@@ -17,7 +17,7 @@ public:
 	void LoadFromAniLayerFile( const RString& sPath );
 	void LoadFromNode( const XNode* pNode );
 
-	void UpdateInternal( float fDeltaTime );
+	void UpdateInternal(int32_t tween_delta);
 
 	float GetMaxTweenTimeLeft() const;
 

--- a/src/BPMDisplay.cpp
+++ b/src/BPMDisplay.cpp
@@ -56,16 +56,16 @@ float BPMDisplay::GetActiveBPM() const
 	return m_fBPMTo + (m_fBPMFrom-m_fBPMTo)*m_fPercentInState;
 }
 
-void BPMDisplay::Update( float fDeltaTime ) 
+void BPMDisplay::UpdateInternal(int32_t tween_delta)
 { 
-	BitmapText::Update( fDeltaTime ); 
+	BitmapText::UpdateInternal(tween_delta);
 
 	if( !(bool)CYCLE )
 		return;
 	if( m_BPMS.size() == 0 )
 		return; // no bpm
 
-	m_fPercentInState -= fDeltaTime / m_fCycleTime;
+	m_fPercentInState -= tween_time_to_secs(tween_delta) / m_fCycleTime;
 	if( m_fPercentInState < 0 )
 	{
 		// go to next state
@@ -276,7 +276,7 @@ class SongBPMDisplay: public BPMDisplay
 public:
 	SongBPMDisplay();
 	virtual SongBPMDisplay *Copy() const;
-	virtual void Update( float fDeltaTime ); 
+	virtual void UpdateInternal(int32_t tween_delta);
 
 private:
 	float m_fLastGameStateBPM;
@@ -288,7 +288,7 @@ SongBPMDisplay::SongBPMDisplay()
 	m_fLastGameStateBPM = 0;
 }
 
-void SongBPMDisplay::Update( float fDeltaTime ) 
+void SongBPMDisplay::UpdateInternal(int32_t tween_delta)
 {
 	float fGameStateBPM = GAMESTATE->m_Position.m_fCurBPS * 60.0f;
 	if( m_fLastGameStateBPM != fGameStateBPM )
@@ -297,7 +297,7 @@ void SongBPMDisplay::Update( float fDeltaTime )
 		SetConstantBpm( fGameStateBPM );
 	}
 
-	BPMDisplay::Update( fDeltaTime );
+	BPMDisplay::UpdateInternal(tween_delta);
 }
 
 REGISTER_ACTOR_CLASS( SongBPMDisplay );

--- a/src/BPMDisplay.h
+++ b/src/BPMDisplay.h
@@ -24,7 +24,7 @@ public:
 	 * @brief Update the display as required.
 	 * @param fDeltaTime the changed time.
 	 */
-	virtual void Update( float fDeltaTime ); 
+	virtual void UpdateInternal(int32_t tween_delta);
 	void LoadFromNode( const XNode *pNode );
 	/**
 	 * @brief Use the BPM[s] from a song.

--- a/src/Background.cpp
+++ b/src/Background.cpp
@@ -46,7 +46,7 @@ class BrightnessOverlay: public ActorFrame
 {
 public:
 	BrightnessOverlay();
-	void Update( float fDeltaTime );
+	void UpdateInternal(int32_t tween_delta);
 
 	void FadeToActualBrightness();
 	void SetActualBrightness();
@@ -74,7 +74,7 @@ public:
 	virtual void LoadFromSong( const Song *pSong );
 	virtual void Unload();
 
-	virtual void Update( float fDeltaTime );
+	virtual void UpdateInternal(int32_t tween_delta);
 	virtual void DrawPrimitives();
 
 	void FadeToActualBrightness() { m_Brightness.FadeToActualBrightness(); }
@@ -798,7 +798,7 @@ void BackgroundImpl::Layer::UpdateCurBGChange( const Song *pSong, float fLastMus
 	}
 
 	/* This is unaffected by the music rate. */
-	float fDeltaTimeNoMusicRate = max( fDeltaTime / fRate, 0 );
+	int32_t fDeltaTimeNoMusicRate = secs_to_tween_time(max(fDeltaTime / fRate, 0 ));
 
 	if( m_pCurrentBGA )
 		m_pCurrentBGA->Update( fDeltaTimeNoMusicRate );
@@ -806,9 +806,9 @@ void BackgroundImpl::Layer::UpdateCurBGChange( const Song *pSong, float fLastMus
 		m_pFadingBGA->Update( fDeltaTimeNoMusicRate );
 }
 
-void BackgroundImpl::Update( float fDeltaTime )
+void BackgroundImpl::UpdateInternal(int32_t tween_delta)
 {
-	ActorFrame::Update( fDeltaTime );
+	ActorFrame::UpdateInternal(tween_delta);
 
 	{
 		bool bVisible = IsDangerAllVisible();
@@ -818,7 +818,7 @@ void BackgroundImpl::Update( float fDeltaTime )
 	}
 
 	if( m_pDancingCharacters )
-		m_pDancingCharacters->Update( fDeltaTime );
+		m_pDancingCharacters->Update(tween_delta);
 
 	FOREACH_BackgroundLayer( i )
 	{
@@ -910,9 +910,9 @@ BrightnessOverlay::BrightnessOverlay()
 	SetActualBrightness();
 }
 
-void BrightnessOverlay::Update( float fDeltaTime )
+void BrightnessOverlay::UpdateInternal(int32_t tween_delta)
 {
-	ActorFrame::Update( fDeltaTime );
+	ActorFrame::UpdateInternal(tween_delta);
 	/* If we're actually playing, then we're past fades, etc; update the
 	 * background brightness to follow Cover. */
 	if( !GAMESTATE->m_bGameplayLeadIn )

--- a/src/Banner.cpp
+++ b/src/Banner.cpp
@@ -76,13 +76,13 @@ void Banner::LoadFromCachedBanner( const RString &sPath )
 		LoadFallback();
 }
 
-void Banner::Update( float fDeltaTime )
+void Banner::UpdateInternal(int32_t tween_delta)
 {
-	Sprite::Update( fDeltaTime );
+	Sprite::UpdateInternal(tween_delta);
 
 	if( m_bScrolling )
 	{
-		m_fPercentScrolling += fDeltaTime/(float)SCROLL_SPEED_DIVISOR;
+		m_fPercentScrolling += tween_time_to_secs(tween_delta)/(float)SCROLL_SPEED_DIVISOR;
 		m_fPercentScrolling -= (int)m_fPercentScrolling;
 
 		const RectF *pTextureRect = GetCurrentTextureCoordRect();

--- a/src/Banner.h
+++ b/src/Banner.h
@@ -23,7 +23,7 @@ public:
 	virtual void Load( RageTextureID ID ) { Load( ID, true ); }
 	void LoadFromCachedBanner( const RString &sPath );
 
-	virtual void Update( float fDeltaTime );
+	virtual void UpdateInternal(int32_t tween_delta);
 
 	/**
 	 * @brief Attempt to load the banner from a song.

--- a/src/BeginnerHelper.cpp
+++ b/src/BeginnerHelper.cpp
@@ -340,7 +340,7 @@ void BeginnerHelper::Step( PlayerNumber pn, int CSTEP )
 	m_sFlash.SetDiffuseAlpha( 0 );
 }
 
-void BeginnerHelper::Update( float fDeltaTime )
+void BeginnerHelper::UpdateInternal(int32_t tween_delta)
 {
 	if( !m_bInitialized )
 		return;
@@ -371,19 +371,19 @@ void BeginnerHelper::Update( float fDeltaTime )
 	m_iLastRowChecked = iCurRow;
 
 	// Update animations
-	ActorFrame::Update( fDeltaTime );
-	m_pDancePad->Update( fDeltaTime );
-	m_sFlash.Update( fDeltaTime );
+	ActorFrame::UpdateInternal(tween_delta);
+	m_pDancePad->Update(tween_delta);
+	m_sFlash.Update(tween_delta);
 
-	float beat = fDeltaTime*GAMESTATE->m_Position.m_fCurBPS;
+	int32_t beat_delta= tween_delta * GAMESTATE->m_Position.m_fCurBPS;
 	// If this is not a human player, the dancer is not shown
 	FOREACH_HumanPlayer( pu )
 	{
 		// Update dancer's animation and StepCircles
-		m_pDancer[pu]->Update( beat );
+		m_pDancer[pu]->Update(beat_delta);
 		for( int scu=0; scu<NUM_PLAYERS; scu++ )
 			for( int scue=0; scue<4; scue++ )
-				m_sStepCircle[scu][scue].Update( beat );
+				m_sStepCircle[scu][scue].Update(beat_delta);
 	}
 }
 

--- a/src/BeginnerHelper.h
+++ b/src/BeginnerHelper.h
@@ -23,7 +23,7 @@ public:
 	void ShowStepCircle( PlayerNumber pn, int CSTEP );
 	bool m_bShowBackground;
 
-	void Update( float fDeltaTime );
+	void UpdateInternal(int32_t tween_delta);
 	virtual void DrawPrimitives();
 
 protected:

--- a/src/CombinedLifeMeterTug.cpp
+++ b/src/CombinedLifeMeterTug.cpp
@@ -54,7 +54,7 @@ CombinedLifeMeterTug::CombinedLifeMeterTug()
 	this->AddChild( m_sprFrame );
 }
 
-void CombinedLifeMeterTug::Update( float fDelta )
+void CombinedLifeMeterTug::UpdateInternal(int32_t tween_delta)
 {
 	float fPercentToShow = GAMESTATE->m_fTugLifePercentP1;
 	CLAMP( fPercentToShow, 0.f, 1.f );
@@ -66,7 +66,7 @@ void CombinedLifeMeterTug::Update( float fDelta )
 
 	m_sprSeparator->SetX( fSeparatorX );
 
-	ActorFrame::Update( fDelta );
+	ActorFrame::UpdateInternal(tween_delta);
 }
 
 void CombinedLifeMeterTug::ChangeLife( PlayerNumber pn, TapNoteScore score )

--- a/src/CombinedLifeMeterTug.h
+++ b/src/CombinedLifeMeterTug.h
@@ -9,7 +9,7 @@ class CombinedLifeMeterTug : public CombinedLifeMeter
 {
 public:
 	CombinedLifeMeterTug();
-	virtual void Update( float fDelta );
+	virtual void UpdateInternal(int32_t tween_delta);
 
 	virtual void ChangeLife( PlayerNumber pn, TapNoteScore score );
 	virtual void ChangeLife( PlayerNumber pn, HoldNoteScore score, TapNoteScore tscore );

--- a/src/ControllerStateDisplay.cpp
+++ b/src/ControllerStateDisplay.cpp
@@ -68,9 +68,9 @@ void ControllerStateDisplay::LoadInternal( RString sType, MultiPlayer mp, GameCo
 	}
 }
 
-void ControllerStateDisplay::Update( float fDelta )
+void ControllerStateDisplay::UpdateInternal(int32_t tween_delta)
 {
-	ActorFrame::Update( fDelta );
+	ActorFrame::UpdateInternal(tween_delta);
 
 	if( m_mp != MultiPlayer_Invalid )
 	{

--- a/src/ControllerStateDisplay.h
+++ b/src/ControllerStateDisplay.h
@@ -62,7 +62,7 @@ public:
 	ControllerStateDisplay();
 	void LoadMultiPlayer( RString sType, MultiPlayer mp );
 	void LoadGameController( RString sType, GameController gc );
-	virtual void Update( float fDelta );
+	virtual void UpdateInternal(int32_t tween_delta);
 	bool IsLoaded() const { return m_bIsLoaded; }
 
 	virtual ControllerStateDisplay *Copy() const;

--- a/src/DancingCharacters.cpp
+++ b/src/DancingCharacters.cpp
@@ -176,13 +176,14 @@ void DancingCharacters::LoadNextSong()
 
 int Neg1OrPos1() { return RandomInt( 2 ) ? -1 : +1; }
 
-void DancingCharacters::Update( float fDelta )
+void DancingCharacters::UpdateInternal(int32_t tween_delta)
 {
+	float delta= tween_time_to_secs(tween_delta);
 	if( GAMESTATE->m_Position.m_bFreeze || GAMESTATE->m_Position.m_bDelay )
 	{
 		// spin the camera Matrix-style
-		m_CameraPanYStart += fDelta*40;
-		m_CameraPanYEnd += fDelta*40;
+		m_CameraPanYStart += delta*40;
+		m_CameraPanYEnd += delta*40;
 	}
 	else
 	{
@@ -198,7 +199,7 @@ void DancingCharacters::Update( float fDelta )
 		FOREACH_PlayerNumber( p )
 		{
 			if( GAMESTATE->IsPlayerEnabled(p) )
-				m_pCharacter[p]->Update( fDelta*fUpdateScale );
+				m_pCharacter[p]->Update(tween_delta*fUpdateScale);
 		}
 	}
 

--- a/src/DancingCharacters.h
+++ b/src/DancingCharacters.h
@@ -32,7 +32,7 @@ public:
 
 	void LoadNextSong();
  
-	virtual void Update( float fDelta );
+	virtual void UpdateInternal(int32_t tween_delta);
 	virtual void DrawPrimitives();
 	bool	m_bDrawDangerLight;
 	void Change2DAnimState( PlayerNumber pn, int iState );

--- a/src/FadingBanner.cpp
+++ b/src/FadingBanner.cpp
@@ -38,16 +38,16 @@ void FadingBanner::ScaleToClipped( float fWidth, float fHeight )
 		m_Banner[i].ScaleToClipped( fWidth, fHeight );
 }
 
-void FadingBanner::UpdateInternal( float fDeltaTime )
+void FadingBanner::UpdateInternal(int32_t tween_delta)
 {
 	// update children manually
 	// ActorFrame::UpdateInternal( fDeltaTime );
-	Actor::UpdateInternal( fDeltaTime );
+	Actor::UpdateInternal(tween_delta);
 
 	if( !m_bSkipNextBannerUpdate )
 	{
 		for( int i = 0; i < NUM_BANNERS; ++i )
-			m_Banner[i].Update( fDeltaTime );
+			m_Banner[i].Update(tween_delta);
 	}
 
 	m_bSkipNextBannerUpdate = false;

--- a/src/FadingBanner.h
+++ b/src/FadingBanner.h
@@ -35,7 +35,7 @@ public:
 	bool LoadFromCachedBackground( const RString &path );
 
 	void SetMovingFast( bool fast ) { m_bMovingFast=fast; }
-	virtual void UpdateInternal( float fDeltaTime );
+	virtual void UpdateInternal(int32_t tween_delta);
 	virtual void DrawPrimitives();
 
 	int GetLatestIndex(){ return m_iIndexLatest; }

--- a/src/Foreground.cpp
+++ b/src/Foreground.cpp
@@ -71,7 +71,7 @@ void Foreground::LoadFromSong( const Song *pSong )
 	this->SortByDrawOrder();
 }
 
-void Foreground::Update( float fDeltaTime )
+void Foreground::UpdateInternal(int32_t tween_delta)
 {
 	// Calls to Update() should *not* be scaled by music rate. Undo it.
 	const float fRate = GAMESTATE->m_SongOptions.GetCurrent().m_fMusicRate;
@@ -98,7 +98,7 @@ void Foreground::Update( float fDeltaTime )
 			bga.m_bga->PlayCommand( "On" );
 
 			const float fStartSecond = m_pSong->m_SongTiming.GetElapsedTimeFromBeat( bga.m_fStartBeat );
-			const float fStopSecond = fStartSecond + bga.m_bga->GetTweenTimeLeft();
+			const float fStopSecond = fStartSecond + bga.m_bga->GetTweenSecsLeft();
 			bga.m_fStopBeat = m_pSong->m_SongTiming.GetBeatFromElapsedTime( fStopSecond );
 
 			lDeltaTime = GAMESTATE->m_Position.m_fMusicSeconds - fStartSecond;
@@ -111,7 +111,7 @@ void Foreground::Update( float fDeltaTime )
 		// This shouldn't go down, but be safe:
 		lDeltaTime = max( lDeltaTime, 0 );
 
-		bga.m_bga->Update( lDeltaTime / fRate );
+		bga.m_bga->Update(tween_delta / fRate);
 
 		if( GAMESTATE->m_Position.m_fSongBeat > bga.m_fStopBeat )
 		{

--- a/src/Foreground.h
+++ b/src/Foreground.h
@@ -12,7 +12,7 @@ public:
 	void Unload();
 	void LoadFromSong( const Song *pSong );
 
-	virtual void Update( float fDeltaTime );
+	virtual void UpdateInternal(int32_t tween_delta);
 	virtual void HandleMessage( const Message &msg );
 
 protected:

--- a/src/GameState.cpp
+++ b/src/GameState.cpp
@@ -1146,13 +1146,13 @@ void GameState::ForceOtherPlayersToCompatibleSteps(PlayerNumber main)
 	}
 }
 
-void GameState::Update( float fDelta )
+void GameState::Update(int32_t tween_delta)
 {
-	m_SongOptions.Update( fDelta );
+	m_SongOptions.Update();
 
 	FOREACH_PlayerNumber( p )
 	{
-		m_pPlayerState[p]->Update( fDelta );
+		m_pPlayerState[p]->Update(tween_delta);
 
 		if( !m_bGoalComplete[p] && IsGoalComplete(p) )
 		{
@@ -1235,7 +1235,7 @@ void GameState::ResetStageStatistics()
 		m_pPlayerState[p]->m_HealthState = HealthState_Alive;
 
 		m_pPlayerState[p]->m_iLastPositiveSumOfAttackLevels = 0;
-		m_pPlayerState[p]->m_fSecondsUntilAttacksPhasedOut = 0;	// PlayerAI not affected
+		m_pPlayerState[p]->m_time_until_attacks_phased_out = 0;	// PlayerAI not affected
 
 		m_bGoalComplete[p] = false;
 	}

--- a/src/GameState.h
+++ b/src/GameState.h
@@ -78,7 +78,7 @@ public:
 	void ForceSharedSidesMatch();
 	void ForceOtherPlayersToCompatibleSteps(PlayerNumber main);
 
-	void Update( float fDelta );
+	void Update(int32_t tween_delta);
 
 	// Main state info
 

--- a/src/GhostArrowRow.cpp
+++ b/src/GhostArrowRow.cpp
@@ -53,11 +53,11 @@ GhostArrowRow::~GhostArrowRow()
 }
 
 
-void GhostArrowRow::Update( float fDeltaTime )
+void GhostArrowRow::UpdateInternal(int32_t tween_delta)
 {
 	for( unsigned c=0; c<m_Ghost.size(); c++ )
 	{
-		m_Ghost[c]->Update( fDeltaTime );
+		m_Ghost[c]->Update(tween_delta);
 		(*m_renderers)[c].UpdateReceptorGhostStuff(m_Ghost[c]);
 	}
 

--- a/src/GhostArrowRow.h
+++ b/src/GhostArrowRow.h
@@ -12,7 +12,7 @@ class GhostArrowRow : public ActorFrame
 {
 public:
 	virtual ~GhostArrowRow();
-	virtual void Update( float fDeltaTime );
+	virtual void UpdateInternal(int32_t tween_delta);
 	virtual void DrawPrimitives();
 
 	void Load( const PlayerState* pPlayerState, float fYReverseOffset );

--- a/src/GrooveRadar.cpp
+++ b/src/GrooveRadar.cpp
@@ -132,11 +132,11 @@ void GrooveRadar::GrooveRadarValueMap::SetFromValues( vector<float> vals )
 		m_PercentTowardNew = 0;
 }
 
-void GrooveRadar::GrooveRadarValueMap::Update( float fDeltaTime )
+void GrooveRadar::GrooveRadarValueMap::UpdateInternal(int32_t tween_delta)
 {
-	ActorFrame::Update( fDeltaTime );
+	ActorFrame::UpdateInternal(tween_delta);
 
-	m_PercentTowardNew = min( m_PercentTowardNew+4.0f*fDeltaTime, 1 );
+	m_PercentTowardNew = min( m_PercentTowardNew+4.0f*tween_time_to_secs(tween_delta), 1 );
 }
 
 void GrooveRadar::GrooveRadarValueMap::DrawPrimitives()

--- a/src/GrooveRadar.h
+++ b/src/GrooveRadar.h
@@ -41,7 +41,7 @@ protected:
 	public:
 		GrooveRadarValueMap();
 
-		virtual void Update( float fDeltaTime );
+		virtual void UpdateInternal(int32_t tween_delta);
 		virtual void DrawPrimitives();
 
 		void SetEmpty();

--- a/src/HelpDisplay.cpp
+++ b/src/HelpDisplay.cpp
@@ -39,16 +39,14 @@ void HelpDisplay::SetTips( const vector<RString> &arrayTips, const vector<RStrin
 }
 
 
-void HelpDisplay::Update( float fDeltaTime )
+void HelpDisplay::UpdateInternal(int32_t tween_delta)
 {
-	float fHibernate = m_fHibernateSecondsLeft;
-
-	BitmapText::Update( fDeltaTime );
+	BitmapText::UpdateInternal(tween_delta);
 
 	if( m_arrayTips.empty() )
 		return;
 
-	m_fSecsUntilSwitch -= max( fDeltaTime - fHibernate, 0 );
+	m_fSecsUntilSwitch -= tween_time_to_secs(tween_delta);
 	if( m_fSecsUntilSwitch > 0 )
 		return;
 

--- a/src/HelpDisplay.h
+++ b/src/HelpDisplay.h
@@ -18,7 +18,7 @@ public:
 	void GetTips( vector<RString> &arrayTipsOut, vector<RString> &arrayTipsAltOut ) const { arrayTipsOut = m_arrayTips; arrayTipsAltOut = m_arrayTipsAlt; }
 	void SetSecsBetweenSwitches( float fSeconds ) { m_fSecsBetweenSwitches = m_fSecsUntilSwitch = fSeconds; }
 
-	virtual void Update( float fDeltaTime );
+	virtual void UpdateInternal(int32_t tween_delta);
 
 	// Lua
 	virtual void PushSelf( lua_State *L );

--- a/src/Inventory.cpp
+++ b/src/Inventory.cpp
@@ -89,7 +89,7 @@ void Inventory::Load( PlayerState* pPlayerState )
 	}
 }
 
-void Inventory::Update( float fDelta )
+void Inventory::UpdateInternal(int32_t tween_delta)
 {
 	if( m_pPlayerState->m_bAttackEndedThisUpdate )
 		m_soundItemEnding.Play(false);
@@ -129,7 +129,7 @@ void Inventory::Update( float fDelta )
 		GAMESTATE->m_Position.m_fSongBeat < song.GetLastBeat() )
 	{
 		// every 1 seconds, try to use an item
-		int iLastSecond = (int)(RageTimer::GetTimeSinceStartFast() - fDelta);
+		int iLastSecond = (int)(RageTimer::GetTimeSinceStartFast() - tween_time_to_secs(tween_delta));
 		int iThisSecond = (int)RageTimer::GetTimeSinceStartFast();
 		if( iLastSecond != iThisSecond )
 		{

--- a/src/Inventory.h
+++ b/src/Inventory.h
@@ -19,7 +19,7 @@ public:
 	~Inventory();
 	void Load( PlayerState* pPlayerState );
 
-	virtual void Update( float fDelta );
+	virtual void UpdateInternal(int32_t tween_delta);
 	virtual void DrawPrimitives() {};
 
 	void UseItem( int iSlot );

--- a/src/LifeMeterBar.cpp
+++ b/src/LifeMeterBar.cpp
@@ -276,14 +276,15 @@ bool LifeMeterBar::IsFailing() const
 }
 
 
-void LifeMeterBar::Update( float fDeltaTime )
+void LifeMeterBar::UpdateInternal(int32_t tween_delta)
 {
-	LifeMeter::Update( fDeltaTime );
+	LifeMeter::UpdateInternal(tween_delta);
+	float double_delta= tween_time_to_secs(tween_delta * 2);
 
-	m_fPassingAlpha += !IsFailing() ? +fDeltaTime*2 : -fDeltaTime*2;
+	m_fPassingAlpha += !IsFailing() ? +double_delta : -double_delta;
 	CLAMP( m_fPassingAlpha, 0, 1 );
 
-	m_fHotAlpha  += IsHot() ? + fDeltaTime*2 : -fDeltaTime*2;
+	m_fHotAlpha  += IsHot() ? + double_delta : -double_delta;
 	CLAMP( m_fHotAlpha, 0, 1 );
 
 	m_pStream->SetPassingAlpha( m_fPassingAlpha );

--- a/src/LifeMeterBar.h
+++ b/src/LifeMeterBar.h
@@ -17,7 +17,7 @@ public:
 
 	virtual void Load( const PlayerState *pPlayerState, PlayerStageStats *pPlayerStageStats );
 
-	virtual void Update( float fDeltaTime );
+	virtual void UpdateInternal(int32_t tween_delta);
 
 	virtual void ChangeLife( TapNoteScore score );
 	virtual void ChangeLife( HoldNoteScore score, TapNoteScore tscore  );

--- a/src/LifeMeterBattery.cpp
+++ b/src/LifeMeterBattery.cpp
@@ -254,9 +254,9 @@ int LifeMeterBattery::GetTotalLives()
 	return m_pPlayerState->m_PlayerOptions.GetSong().m_BatteryLives;
 }
 
-void LifeMeterBattery::Update( float fDeltaTime )
+void LifeMeterBattery::UpdateInternal(int32_t tween_delta)
 {
-	LifeMeter::Update( fDeltaTime );
+	LifeMeter::UpdateInternal(tween_delta);
 }
 
 // lua start

--- a/src/LifeMeterBattery.h
+++ b/src/LifeMeterBattery.h
@@ -17,7 +17,7 @@ public:
 
 	virtual void Load( const PlayerState *pPlayerState, PlayerStageStats *pPlayerStageStats );
 
-	virtual void Update( float fDeltaTime );
+	virtual void UpdateInternal(int32_t tween_delta);
 
 	virtual void OnSongEnded();
 	virtual void ChangeLife( TapNoteScore score );

--- a/src/LifeMeterTime.cpp
+++ b/src/LifeMeterTime.cpp
@@ -210,14 +210,14 @@ bool LifeMeterTime::IsFailing() const
 	return GetLifeSeconds() <= 0;
 }
 
-void LifeMeterTime::Update( float fDeltaTime )
+void LifeMeterTime::UpdateInternal(int32_t tween_delta)
 {
 	// update current stage stats so ScoreDisplayLifeTime can show the right thing
 	float fSecs = GetLifeSeconds();
 	fSecs = max( 0, fSecs );
 	m_pPlayerStageStats->m_fLifeRemainingSeconds = fSecs;
 	
-	LifeMeter::Update( fDeltaTime );
+	LifeMeter::UpdateInternal(tween_delta);
 
 	m_pStream->SetPercent( GetLife() );
 	m_pStream->SetPassingAlpha( 0 );

--- a/src/LifeMeterTime.h
+++ b/src/LifeMeterTime.h
@@ -20,7 +20,7 @@ public:
 
 	virtual void Load( const PlayerState *pPlayerState, PlayerStageStats *pPlayerStageStats );
 
-	virtual void Update( float fDeltaTime );
+	virtual void UpdateInternal(int32_t tween_delta);
 
 	virtual void OnLoadSong();
 	virtual void ChangeLife( TapNoteScore score );

--- a/src/LyricDisplay.cpp
+++ b/src/LyricDisplay.cpp
@@ -38,12 +38,12 @@ void LyricDisplay::Stop() {
 	m_bStopped = true;
 }
 
-void LyricDisplay::Update( float fDeltaTime )
+void LyricDisplay::UpdateInternal(int32_t tween_delta)
 {
 	if( m_bStopped )
 		return;
 
-	ActorFrame::Update( fDeltaTime );
+	ActorFrame::UpdateInternal(tween_delta);
 
 	if( GAMESTATE->m_pCurSong == NULL )
 		return;

--- a/src/LyricDisplay.h
+++ b/src/LyricDisplay.h
@@ -8,7 +8,7 @@ class LyricDisplay: public ActorFrame
 {
 public:
 	LyricDisplay();
-	void Update( float fDeltaTime );
+	void UpdateInternal(int32_t tween_delta);
 
 	// Call when song changes:
 	void Init();

--- a/src/MemoryCardDisplay.cpp
+++ b/src/MemoryCardDisplay.cpp
@@ -41,7 +41,7 @@ void MemoryCardDisplay::LoadFromNode( const XNode* pNode )
 	ActorFrame::LoadFromNode( pNode );
 }
 
-void MemoryCardDisplay::Update( float fDelta )
+void MemoryCardDisplay::UpdateInternal(int32_t tween_delta)
 {
 	MemoryCardState newMcs = MEMCARDMAN->GetCardState(m_PlayerNumber);
 	if( m_LastSeenState != newMcs )
@@ -52,7 +52,7 @@ void MemoryCardDisplay::Update( float fDelta )
 		m_spr[m_LastSeenState].SetVisible( true );
 	}
 
-	ActorFrame::Update( fDelta );
+	ActorFrame::UpdateInternal(tween_delta);
 }
 
 /*

--- a/src/MemoryCardDisplay.h
+++ b/src/MemoryCardDisplay.h
@@ -13,7 +13,7 @@ public:
 	void Load( PlayerNumber pn );
 	void LoadFromNode( const XNode* pNode );
 	virtual MemoryCardDisplay *Copy() const;
-	void Update( float fDelta );
+	void UpdateInternal(int32_t tween_delta);
 
 protected:
 	PlayerNumber m_PlayerNumber;

--- a/src/MenuTimer.cpp
+++ b/src/MenuTimer.cpp
@@ -73,12 +73,13 @@ void MenuTimer::EnableStealth( bool bStealth )
 	}
 }
 
-void MenuTimer::Update( float fDeltaTime ) 
+void MenuTimer::UpdateInternal(int32_t tween_delta)
 { 
-	ActorFrame::Update( fDeltaTime );
+	ActorFrame::UpdateInternal(tween_delta);
 
 	if( m_bPaused )
 		return;
+	float fDeltaTime= tween_time_to_secs(tween_delta);
 
 	// run down the stall time if any
 	if( m_fStallSeconds > 0 )

--- a/src/MenuTimer.h
+++ b/src/MenuTimer.h
@@ -18,7 +18,7 @@ public:
 	virtual ~MenuTimer();
 	void Load( RString sMetricsGroup );
 	
-	virtual void Update( float fDeltaTime ); 
+	virtual void UpdateInternal(int32_t tween_delta);
 
 	void SetSeconds( float fSeconds );
 	float GetSeconds() const { return m_fSecondsLeft; }

--- a/src/MeterDisplay.cpp
+++ b/src/MeterDisplay.cpp
@@ -76,7 +76,7 @@ void MeterDisplay::SetStreamWidth( float fStreamWidth )
 	m_sprStream->SetZoomX( m_fStreamWidth / m_sprStream->GetUnzoomedWidth() );
 }
 
-void SongMeterDisplay::Update( float fDeltaTime )
+void SongMeterDisplay::UpdateInternal(int32_t tween_delta)
 {
 	if( GAMESTATE->m_pCurSong )
 	{
@@ -88,7 +88,7 @@ void SongMeterDisplay::Update( float fDeltaTime )
 		SetPercent( fPercentPositionSong );
 	}
 
-	MeterDisplay::Update( fDeltaTime );
+	MeterDisplay::UpdateInternal(tween_delta);
 }
 
 // lua start

--- a/src/MeterDisplay.h
+++ b/src/MeterDisplay.h
@@ -31,7 +31,7 @@ private:
 class SongMeterDisplay: public MeterDisplay 
 {
 public:
-	virtual void Update( float fDeltaTime );
+	virtual void UpdateInternal(int32_t tween_delta);
 	virtual SongMeterDisplay *Copy() const;
 };
 

--- a/src/Model.cpp
+++ b/src/Model.cpp
@@ -712,9 +712,10 @@ void Model::UpdateTempGeometry()
 	m_pTempGeometry->Change( m_vTempMeshes );
 }
 
-void Model::Update( float fDelta )
+void Model::UpdateInternal(int32_t tween_delta)
 {
-	Actor::Update( fDelta );
+	Actor::UpdateInternal(tween_delta);
+	float fDelta= tween_time_to_secs(tween_delta);
 	AdvanceFrame( fDelta );
 
 	for( unsigned i = 0; i < m_Materials.size(); ++i )

--- a/src/Model.h
+++ b/src/Model.h
@@ -34,7 +34,7 @@ public:
 	void	SetLoop( bool b ) { m_bLoop = b; }
 	void	SetPosition( float fSeconds );
 
-	virtual void	Update( float fDelta );
+	virtual void	UpdateInternal(int32_t tween_delta);
 	virtual bool	EarlyAbortDraw() const;
 	virtual void	DrawPrimitives();
 

--- a/src/ModsGroup.h
+++ b/src/ModsGroup.h
@@ -38,12 +38,11 @@ public:
 		Call( ModsLevel_Preferred, &T::Init );
 	}
 
-	void Update( float fDelta )
+	void Update()
 	{
 		// Don't let the mod approach speed be affected by Tab.
 		// TODO: Find a more elegant way of handling this.
-		fDelta = m_Timer.GetDeltaTime();
-		m_[ModsLevel_Current].Approach( m_[ModsLevel_Song], fDelta );
+		m_[ModsLevel_Current].Approach(m_[ModsLevel_Song], m_Timer.GetDeltaTime());
 	}
 
 	template<typename U>

--- a/src/NoteDisplay.cpp
+++ b/src/NoteDisplay.cpp
@@ -638,7 +638,7 @@ bool NoteDisplay::DrawRollHeadForTapsOnSameRow() const
 	return cache->m_bDrawRollHeadForTapsOnSameRow;
 }
 
-void NoteDisplay::Update( float fDeltaTime )
+void NoteDisplay::Update(int32_t tween_delta)
 {
 	/* This function is static: it's called once per game loop, not once per
 	 * NoteDisplay.  Update each cached item exactly once. */
@@ -646,7 +646,7 @@ void NoteDisplay::Update( float fDeltaTime )
 	for( it = g_NoteResource.begin(); it != g_NoteResource.end(); ++it )
 	{
 		NoteResource *pRes = it->second;
-		pRes->m_pActor->Update( fDeltaTime );
+		pRes->m_pActor->Update(tween_delta);
 	}
 }
 

--- a/src/NoteDisplay.h
+++ b/src/NoteDisplay.h
@@ -180,7 +180,7 @@ public:
 
 	void Load( int iColNum, const PlayerState* pPlayerState, float fYReverseOffsetPixels );
 
-	static void Update( float fDeltaTime );
+	static void Update(int32_t tween_delta);
 
 	bool IsOnScreen( float fBeat, int iCol, int iDrawDistanceAfterTargetsPixels, int iDrawDistanceBeforeTargetsPixels ) const;
 

--- a/src/NoteField.cpp
+++ b/src/NoteField.cpp
@@ -291,18 +291,18 @@ void NoteField::InitColumnRenderers()
 	m_pCurDisplay->m_GhostArrowRow.SetColumnRenderers(m_ColumnRenderers);
 }
 
-void NoteField::Update( float fDeltaTime )
+void NoteField::UpdateInternal(int32_t tween_delta)
 {
 	if( m_bFirstUpdate )
 	{
 		m_pCurDisplay->m_ReceptorArrowRow.PlayCommand( "On" );
 	}
 
-	ActorFrame::Update( fDeltaTime );
+	ActorFrame::UpdateInternal(tween_delta);
 
 	for(size_t c= 0; c < m_ColumnRenderers.size(); ++c)
 	{
-		m_ColumnRenderers[c].Update(fDeltaTime);
+		m_ColumnRenderers[c].Update(tween_delta);
 	}
 
 	// update m_fBoardOffsetPixels, m_fCurrentBeatLastUpdate, m_fYPosCurrentBeatLastUpdate
@@ -323,27 +323,30 @@ void NoteField::Update( float fDeltaTime )
 	const float fYOffsetCurrent	= ArrowEffects::GetYOffset( m_pPlayerState, 0, m_fCurrentBeatLastUpdate );
 	m_fYPosCurrentBeatLastUpdate	= ArrowEffects::GetYPos(    m_pPlayerState, 0, fYOffsetCurrent, m_fYReverseOffsetPixels );
 
-	m_rectMarkerBar.Update( fDeltaTime );
+	m_rectMarkerBar.Update(tween_delta);
 
 	NoteDisplayCols *cur = m_pCurDisplay;
 
-	cur->m_ReceptorArrowRow.Update( fDeltaTime );
-	cur->m_GhostArrowRow.Update( fDeltaTime );
+	cur->m_ReceptorArrowRow.Update(tween_delta);
+	cur->m_GhostArrowRow.Update(tween_delta);
 
 	if( m_FieldRenderArgs.fail_fade >= 0 )
-		m_FieldRenderArgs.fail_fade = min( m_FieldRenderArgs.fail_fade + fDeltaTime/FADE_FAIL_TIME, 1 );
+	{
+		m_FieldRenderArgs.fail_fade = min(m_FieldRenderArgs.fail_fade +
+			tween_time_to_secs(tween_delta)/FADE_FAIL_TIME, 1);
+	}
 
 	// Update fade to failed
 	m_pCurDisplay->m_ReceptorArrowRow.SetFadeToFailPercent( m_FieldRenderArgs.fail_fade );
 
-	NoteDisplay::Update( fDeltaTime );
+	NoteDisplay::Update(tween_delta);
 	/* Update all NoteDisplays. Hack: We need to call this once per frame, not
 	 * once per player. */
 	// TODO: Remove use of PlayerNumber.
 
 	PlayerNumber pn = m_pPlayerState->m_PlayerNumber;
 	if( pn == GAMESTATE->GetMasterPlayerNumber() )
-		NoteDisplay::Update( fDeltaTime );
+		NoteDisplay::Update(tween_delta);
 }
 
 float NoteField::GetWidth() const

--- a/src/NoteField.h
+++ b/src/NoteField.h
@@ -19,7 +19,7 @@ class NoteField : public ActorFrame
 public:
 	NoteField();
 	~NoteField();
-	virtual void Update( float fDeltaTime );
+	virtual void UpdateInternal(int32_t tween_delta);
 	virtual void DrawPrimitives();
 	void CalcPixelsBeforeAndAfterTargets();
 	void DrawBoardPrimitive();

--- a/src/PercentageDisplay.cpp
+++ b/src/PercentageDisplay.cpp
@@ -131,9 +131,9 @@ void PercentageDisplay::Load( const PlayerState *pPlayerState, const PlayerStage
 	Refresh();
 }
 
-void PercentageDisplay::Update( float fDeltaTime )
+void PercentageDisplay::UpdateInternal(int32_t tween_delta)
 {
-	ActorFrame::Update( fDeltaTime );
+	ActorFrame::UpdateInternal(tween_delta);
 
 	if( m_bAutoRefresh )
 		Refresh();

--- a/src/PercentageDisplay.h
+++ b/src/PercentageDisplay.h
@@ -16,7 +16,7 @@ public:
 	PercentageDisplay();
 	void Load( const PlayerState *pPlayerState, const PlayerStageStats *pPlayerStageStats );
 	void Load( const PlayerState *pPlayerState, const PlayerStageStats *pPlayerStageStats, const RString &sMetricsGroup, bool bAutoRefresh );
-	void Update( float fDeltaTime );
+	void UpdateInternal(int32_t tween_delta);
 	virtual void LoadFromNode( const XNode* pNode );
 	virtual PercentageDisplay *Copy() const;
 

--- a/src/Player.cpp
+++ b/src/Player.cpp
@@ -787,7 +787,7 @@ void Player::SendComboMessages( unsigned int iOldCombo, unsigned int iOldMissCom
 	}
 }
 
-void Player::Update( float fDeltaTime )
+void Player::UpdateInternal(int32_t tween_delta)
 {
 	const RageTimer now;
 	// Don't update if we haven't been loaded yet.
@@ -799,7 +799,7 @@ void Player::Update( float fDeltaTime )
 	if( GAMESTATE->m_pCurSong==NULL || IsOniDead() )
 		return;
 
-	ActorFrame::Update( fDeltaTime );
+	ActorFrame::UpdateInternal(tween_delta);
 
 	if(m_pPlayerState->m_mp != MultiPlayer_Invalid)
 	{
@@ -815,6 +815,8 @@ void Player::Update( float fDeltaTime )
 		if((m_pPlayerState->m_mp % 8) != iCycle)
 			return;
 	}
+
+	float fDeltaTime= tween_time_to_secs(tween_delta);
 
 	const float fSongBeat = m_pPlayerState->m_Position.m_fSongBeat;
 	const int iSongRow = BeatToNoteRow( fSongBeat );

--- a/src/Player.h
+++ b/src/Player.h
@@ -44,7 +44,7 @@ public:
 	Player( NoteData &nd, bool bVisibleParts = true );
 	~Player();
 
-	virtual void Update( float fDeltaTime );
+	virtual void UpdateInternal(int32_t tween_delta);
 	virtual void DrawPrimitives();
 	// PushPlayerMatrix and PopPlayerMatrix are separate functions because
 	// they need to be used twice so that the notefield board can rendered

--- a/src/PlayerAI.cpp
+++ b/src/PlayerAI.cpp
@@ -128,8 +128,8 @@ TapNoteScore PlayerAI::GetTapNoteScore( const PlayerState* pPlayerState )
 	if( !GAMESTATE->m_bDemonstrationOrJukebox )
 	{
 		int iSumOfAttackLevels = 
-			pPlayerState->m_fSecondsUntilAttacksPhasedOut > 0 ? 
-			pPlayerState->m_iLastPositiveSumOfAttackLevels : 
+			pPlayerState->m_time_until_attacks_phased_out > 0 ?
+			pPlayerState->m_iLastPositiveSumOfAttackLevels :
 			0;
 
 		ASSERT_M( iCpuSkill>=0 && iCpuSkill<NUM_SKILL_LEVELS, ssprintf("%i", iCpuSkill) );

--- a/src/PlayerState.cpp
+++ b/src/PlayerState.cpp
@@ -1,4 +1,6 @@
 #include "global.h"
+// Just for secs_to_tween_time.
+#include "Actor.h"
 #include "PlayerState.h"
 #include "Foreach.h"
 #include "GameState.h"
@@ -31,7 +33,7 @@ void PlayerState::Reset()
 	m_iCpuSkill = 5;
 
 	m_iLastPositiveSumOfAttackLevels = 0;
-	m_fSecondsUntilAttacksPhasedOut = 0;
+	m_time_until_attacks_phased_out = 0;
 	m_bAttackBeganThisUpdate = false;
 	m_bAttackEndedThisUpdate = false;
 	m_ActiveAttacks.clear();
@@ -50,7 +52,7 @@ void PlayerState::Reset()
 	ClearHopoState();
 }
 
-void PlayerState::Update( float fDelta )
+void PlayerState::Update(int32_t tween_delta)
 {
 	// TRICKY: GAMESTATE->Update is run before any of the Screen update's,
 	// so we'll clear these flags here and let them get turned on later
@@ -91,10 +93,10 @@ void PlayerState::Update( float fDelta )
 		RebuildPlayerOptionsFromActiveAttacks();
 
 	// Update after enabling attacks, so we approach the new state.
-	m_PlayerOptions.Update( fDelta );
+	m_PlayerOptions.Update();
 
-	if( m_fSecondsUntilAttacksPhasedOut > 0 )
-		m_fSecondsUntilAttacksPhasedOut = max( 0, m_fSecondsUntilAttacksPhasedOut - fDelta );
+	if(m_time_until_attacks_phased_out > 0)
+		m_time_until_attacks_phased_out = max(0, m_time_until_attacks_phased_out - tween_delta);
 }
 
 void PlayerState::SetPlayerNumber(PlayerNumber pn)
@@ -180,12 +182,12 @@ void PlayerState::RebuildPlayerOptionsFromActiveAttacks()
 	if( iSumOfAttackLevels > 0 )
 	{
 		m_iLastPositiveSumOfAttackLevels = iSumOfAttackLevels;
-		m_fSecondsUntilAttacksPhasedOut = 10000;	// any positive number that won't run out before the attacks
+		m_time_until_attacks_phased_out = secs_to_tween_time(2);	// any positive number that won't run out before the attacks
 	}
 	else
 	{
 		// don't change!  m_iLastPositiveSumOfAttackLevels[p] = iSumOfAttackLevels;
-		m_fSecondsUntilAttacksPhasedOut = 2;	// 2 seconds to phase out
+		m_time_until_attacks_phased_out = secs_to_tween_time(2);	// 2 seconds to phase out
 	}
 }
 

--- a/src/PlayerState.h
+++ b/src/PlayerState.h
@@ -35,7 +35,7 @@ public:
 	/** 
 	 * @brief Update the PlayerState based on the present time.
 	 * @param fDelta the current time. */
-	void Update( float fDelta );
+	void Update(int32_t tween_delta);
 
 	void SetPlayerNumber(PlayerNumber pn);
 
@@ -131,7 +131,7 @@ public:
 	// Attacks take a while to transition out of use.  Account for this in PlayerAI
 	// by still penalizing it for 1 second after the player options are rebuilt.
 	int		m_iLastPositiveSumOfAttackLevels;
-	float	m_fSecondsUntilAttacksPhasedOut; // positive means PlayerAI is still affected
+	int32_t m_time_until_attacks_phased_out; // positive means PlayerAI is still affected
 	bool	m_bAttackBeganThisUpdate;	// flag for other objects to watch (play sounds)
 	bool	m_bAttackEndedThisUpdate;	// flag for other objects to watch (play sounds)
 

--- a/src/RageTimer.cpp
+++ b/src/RageTimer.cpp
@@ -63,6 +63,11 @@ uint64_t RageTimer::GetUsecsSinceStart()
 	return GetTime(true) - g_iStartTime;
 }
 
+uint64_t RageTimer::GetRawTime()
+{
+	return GetTime(true);
+}
+
 void RageTimer::Touch()
 {
 	uint64_t usecs = GetTime( true );
@@ -151,6 +156,21 @@ float RageTimer::Difference(const RageTimer &lhs, const RageTimer &rhs)
 
 	return float(secs) + float(us) / TIMESTAMP_RESOLUTION;
 }
+
+DEF_TOT_CALL_END(actor_update);
+DEF_TOT_CALL_PAIR(game_loop_body);
+DEF_TOTAL_TIME(check_focus);
+DEF_TOTAL_TIME(soundman_update);
+DEF_TOTAL_TIME(sound_update);
+DEF_TOTAL_TIME(textureman_update);
+DEF_TOTAL_TIME(gamestate_update);
+DEF_TOTAL_TIME(screenman_update);
+DEF_TOTAL_TIME(memcardman_update);
+DEF_TOTAL_TIME(nsman_update);
+DEF_TOTAL_TIME(handle_input);
+DEF_TOTAL_TIME(devices_changed);
+DEF_TOTAL_TIME(lightsman_update);
+DEF_TOTAL_TIME(screenman_draw);
 
 #include "LuaManager.h"
 LuaFunction(GetTimeSinceStart, RageTimer::GetTimeSinceStartFast())

--- a/src/RageTimer.h
+++ b/src/RageTimer.h
@@ -24,6 +24,7 @@ public:
 	static float GetTimeSinceStart( bool bAccurate = true );	// seconds since the program was started
 	static float GetTimeSinceStartFast() { return GetTimeSinceStart(false); }
 	static uint64_t GetUsecsSinceStart();
+	static uint64_t GetRawTime();
 
 	/* Get a timer representing half of the time ago as this one. */
 	RageTimer Half() const;
@@ -57,6 +58,7 @@ extern const RageTimer RageZeroTimer;
 #define START_TIME_CALL_COUNT(name) START_TIME(name); ++name##_call_count;
 #define END_TIME(name) uint64_t name##_end_time= RageTimer::GetUsecsSinceStart();  LOG->Time(#name " time: %zu to %zu = %zu", name##_start_time, name##_end_time, name##_end_time - name##_start_time);
 #define END_TIME_ADD_TO(name) uint64_t name##_end_time= RageTimer::GetUsecsSinceStart();  name##_total += name##_end_time - name##_start_time;
+#define END_TIME_CALL_COUNT(name) END_TIME_ADD_TO(name); ++name##_end_count;
 
 #define DECL_TOTAL_TIME(name) extern uint64_t name##_total;
 #define DEF_TOTAL_TIME(name) uint64_t name##_total= 0;
@@ -64,6 +66,24 @@ extern const RageTimer RageZeroTimer;
 #define DECL_TOT_CALL_PAIR(name) extern uint64_t name##_total; extern uint64_t name##_call_count;
 #define DEF_TOT_CALL_PAIR(name) uint64_t name##_total= 0; uint64_t name##_call_count= 0;
 #define PRINT_TOT_CALL_PAIR(name) LOG->Time(#name " calls: %zu, time: %zu", name##_call_count, name##_total);
+#define DECL_TOT_CALL_END(name) DECL_TOT_CALL_PAIR(name); extern uint64_t name##_end_count;
+#define DEF_TOT_CALL_END(name) DEF_TOT_CALL_PAIR(name); uint64_t name##_end_count= 0;
+#define PRINT_TOT_CALL_END(name) LOG->Time(#name " calls: %zu, time: %zu, early end: %zu", name##_call_count, name##_total, name##_end_count);
+
+DECL_TOT_CALL_END(actor_update);
+DECL_TOT_CALL_PAIR(game_loop_body);
+DECL_TOTAL_TIME(check_focus);
+DECL_TOTAL_TIME(soundman_update);
+DECL_TOTAL_TIME(sound_update);
+DECL_TOTAL_TIME(textureman_update);
+DECL_TOTAL_TIME(gamestate_update);
+DECL_TOTAL_TIME(screenman_update);
+DECL_TOTAL_TIME(memcardman_update);
+DECL_TOTAL_TIME(nsman_update);
+DECL_TOTAL_TIME(handle_input);
+DECL_TOTAL_TIME(devices_changed);
+DECL_TOTAL_TIME(lightsman_update);
+DECL_TOTAL_TIME(screenman_draw);
 
 #endif
 

--- a/src/RageUtil.cpp
+++ b/src/RageUtil.cpp
@@ -176,6 +176,10 @@ float fmodfp(float x, float y)
 	x = fmodf(x, y);	/* x is [0,y] */
 	return x;
 }
+int32_t mod_positive(int32_t x, int32_t y)
+{
+	return ((x % y) + y) % y;
+}
 
 int power_of_two( int iInput )
 {

--- a/src/RageUtil.h
+++ b/src/RageUtil.h
@@ -343,6 +343,7 @@ void fapproach( float& val, float other_val, float to_move );
 
 /* Return a positive x mod y. */
 float fmodfp( float x, float y );
+int32_t mod_positive(int32_t x, int32_t y);
 
 int power_of_two( int input );
 bool IsAnInt( const RString &s );

--- a/src/ReceptorArrow.cpp
+++ b/src/ReceptorArrow.cpp
@@ -38,9 +38,9 @@ void ReceptorArrow::Load( const PlayerState* pPlayerState, int iColNo )
 	m_bWasReverse = bReverse;
 }
 
-void ReceptorArrow::Update( float fDeltaTime )
+void ReceptorArrow::UpdateInternal(int32_t tween_delta)
 {
-	ActorFrame::Update( fDeltaTime );
+	ActorFrame::UpdateInternal(tween_delta);
 
 	bool bReverse = m_pPlayerState->m_PlayerOptions.GetCurrent().GetReversePercentForColumn(m_iColNo) > 0.5f;
 	if( bReverse != m_bWasReverse )

--- a/src/ReceptorArrow.h
+++ b/src/ReceptorArrow.h
@@ -15,7 +15,7 @@ public:
 	void Load( const PlayerState* pPlayerState, int iColNo );
 
 	virtual void DrawPrimitives();
-	virtual void Update( float fDeltaTime );
+	virtual void UpdateInternal(int32_t tween_delta);
 	void Step( TapNoteScore score );
 	void SetPressed() { m_bIsPressed = true; };
 	void SetNoteUpcoming( bool b );

--- a/src/ReceptorArrowRow.cpp
+++ b/src/ReceptorArrowRow.cpp
@@ -47,9 +47,9 @@ ReceptorArrowRow::~ReceptorArrowRow()
 		delete m_ReceptorArrow[i];
 }
 
-void ReceptorArrowRow::Update( float fDeltaTime )
+void ReceptorArrowRow::UpdateInternal(int32_t tween_delta)
 {
-	ActorFrame::Update( fDeltaTime );
+	ActorFrame::UpdateInternal(tween_delta);
 	ArrowEffects::Update();
 
 	for( unsigned c=0; c<m_ReceptorArrow.size(); c++ )

--- a/src/ReceptorArrowRow.h
+++ b/src/ReceptorArrowRow.h
@@ -13,7 +13,7 @@ class ReceptorArrowRow : public ActorFrame
 public:
 	ReceptorArrowRow();
 	virtual ~ReceptorArrowRow();
-	virtual void Update( float fDeltaTime );
+	virtual void UpdateInternal(int32_t tween_delta);
 	virtual void DrawPrimitives();
 
 	void Load( const PlayerState* pPlayerState, float fYReverseOffset );

--- a/src/RollingNumbers.cpp
+++ b/src/RollingNumbers.cpp
@@ -86,15 +86,16 @@ void RollingNumbers::DrawPrimitives()
 	m_pTempState->crop.right= original_crop_right;
 }
 
-void RollingNumbers::Update( float fDeltaTime )
+void RollingNumbers::UpdateInternal(int32_t tween_delta)
 {
 	if(m_fCurrentNumber != m_fTargetNumber)
 	{
-		fapproach( m_fCurrentNumber, m_fTargetNumber, fabsf(m_fScoreVelocity) * fDeltaTime );
+		fapproach(m_fCurrentNumber, m_fTargetNumber, fabsf(m_fScoreVelocity) *
+			tween_time_to_secs(tween_delta));
 		UpdateText();
 	}
 
-	BitmapText::Update( fDeltaTime );
+	BitmapText::UpdateInternal(tween_delta);
 }
 
 void RollingNumbers::SetTargetNumber( float fTargetNumber )

--- a/src/RollingNumbers.h
+++ b/src/RollingNumbers.h
@@ -16,7 +16,7 @@ public:
 	void DrawPart(RageColor const* diffuse, RageColor const& stroke,
 		float crop_left, float crop_right);
 	virtual void DrawPrimitives();
-	virtual void Update( float fDeltaTime );
+	virtual void UpdateInternal(int32_t tween_delta);
 
 	/** 
 	 * @brief Set the new target number to be reached.

--- a/src/RoomInfoDisplay.cpp
+++ b/src/RoomInfoDisplay.cpp
@@ -134,14 +134,14 @@ void RoomInfoDisplay::SetRoom( const RoomWheelItemData* roomData )
 	m_Desc.SetText( ROOM_DESC.GetValue() + roomData->m_sDesc );
 }
 
-void RoomInfoDisplay::Update( float fDeltaTime )
+void RoomInfoDisplay::UpdateInternal(int32_t tween_delta)
 {
 	if ((m_deployDelay.PeekDeltaTime() >= DEPLOY_DELAY) && (m_deployDelay.PeekDeltaTime() < (DEPLOY_DELAY + RETRACT_DELAY)))
 		DeployInfoBox();
 	else if (m_deployDelay.PeekDeltaTime() >= DEPLOY_DELAY + RETRACT_DELAY)
 		RetractInfoBox();
 
-	ActorFrame::Update(fDeltaTime);
+	ActorFrame::UpdateInternal(tween_delta);
 }
 
 void RoomInfoDisplay::RequestRoomInfo(const RString& name)

--- a/src/RoomInfoDisplay.h
+++ b/src/RoomInfoDisplay.h
@@ -12,7 +12,7 @@ public:
 	RoomInfoDisplay();
 	~RoomInfoDisplay();
 	virtual void Load( RString sType );
-	virtual void Update( float fDeltaTime );
+	virtual void UpdateInternal(int32_t tween_delta);
 	void SetRoom( const RoomWheelItemData* roomData );
 	void SetRoomInfo( const RoomInfo& info);
 	void DeployInfoBox();

--- a/src/ScoreDisplayAliveTime.cpp
+++ b/src/ScoreDisplayAliveTime.cpp
@@ -37,10 +37,10 @@ void ScoreDisplayAliveTime::LoadFromNode( const XNode* pNode )
 	}
 }
 
-void ScoreDisplayAliveTime::Update( float fDelta )
+void ScoreDisplayAliveTime::UpdateInternal(int32_t tween_delta)
 {
 	UpdateNumber();
-	BitmapText::Update( fDelta );
+	BitmapText::UpdateInternal(tween_delta);
 }
 
 void ScoreDisplayAliveTime::HandleMessage( const Message &msg )

--- a/src/ScoreDisplayAliveTime.h
+++ b/src/ScoreDisplayAliveTime.h
@@ -15,7 +15,7 @@ public:
 	ScoreDisplayAliveTime();
 	~ScoreDisplayAliveTime();
 
-	virtual void Update( float fDelta );
+	virtual void UpdateInternal(int32_t tween_delta);
 
 	void LoadFromNode( const XNode* pNode );
 	virtual ScoreDisplayAliveTime *Copy() const;

--- a/src/ScoreDisplayBattle.cpp
+++ b/src/ScoreDisplayBattle.cpp
@@ -36,9 +36,9 @@ void ScoreDisplayBattle::Init( const PlayerState* pPlayerState, const PlayerStag
 	ScoreDisplay::Init( pPlayerState, pPlayerStageStats );
 }
 
-void ScoreDisplayBattle::Update( float fDelta )
+void ScoreDisplayBattle::UpdateInternal(int32_t tween_delta)
 {
-	ScoreDisplay::Update( fDelta );
+	ScoreDisplay::UpdateInternal(tween_delta);
 
 	for( int s=0; s<NUM_INVENTORY_SLOTS; s++ )
 	{

--- a/src/ScoreDisplayBattle.h
+++ b/src/ScoreDisplayBattle.h
@@ -13,7 +13,7 @@ public:
 	ScoreDisplayBattle();
 	virtual void Init( const PlayerState* pPlayerState, const PlayerStageStats* pPlayerStageStats );
 
-	virtual void Update( float fDelta );
+	virtual void UpdateInternal(int32_t tween_delta);
 
 protected:
 	Sprite	m_sprFrame;

--- a/src/ScoreDisplayCalories.cpp
+++ b/src/ScoreDisplayCalories.cpp
@@ -37,14 +37,14 @@ void ScoreDisplayCalories::LoadFromNode( const XNode* pNode )
 	MESSAGEMAN->Subscribe( this, "Step" );
 }
 
-void ScoreDisplayCalories::Update( float fDelta )
+void ScoreDisplayCalories::UpdateInternal(int32_t tween_delta)
 {
 	// We have to set the initial text after StatsManager::CalcAccumPlayedStageStats
 	// is called.
 	if( IsFirstUpdate() )
 		UpdateNumber();
 
-	RollingNumbers::Update( fDelta );
+	RollingNumbers::UpdateInternal(tween_delta);
 }
 
 void ScoreDisplayCalories::HandleMessage( const Message &msg )

--- a/src/ScoreDisplayCalories.h
+++ b/src/ScoreDisplayCalories.h
@@ -11,7 +11,7 @@ public:
 	ScoreDisplayCalories();
 	~ScoreDisplayCalories();
 
-	virtual void Update( float fDelta );
+	virtual void UpdateInternal(int32_t tween_delta);
 
 	void LoadFromNode( const XNode* pNode );
 	virtual ScoreDisplayCalories *Copy() const;

--- a/src/ScoreDisplayLifeTime.cpp
+++ b/src/ScoreDisplayLifeTime.cpp
@@ -49,9 +49,9 @@ void ScoreDisplayLifeTime::Init( const PlayerState* pPlayerState, const PlayerSt
 	}
 }
 
-void ScoreDisplayLifeTime::Update( float fDelta )
+void ScoreDisplayLifeTime::UpdateInternal(int32_t tween_delta)
 {
-	ScoreDisplay::Update( fDelta );
+	ScoreDisplay::UpdateInternal(tween_delta);
 
 	float fSecs = m_pPlayerStageStats->m_fLifeRemainingSeconds;
 

--- a/src/ScoreDisplayLifeTime.h
+++ b/src/ScoreDisplayLifeTime.h
@@ -16,7 +16,7 @@ public:
 
 	virtual void Init( const PlayerState* pPlayerState, const PlayerStageStats* pPlayerStageStats );
 
-	virtual void Update( float fDelta );
+	virtual void UpdateInternal(int32_t tween_delta);
 
 	virtual void OnLoadSong();
 	virtual void OnJudgment( TapNoteScore score );

--- a/src/ScoreDisplayOni.cpp
+++ b/src/ScoreDisplayOni.cpp
@@ -30,9 +30,9 @@ void ScoreDisplayOni::Init( const PlayerState* pPlayerState, const PlayerStageSt
 }
 
 
-void ScoreDisplayOni::Update( float fDelta )
+void ScoreDisplayOni::UpdateInternal(int32_t tween_delta)
 {
-	ScoreDisplay::Update( fDelta );
+	ScoreDisplay::UpdateInternal(tween_delta);
 
 	// TODO: Remove use of PlayerNumber.
 	PlayerNumber pn = m_pPlayerState->m_PlayerNumber;

--- a/src/ScoreDisplayOni.h
+++ b/src/ScoreDisplayOni.h
@@ -13,7 +13,7 @@ public:
 
 	virtual void Init( const PlayerState* pPlayerState, const PlayerStageStats* pPlayerStageStats );
 
-	virtual void Update( float fDelta );
+	virtual void UpdateInternal(int32_t tween_delta);
 
 protected:
 	Sprite		m_sprFrame;

--- a/src/ScoreDisplayRave.cpp
+++ b/src/ScoreDisplayRave.cpp
@@ -51,9 +51,9 @@ void ScoreDisplayRave::Init( const PlayerState* pPlayerState, const PlayerStageS
 	this->AddChild( m_sprFrameOverlay );
 }
 
-void ScoreDisplayRave::Update( float fDelta )
+void ScoreDisplayRave::UpdateInternal(int32_t tween_delta)
 {
-	ScoreDisplay::Update( fDelta );
+	ScoreDisplay::UpdateInternal(tween_delta);
 
 	float fLevel = m_pPlayerState->m_fSuperMeter;
 	AttackLevel level = (AttackLevel)(int)fLevel;

--- a/src/ScoreDisplayRave.h
+++ b/src/ScoreDisplayRave.h
@@ -14,7 +14,7 @@ public:
 	ScoreDisplayRave();
 	virtual void Init( const PlayerState* pPlayerState, const PlayerStageStats* pPlayerStageStats );
 
-	virtual void Update( float fDelta );
+	virtual void UpdateInternal(int32_t tween_delta);
 
 protected:
 	AutoActor m_sprFrameBase;

--- a/src/ScoreKeeperNormal.cpp
+++ b/src/ScoreKeeperNormal.cpp
@@ -515,8 +515,9 @@ void ScoreKeeperNormal::HandleTapRowScore( const NoteData &nd, int iRow )
 	{
 	case TNS_W1:
 	case TNS_W2:
-		m_iCurToastyCombo += iNumTapsInRow;
-
+		// TODO:  Come up with a design for the theme to list a set of milestone
+		// values?  Current behavior is to just happen at multiples of
+		// m_ToastyTrigger.  -Kyz
 		/*
 		// compile the list of toasty triggers
 		{
@@ -536,21 +537,25 @@ void ScoreKeeperNormal::HandleTapRowScore( const NoteData &nd, int iRow )
 			m_iNextToastyAt = -1;
 		}
 		*/
-
-		if( m_iCurToastyCombo >= m_ToastyTrigger &&
-			m_iCurToastyCombo - iNumTapsInRow < m_ToastyTrigger &&
-			!GAMESTATE->m_bDemonstrationOrJukebox )
 		{
-			SCREENMAN->PostMessageToTopScreen( SM_PlayToasty, 0 );
-			Message msg("ToastyAchieved");
-			msg.SetParam( "PlayerNumber", m_pPlayerState->m_PlayerNumber );
-			msg.SetParam( "ToastyCombo", m_iCurToastyCombo );
-			MESSAGEMAN->Broadcast(msg);
+			int old_toastiness= m_iCurToastyCombo / m_ToastyTrigger;
+			m_iCurToastyCombo += iNumTapsInRow;
+			int new_toastiness= m_iCurToastyCombo / m_ToastyTrigger;
+			if(new_toastiness > old_toastiness &&
+				!GAMESTATE->m_bDemonstrationOrJukebox)
+			{
+				SCREENMAN->PostMessageToTopScreen( SM_PlayToasty, 0 );
+				Message msg("ToastyAchieved");
+				msg.SetParam( "PlayerNumber", m_pPlayerState->m_PlayerNumber );
+				msg.SetParam( "ToastyCombo", m_iCurToastyCombo );
+				msg.SetParam( "Level", new_toastiness );
+				MESSAGEMAN->Broadcast(msg);
 
-			// TODO: keep a pointer to the Profile.  Don't index with m_PlayerNumber
-			PROFILEMAN->IncrementToastiesCount( m_pPlayerState->m_PlayerNumber );
+				// TODO: keep a pointer to the Profile.  Don't index with m_PlayerNumber
+				PROFILEMAN->IncrementToastiesCount( m_pPlayerState->m_PlayerNumber );
 
-			//m_iCurToastyTrigger++;
+				//m_iCurToastyTrigger++;
+			}
 		}
 		break;
 	default:

--- a/src/Screen.cpp
+++ b/src/Screen.cpp
@@ -105,10 +105,10 @@ void Screen::EndScreen()
 	m_bRunning = false;
 }
 
-void Screen::Update( float fDeltaTime )
+void Screen::UpdateInternal(int32_t tween_delta)
 {
-	ActorFrame::Update( fDeltaTime );
-	
+	ActorFrame::UpdateInternal(tween_delta);
+	float fDeltaTime= tween_time_to_secs(tween_delta);
 	m_fLockInputSecs = max( 0, m_fLockInputSecs-fDeltaTime );
 
 	/* We need to ensure two things:

--- a/src/Screen.h
+++ b/src/Screen.h
@@ -58,7 +58,7 @@ public:
 	/** @brief This is called when the screen is popped. */
 	virtual void EndScreen();
 
-	virtual void Update( float fDeltaTime );
+	virtual void UpdateInternal(int32_t tween_delta);
 	virtual bool Input( const InputEventPlus &input );
 	virtual void HandleScreenMessage( const ScreenMessage SM );
 	void SetLockInputSecs( float f ) { m_fLockInputSecs = f; }

--- a/src/ScreenBookkeeping.cpp
+++ b/src/ScreenBookkeeping.cpp
@@ -61,11 +61,11 @@ void ScreenBookkeeping::Init()
 	UpdateView();
 }
 
-void ScreenBookkeeping::Update( float fDelta )
+void ScreenBookkeeping::UpdateInternal(int32_t tween_delta)
 {
 	UpdateView();	// refresh so that counts change in real-time
 
-	ScreenWithMenuElements::Update( fDelta );
+	ScreenWithMenuElements::UpdateInternal(tween_delta);
 }
 
 bool ScreenBookkeeping::Input( const InputEventPlus &input )

--- a/src/ScreenBookkeeping.h
+++ b/src/ScreenBookkeeping.h
@@ -24,7 +24,7 @@ class ScreenBookkeeping : public ScreenWithMenuElements
 public:
 	virtual void Init();
 
-	virtual void Update( float fDelta );
+	virtual void UpdateInternal(int32_t tween_delta);
 	virtual bool Input( const InputEventPlus &input );
 
 	virtual bool MenuLeft( const InputEventPlus &input );

--- a/src/ScreenDebugOverlay.cpp
+++ b/src/ScreenDebugOverlay.cpp
@@ -305,7 +305,7 @@ void ScreenDebugOverlay::Init()
 	this->SetVisible( false );
 }
 
-void ScreenDebugOverlay::Update( float fDeltaTime )
+void ScreenDebugOverlay::UpdateInternal(int32_t tween_delta)
 {
 	{
 		float fRate = 1;
@@ -330,7 +330,7 @@ void ScreenDebugOverlay::Update( float fDeltaTime )
 	}
 
 	bool bCenteringNeedsUpdate = g_fImageScaleCurrent != g_fImageScaleDestination;
-	fapproach( g_fImageScaleCurrent, g_fImageScaleDestination, fDeltaTime );
+	fapproach(g_fImageScaleCurrent, g_fImageScaleDestination, tween_time_to_secs(tween_delta));
 	if( bCenteringNeedsUpdate )
 	{
 		DISPLAY->ChangeCentering(
@@ -340,7 +340,7 @@ void ScreenDebugOverlay::Update( float fDeltaTime )
 			PREFSMAN->m_fCenterImageAddHeight - (int)SCREEN_HEIGHT + (int)(g_fImageScaleCurrent*SCREEN_HEIGHT) );
 	}
 
-	Screen::Update(fDeltaTime);
+	Screen::UpdateInternal(tween_delta);
 
 	this->SetVisible( g_bIsDisplayed && !m_bForcedHidden );
 	if( !g_bIsDisplayed )

--- a/src/ScreenDebugOverlay.h
+++ b/src/ScreenDebugOverlay.h
@@ -18,7 +18,7 @@ public:
 
 	bool Input( const InputEventPlus &input );
 
-	void Update( float fDeltaTime );
+	void UpdateInternal(int32_t tween_delta);
 
 private:
 	void UpdateText();

--- a/src/ScreenEdit.cpp
+++ b/src/ScreenEdit.cpp
@@ -1633,9 +1633,9 @@ void ScreenEdit::EditMiniMenu( const MenuDef* pDef, ScreenMessage SM_SendOnOK, S
 	ScreenMiniMenu::MiniMenu( &menu, SM_SendOnOK, SM_SendOnCancel );
 }
 
-void ScreenEdit::Update( float fDeltaTime )
+void ScreenEdit::UpdateInternal(int32_t tween_delta)
 {
-	m_PlayerStateEdit.Update( fDeltaTime );
+	m_PlayerStateEdit.Update(tween_delta);
 
 	if( m_pSoundMusic->IsPlaying() )
 	{
@@ -1740,17 +1740,17 @@ void ScreenEdit::Update( float fDeltaTime )
 	}
 
 	//LOG->Trace( "ScreenEdit::Update(%f)", fDeltaTime );
-	ScreenWithMenuElements::Update( fDeltaTime );
+	ScreenWithMenuElements::UpdateInternal(tween_delta);
 
 
 	// Update trailing beat
 	float fDelta = GetBeat() - m_fTrailingBeat;
 	if( fabsf(fDelta) < 10 )
 		fapproach( m_fTrailingBeat, GetBeat(),
-			fDeltaTime*40 / m_NoteFieldEdit.GetPlayerState()->m_PlayerOptions.GetCurrent().m_fScrollSpeed );
+			tween_time_to_secs(tween_delta)*40 / m_NoteFieldEdit.GetPlayerState()->m_PlayerOptions.GetCurrent().m_fScrollSpeed );
 	else
 		fapproach( m_fTrailingBeat, GetBeat(),
-			fabsf(fDelta) * fDeltaTime*5 );
+			fabsf(fDelta) * tween_time_to_secs(tween_delta)*5 );
 
 	PlayTicks();
 }

--- a/src/ScreenEdit.h
+++ b/src/ScreenEdit.h
@@ -207,7 +207,7 @@ public:
 	virtual void EndScreen();
 
 	virtual ~ScreenEdit();
-	virtual void Update( float fDeltaTime );
+	virtual void UpdateInternal(int32_t tween_delta);
 	virtual void DrawPrimitives();
 	virtual bool Input( const InputEventPlus &input );
 	bool InputEdit( const InputEventPlus &input, EditButton EditB );

--- a/src/ScreenGameplay.cpp
+++ b/src/ScreenGameplay.cpp
@@ -1649,27 +1649,28 @@ void ScreenGameplay::GetMusicEndTiming( float &fSecondsToStartFadingOutMusic, fl
 	fSecondsToStartTransitioningOut = max( fSecondsToStartTransitioningOut, fSecondsToStartFadingOutMusic + MUSIC_FADE_OUT_SECONDS - fTransitionLength );
 }
 
-void ScreenGameplay::Update( float fDeltaTime )
+void ScreenGameplay::UpdateInternal(int32_t tween_delta)
 {
 	if( GAMESTATE->m_pCurSong == NULL  )
 	{
 		/* ScreenDemonstration will move us to the next screen.  We just need to
 		 * survive for one update without crashing.  We need to call Screen::Update
 		 * to make sure we receive the next-screen message. */
-		Screen::Update( fDeltaTime );
+		Screen::UpdateInternal(tween_delta);
 		return;
 	}
 
+	float fDeltaTime= tween_time_to_secs(tween_delta);
 	UpdateSongPosition( fDeltaTime );
 
 	if( m_bZeroDeltaOnNextUpdate )
 	{
-		Screen::Update( 0 );
+		Screen::UpdateInternal( 0 );
 		m_bZeroDeltaOnNextUpdate = false;
 	}
 	else
 	{
-		Screen::Update( fDeltaTime );
+		Screen::UpdateInternal(tween_delta);
 	}
 
 	/* This happens if ScreenDemonstration::HandleScreenMessage sets a new screen when
@@ -2874,10 +2875,11 @@ void ScreenGameplay::HandleScreenMessage( const ScreenMessage SM )
 	}
 	else if( SM == SM_PlayToasty )
 	{
-		// todo: make multiple toasties work -aj
 		if( g_bEasterEggs )
-			if( !m_Toasty.IsTransitioning()  &&  !m_Toasty.IsFinished() )	// don't play if we've already played it once
-				m_Toasty.StartTransitioning();
+		{
+			m_Toasty.Reset();
+			m_Toasty.StartTransitioning();
+		}
 	}
 	else if( ScreenMessageHelpers::ScreenMessageToString(SM).find("0Combo") != string::npos )
 	{

--- a/src/ScreenGameplay.h
+++ b/src/ScreenGameplay.h
@@ -146,7 +146,7 @@ public:
 	virtual ~ScreenGameplay();
 	virtual void BeginScreen();
 
-	virtual void Update( float fDeltaTime );
+	virtual void UpdateInternal(int32_t tween_delta);
 	virtual bool Input( const InputEventPlus &input );
 	virtual void HandleScreenMessage( const ScreenMessage SM );
 	virtual void HandleMessage( const Message &msg );

--- a/src/ScreenGameplaySyncMachine.cpp
+++ b/src/ScreenGameplaySyncMachine.cpp
@@ -63,9 +63,9 @@ void ScreenGameplaySyncMachine::Init()
 	RefreshText();
 }
 
-void ScreenGameplaySyncMachine::Update( float fDelta )
+void ScreenGameplaySyncMachine::UpdateInternal(int32_t tween_delta)
 {
-	ScreenGameplayNormal::Update( fDelta );
+	ScreenGameplayNormal::UpdateInternal(tween_delta);
 	RefreshText();
 }
 

--- a/src/ScreenGameplaySyncMachine.h
+++ b/src/ScreenGameplaySyncMachine.h
@@ -9,7 +9,7 @@ class ScreenGameplaySyncMachine : public ScreenGameplayNormal
 public:
 	virtual void Init();
 
-	virtual void Update( float fDelta );
+	virtual void UpdateInternal(int32_t tween_delta);
 	virtual bool Input( const InputEventPlus &input );
 
 	virtual ScreenType GetScreenType() const { return system_menu; }

--- a/src/ScreenHowToPlay.cpp
+++ b/src/ScreenHowToPlay.cpp
@@ -242,13 +242,13 @@ void ScreenHowToPlay::Step()
 	}
 }
 
-void ScreenHowToPlay::Update( float fDelta )
+void ScreenHowToPlay::UpdateInternal(int32_t tween_delta)
 {
 	if( GAMESTATE->m_pCurSong != NULL )
 	{
 		RageTimer tm;
 		GAMESTATE->UpdateSongPosition( m_fFakeSecondsIntoSong, GAMESTATE->m_pCurSong->m_SongTiming, tm );
-		m_fFakeSecondsIntoSong += fDelta;
+		m_fFakeSecondsIntoSong += tween_time_to_secs(tween_delta);
 
 		static int iLastNoteRowCounted = 0;
 		int iCurNoteRow = BeatToNoteRowNotRounded( GAMESTATE->m_Position.m_fSongBeat );
@@ -282,7 +282,7 @@ void ScreenHowToPlay::Update( float fDelta )
 		}
 	}
 
-	ScreenAttract::Update( fDelta );
+	ScreenAttract::UpdateInternal(tween_delta);
 }
 
 void ScreenHowToPlay::HandleScreenMessage( const ScreenMessage SM )

--- a/src/ScreenHowToPlay.h
+++ b/src/ScreenHowToPlay.h
@@ -15,7 +15,7 @@ public:
 	virtual void Init();
 	~ScreenHowToPlay();
 
-	virtual void Update( float fDelta );
+	virtual void UpdateInternal(int32_t tween_delta);
 	virtual void HandleScreenMessage( const ScreenMessage SM );
 
 	// Lua

--- a/src/ScreenInstallOverlay.cpp
+++ b/src/ScreenInstallOverlay.cpp
@@ -337,9 +337,10 @@ bool ScreenInstallOverlay::Input( const InputEventPlus &input )
 	return Screen::Input(input);
 }
 
-void ScreenInstallOverlay::Update( float fDeltaTime )
+void ScreenInstallOverlay::UpdateInternal(int32_t tween_delta)
 {
-	Screen::Update(fDeltaTime);
+	Screen::UpdateInternal(tween_delta);
+	float fDeltaTime= tween_time_to_secs(tween_delta);
 	PlayAfterLaunchInfo playAfterLaunchInfo;
 	while( CommandLineActions::ToProcess.size() > 0 )
 	{

--- a/src/ScreenInstallOverlay.h
+++ b/src/ScreenInstallOverlay.h
@@ -12,7 +12,7 @@ public:
 	virtual ~ScreenInstallOverlay();
 	virtual void Init();
 
-	void Update( float fDeltaTime );
+	void UpdateInternal(int32_t tween_delta);
 	bool Input( const InputEventPlus &input );
 
 private:

--- a/src/ScreenManager.cpp
+++ b/src/ScreenManager.cpp
@@ -404,7 +404,7 @@ ScreenMessage ScreenManager::PopTopScreenInternal( bool bSendLoseFocus )
 	return ls.m_SendOnPop;
 }
 
-void ScreenManager::Update( float fDeltaTime )
+void ScreenManager::Update(int32_t delta_time)
 {
 	// Pop the top screen, if PopTopScreen was called.
 	if( m_PopTopScreen != SM_Invalid )
@@ -442,20 +442,20 @@ void ScreenManager::Update( float fDeltaTime )
 	 * animations don't jump. */
 	if( pScreen && m_bZeroNextUpdate )
 	{
-		LOG->Trace( "Zeroing this update.  Was %f", fDeltaTime );
-		fDeltaTime = 0;
+		LOG->Trace( "Zeroing this update.  Was %zu", delta_time );
+		delta_time = 0;
 		m_bZeroNextUpdate = false;
 	}
 
 	// Update screens.
 	{
 		for( unsigned i=0; i<g_ScreenStack.size(); i++ )
-			g_ScreenStack[i].m_pScreen->Update( fDeltaTime );
+			g_ScreenStack[i].m_pScreen->Update(delta_time);
 
-		g_pSharedBGA->Update( fDeltaTime );
+		g_pSharedBGA->Update(delta_time);
 
 		for( unsigned i=0; i<g_OverlayScreens.size(); i++ )
-			g_OverlayScreens[i]->Update( fDeltaTime );	
+			g_OverlayScreens[i]->Update(delta_time);
 	}
 
 	/* The music may be started on the first update. If we're reading from a CD,

--- a/src/ScreenManager.h
+++ b/src/ScreenManager.h
@@ -17,7 +17,7 @@ public:
 	~ScreenManager();
 
 	// pass these messages along to the current state
-	void Update( float fDeltaTime );
+	void Update(int32_t delta_time);
 	void Draw();
 	void Input( const InputEventPlus &input );
 

--- a/src/ScreenMapControllers.cpp
+++ b/src/ScreenMapControllers.cpp
@@ -231,9 +231,10 @@ void ScreenMapControllers::BeginScreen()
 }
 
 
-void ScreenMapControllers::Update( float fDeltaTime )
+void ScreenMapControllers::UpdateInternal(int32_t tween_delta)
 {
-	ScreenWithMenuElements::Update( fDeltaTime );
+	ScreenWithMenuElements::UpdateInternal(tween_delta);
+	float fDeltaTime= tween_time_to_secs(tween_delta);
 
 	if(m_fLockInputSecs <= 0.0f)
 	{

--- a/src/ScreenMapControllers.h
+++ b/src/ScreenMapControllers.h
@@ -17,7 +17,7 @@ public:
 	virtual void Init();
 	virtual void BeginScreen();
 
-	virtual void Update( float fDeltaTime );
+	virtual void UpdateInternal(int32_t tween_delta);
 	virtual bool Input( const InputEventPlus &input );
 	virtual void HandleMessage( const Message &msg );
 	virtual void HandleScreenMessage( const ScreenMessage SM );

--- a/src/ScreenNameEntry.cpp
+++ b/src/ScreenNameEntry.cpp
@@ -325,15 +325,15 @@ bool ScreenNameEntry::AnyStillEntering() const
 	return false;
 }
 
-void ScreenNameEntry::Update( float fDelta )
+void ScreenNameEntry::UpdateInternal(int32_t tween_delta)
 {
 	if( m_bFirstUpdate )
 		SOUND->PlayOnceFromDir( ANNOUNCER->GetPathTo("name entry") );
 
-	m_fFakeBeat += fDelta * FAKE_BEATS_PER_SEC;
+	m_fFakeBeat += tween_time_to_secs(tween_delta) * FAKE_BEATS_PER_SEC;
 	GAMESTATE->m_Position.m_fSongBeat = m_fFakeBeat;
 
-	ScreenWithMenuElements::Update(fDelta);
+	ScreenWithMenuElements::UpdateInternal(tween_delta);
 }
 
 bool ScreenNameEntry::Input( const InputEventPlus &input )

--- a/src/ScreenNameEntry.h
+++ b/src/ScreenNameEntry.h
@@ -12,7 +12,7 @@ class ScreenNameEntry : public ScreenWithMenuElements
 public:
 	ScreenNameEntry();
 	virtual void Init();
-	virtual void Update( float fDeltaTime );
+	virtual void UpdateInternal(int32_t tween_delta);
 	virtual bool Input( const InputEventPlus &input );
 	virtual void HandleScreenMessage( const ScreenMessage SM );
 

--- a/src/ScreenNetSelectMusic.cpp
+++ b/src/ScreenNetSelectMusic.cpp
@@ -557,14 +557,14 @@ void ScreenNetSelectMusic::MusicChanged()
 	}
 }
 
-void ScreenNetSelectMusic::Update( float fDeltaTime )
+void ScreenNetSelectMusic::UpdateInternal(int32_t tween_delta)
 {
 	if(!m_bInitialSelect)
 	{
 		m_bInitialSelect = true;
 		SCREENMAN->PostMessageToTopScreen( SM_RefreshWheelLocation, 1.0f );
 	}
-	ScreenNetSelectBase::Update( fDeltaTime );
+	ScreenNetSelectBase::UpdateInternal(tween_delta);
 }
 
 #endif

--- a/src/ScreenNetSelectMusic.h
+++ b/src/ScreenNetSelectMusic.h
@@ -32,7 +32,7 @@ protected:
 	virtual bool MenuDown( const InputEventPlus &input );
 	bool LeftAndRightPressed( const PlayerNumber pn );
 
-	virtual void Update( float fDeltaTime );
+	virtual void UpdateInternal(int32_t tween_delta);
 
 	void MusicChanged();
 

--- a/src/ScreenOptions.cpp
+++ b/src/ScreenOptions.cpp
@@ -486,11 +486,11 @@ void ScreenOptions::TweenCursor( PlayerNumber pn )
 	}
 }
 
-void ScreenOptions::Update( float fDeltaTime )
+void ScreenOptions::UpdateInternal(int32_t tween_delta)
 {
 	//LOG->Trace( "ScreenOptions::Update(%f)", fDeltaTime );
 
-	ScreenWithMenuElements::Update( fDeltaTime );
+	ScreenWithMenuElements::UpdateInternal(tween_delta);
 }
 
 bool ScreenOptions::Input( const InputEventPlus &input )

--- a/src/ScreenOptions.h
+++ b/src/ScreenOptions.h
@@ -39,7 +39,7 @@ public:
 	virtual void BeginScreen();
 	void InitMenu( const vector<OptionRowHandler*> &vHands );
 	virtual ~ScreenOptions();
-	virtual void Update( float fDeltaTime );
+	virtual void UpdateInternal(int32_t tween_delta);
 	virtual bool Input( const InputEventPlus &input );
 	virtual void HandleScreenMessage( const ScreenMessage SM );
 

--- a/src/ScreenPackages.cpp
+++ b/src/ScreenPackages.cpp
@@ -140,11 +140,11 @@ void ScreenPackages::HandleScreenMessage( const ScreenMessage SM )
 }
 
 static LocalizedString DOWNLOAD_PROGRESS( "ScreenPackages", "DL @ %d KB/s" );
-void ScreenPackages::Update( float fDeltaTime )
+void ScreenPackages::UpdateInternal(int32_t tween_delta)
 {
 	HTTPUpdate();
 
-	m_fLastUpdate += fDeltaTime;
+	m_fLastUpdate += tween_time_to_secs(tween_delta);
 	if ( m_fLastUpdate >= 1.0 )
 	{
 		if ( m_bIsDownloading && m_bGotHeader )
@@ -155,7 +155,7 @@ void ScreenPackages::Update( float fDeltaTime )
 		m_fLastUpdate = 0;
 	}
 
-	ScreenWithMenuElements::Update(fDeltaTime);
+	ScreenWithMenuElements::UpdateInternal(tween_delta);
 }
 
 static LocalizedString ENTER_URL ("ScreenPackages","Enter URL");

--- a/src/ScreenPackages.h
+++ b/src/ScreenPackages.h
@@ -26,7 +26,7 @@ public:
 	virtual bool MenuBack( const InputEventPlus &input );
 
 	virtual void TweenOffScreen( );
-	virtual void Update(float f);
+	virtual void UpdateInternal(int32_t tween_delta);
 
 protected:
 	ThemeMetric<float> EXISTINGBG_WIDTH; // "PackagesBGWidth"

--- a/src/ScreenReloadSongs.cpp
+++ b/src/ScreenReloadSongs.cpp
@@ -66,9 +66,9 @@ ScreenReloadSongs::~ScreenReloadSongs()
 	delete m_pLoadingWindow;
 }
 
-void ScreenReloadSongs::Update( float fDeltaTime )
+void ScreenReloadSongs::UpdateInternal(int32_t tween_delta)
 {
-	Screen::Update( fDeltaTime );
+	Screen::UpdateInternal(tween_delta);
 
 	/* Start the reload on the second update. On the first (0), SCREENMAN->Draw won't draw. */
 	++m_iUpdates;

--- a/src/ScreenReloadSongs.h
+++ b/src/ScreenReloadSongs.h
@@ -13,7 +13,7 @@ public:
 	~ScreenReloadSongs();
 
 	virtual void Init();
-	void Update( float fDeltaTime );
+	void UpdateInternal(int32_t tween_delta);
 private:
 	int m_iUpdates;
 	LoadingWindow *m_pLoadingWindow;

--- a/src/ScreenSandbox.cpp
+++ b/src/ScreenSandbox.cpp
@@ -27,9 +27,9 @@ bool ScreenSandbox::Input( const InputEventPlus &input )
 	return Screen::Input( input );
 }
 
-void ScreenSandbox::Update( float fDeltaTime )
+void ScreenSandbox::UpdateInternal(int32_t tween_delta)
 {
-	Screen::Update(fDeltaTime);
+	Screen::UpdateInternal(tween_delta);
 }
 
 void ScreenSandbox::DrawPrimitives()

--- a/src/ScreenSandbox.h
+++ b/src/ScreenSandbox.h
@@ -8,7 +8,7 @@ class ScreenSandbox : public Screen
 public:
 	virtual bool Input( const InputEventPlus &input );
 	virtual void HandleScreenMessage( const ScreenMessage SM );
-	virtual void Update(float f);
+	virtual void UpdateInternal(int32_t tween_delta);
 	virtual void DrawPrimitives();
 };
 

--- a/src/ScreenSelect.cpp
+++ b/src/ScreenSelect.cpp
@@ -114,7 +114,7 @@ ScreenSelect::~ScreenSelect()
 		MESSAGEMAN->Unsubscribe( this, m_asSubscribedMessages[i] );
 }
 
-void ScreenSelect::Update( float fDelta )
+void ScreenSelect::UpdateInternal(int32_t tween_delta)
 {
 	if( !IsTransitioning() )
 	{
@@ -132,7 +132,7 @@ void ScreenSelect::Update( float fDelta )
 		}
 	}
 
-	ScreenWithMenuElements::Update( fDelta );
+	ScreenWithMenuElements::UpdateInternal(tween_delta);
 }
 
 bool ScreenSelect::Input( const InputEventPlus &input )

--- a/src/ScreenSelect.h
+++ b/src/ScreenSelect.h
@@ -12,7 +12,7 @@ public:
 	virtual void BeginScreen();
 	virtual ~ScreenSelect();
 
-	virtual void Update( float fDelta );
+	virtual void UpdateInternal(int32_t tween_delta);
 	virtual bool Input( const InputEventPlus &input );
 	virtual void HandleScreenMessage( const ScreenMessage SM );
 	virtual void HandleMessage( const Message &msg );

--- a/src/ScreenSelectMaster.cpp
+++ b/src/ScreenSelectMaster.cpp
@@ -363,7 +363,7 @@ void ScreenSelectMaster::BeginScreen()
 	ScreenSelect::BeginScreen();
 
 	// Call GetTweenTimeLeft after the base BeginScreen has started the in Transition.
-	m_fLockInputSecs = this->GetTweenTimeLeft();
+	m_fLockInputSecs = this->GetTweenSecsLeft();
 }
 
 void ScreenSelectMaster::HandleScreenMessage( const ScreenMessage SM )
@@ -708,7 +708,7 @@ bool ScreenSelectMaster::ChangePage( int iNewChoice )
 	}
 
 	m_fLockInputSecs = PRE_SWITCH_PAGE_SECONDS;
-	this->PostScreenMessage( SM_PlayPostSwitchPage, GetTweenTimeLeft() );
+	this->PostScreenMessage( SM_PlayPostSwitchPage, GetTweenSecsLeft() );
 	return true;
 }
 
@@ -883,7 +883,7 @@ float ScreenSelectMaster::DoMenuStart( PlayerNumber pn )
 		FOREACH_ENUM( Page, page )
 		{
 			m_sprMore[page]->PlayCommand( "Off" );
-			fSecs = max( fSecs, m_sprMore[page]->GetTweenTimeLeft() );
+			fSecs = max( fSecs, m_sprMore[page]->GetTweenSecsLeft() );
 		}
 	}
 	if( SHOW_CURSOR )
@@ -891,7 +891,7 @@ float ScreenSelectMaster::DoMenuStart( PlayerNumber pn )
 		if(m_sprCursor[pn] != NULL)
 		{
 			m_sprCursor[pn]->PlayCommand( "Choose" );
-			fSecs = max( fSecs, m_sprCursor[pn]->GetTweenTimeLeft() );
+			fSecs = max( fSecs, m_sprCursor[pn]->GetTweenSecsLeft() );
 		}
 	}
 

--- a/src/ScreenSelectMusic.cpp
+++ b/src/ScreenSelectMusic.cpp
@@ -388,7 +388,7 @@ void ScreenSelectMusic::CheckBackgroundRequests( bool bForce )
 	}
 }
 
-void ScreenSelectMusic::Update( float fDeltaTime )
+void ScreenSelectMusic::UpdateInternal(int32_t tween_delta)
 {
 	if( !IsTransitioning() )
 	{
@@ -399,7 +399,7 @@ void ScreenSelectMusic::Update( float fDeltaTime )
 		}
 	}
 
-	ScreenWithMenuElements::Update( fDeltaTime );
+	ScreenWithMenuElements::UpdateInternal(tween_delta);
 
 	CheckBackgroundRequests( false );
 }
@@ -538,7 +538,7 @@ bool ScreenSelectMusic::Input( const InputEventPlus &input )
 		// Re-queue SM_BeginFadingOut, since ShowEnteringOptions may have
 		// short-circuited animations.
 		this->ClearMessageQueue( SM_BeginFadingOut );
-		this->PostScreenMessage( SM_BeginFadingOut, this->GetTweenTimeLeft() );
+		this->PostScreenMessage( SM_BeginFadingOut, this->GetTweenSecsLeft() );
 
 		return true;
 	}
@@ -1186,7 +1186,7 @@ void ScreenSelectMusic::HandleScreenMessage( const ScreenMessage SM )
 		if( OPTIONS_MENU_AVAILABLE && !m_bGoToOptions )
 			this->PlayCommand( "HidePressStartForOptions" );
 
-		this->PostScreenMessage( SM_GoToNextScreen, this->GetTweenTimeLeft() );
+		this->PostScreenMessage( SM_GoToNextScreen, this->GetTweenSecsLeft() );
 	}
 	else if( SM == SM_GoToNextScreen )
 	{
@@ -1511,7 +1511,7 @@ bool ScreenSelectMusic::MenuStart( const InputEventPlus &input )
 			this->PostScreenMessage( SM_AllowOptionsMenuRepeat, 0.5f );
 
 			StartTransitioningScreen( SM_None );
-			float fTime = max( SHOW_OPTIONS_MESSAGE_SECONDS, this->GetTweenTimeLeft() );
+			float fTime = max( SHOW_OPTIONS_MESSAGE_SECONDS, this->GetTweenSecsLeft() );
 			this->PostScreenMessage( SM_BeginFadingOut, fTime );
 		}
 		else

--- a/src/ScreenSelectMusic.h
+++ b/src/ScreenSelectMusic.h
@@ -32,7 +32,7 @@ public:
 	virtual void Init();
 	virtual void BeginScreen();
 
-	virtual void Update( float fDeltaTime );
+	virtual void UpdateInternal(int32_t tween_delta);
 	virtual bool Input( const InputEventPlus &input );
 	virtual void HandleMessage( const Message &msg );
 	virtual void HandleScreenMessage( const ScreenMessage SM );

--- a/src/ScreenSetTime.cpp
+++ b/src/ScreenSetTime.cpp
@@ -77,9 +77,9 @@ void ScreenSetTime::Init()
 	ChangeSelection( 0 );
 }
 
-void ScreenSetTime::Update( float fDelta )
+void ScreenSetTime::UpdateInternal(int32_t tween_delta)
 {
-	Screen::Update( fDelta );
+	Screen::UpdateInternal(tween_delta);
 
 	time_t iNow = time(NULL);
 	iNow += m_TimeOffset;

--- a/src/ScreenSetTime.h
+++ b/src/ScreenSetTime.h
@@ -22,7 +22,7 @@ class ScreenSetTime : public ScreenWithMenuElements
 public:
 	virtual void Init();
 
-	virtual void Update( float fDelta );
+	virtual void UpdateInternal(int32_t tween_delta);
 	virtual bool Input( const InputEventPlus &input );
 
 	virtual bool MenuUp( const InputEventPlus &input );

--- a/src/ScreenStatsOverlay.cpp
+++ b/src/ScreenStatsOverlay.cpp
@@ -60,9 +60,9 @@ void ScreenStatsOverlay::Init()
 	this->SubscribeToMessage( "ShowStatsChanged" );
 }
 
-void ScreenStatsOverlay::Update( float fDeltaTime )
+void ScreenStatsOverlay::UpdateInternal(int32_t tween_delta)
 {
-	Screen::Update(fDeltaTime);
+	Screen::UpdateInternal(tween_delta);
 
 	static bool bShowStatsWasOn = false;
 

--- a/src/ScreenStatsOverlay.h
+++ b/src/ScreenStatsOverlay.h
@@ -14,7 +14,7 @@ class ScreenStatsOverlay : public Screen
 public:
 	virtual void Init();
 	
-	void Update( float fDeltaTime );
+	void UpdateInternal(int32_t tween_delta);
 
 private:
 	void AddTimestampLine( const RString &txt, const RageColor &color );

--- a/src/ScreenSyncOverlay.cpp
+++ b/src/ScreenSyncOverlay.cpp
@@ -69,7 +69,7 @@ void ScreenSyncOverlay::Init()
 	Update( 0 );
 }
 
-void ScreenSyncOverlay::Update( float fDeltaTime )
+void ScreenSyncOverlay::UpdateInternal(int32_t tween_delta)
 {
 	this->SetVisible( IsGameplay() );
 	if( !IsGameplay() )
@@ -78,7 +78,7 @@ void ScreenSyncOverlay::Update( float fDeltaTime )
 		return;
 	}
 
-	Screen::Update(fDeltaTime);
+	Screen::UpdateInternal(tween_delta);
 
 	UpdateText();
 }

--- a/src/ScreenSyncOverlay.h
+++ b/src/ScreenSyncOverlay.h
@@ -12,7 +12,7 @@ public:
 	
 	bool Input( const InputEventPlus &input );
 
-	void Update( float fDeltaTime );
+	void UpdateInternal(int32_t tween_delta);
 
 	static void SetShowAutoplay( bool b );
 private:

--- a/src/ScreenTestInput.cpp
+++ b/src/ScreenTestInput.cpp
@@ -13,12 +13,12 @@
 class DeviceList: public BitmapText
 {
 public:
-	void Update( float fDeltaTime )
+	void UpdateInternal(int32_t tween_delta)
 	{
 		// Update devices text
 		this->SetText( INPUTMAN->GetDisplayDevicesString() );
 
-		BitmapText::Update( fDeltaTime );
+		BitmapText::UpdateInternal(tween_delta);
 	}
 
 	virtual DeviceList *Copy() const;
@@ -33,7 +33,7 @@ class InputList: public BitmapText
 {
 	virtual InputList *Copy() const;
 
-	void Update( float fDeltaTime )
+	void Update(int32_t tween_delta)
 	{
 		// Update input texts
 		vector<RString> asInputs;
@@ -82,7 +82,7 @@ class InputList: public BitmapText
 
 		this->SetText( join( "\n", asInputs ) );
 
-		BitmapText::Update( fDeltaTime );
+		BitmapText::UpdateInternal(tween_delta);
 	}
 };
 

--- a/src/ScreenTestLights.cpp
+++ b/src/ScreenTestLights.cpp
@@ -40,9 +40,9 @@ static LocalizedString AUTO_CYCLE	( "ScreenTestLights", "Auto Cycle" );
 static LocalizedString MANUAL_CYCLE	( "ScreenTestLights", "Manual Cycle" );
 static LocalizedString CABINET_LIGHT( "ScreenTestLights", "cabinet light" );
 static LocalizedString CONTROLLER_LIGHT( "ScreenTestLights", "controller light" );
-void ScreenTestLights::Update( float fDeltaTime )
+void ScreenTestLights::UpdateInternal(int32_t tween_delta)
 {
-	Screen::Update( fDeltaTime );
+	Screen::UpdateInternal(tween_delta);
 
 
 	if( m_timerBackToAutoCycle.Ago() > 20 )

--- a/src/ScreenTestLights.h
+++ b/src/ScreenTestLights.h
@@ -12,7 +12,7 @@ public:
 	virtual void BeginScreen();
 	virtual void EndScreen();
 
-	virtual void Update( float fDelta );
+	virtual void UpdateInternal(int32_t tween_delta);
 	virtual bool Input( const InputEventPlus &input );
 
 	virtual bool MenuLeft( const InputEventPlus &input );

--- a/src/ScreenTestSound.cpp
+++ b/src/ScreenTestSound.cpp
@@ -106,9 +106,9 @@ void ScreenTestSound::UpdateText(int n)
 		));
 }
 
-void ScreenTestSound::Update(float f)
+void ScreenTestSound::UpdateInternal(int32_t tween_delta)
 {
-	Screen::Update(f);
+	Screen::UpdateInternal(tween_delta);
 
 	for(int i = 0; i < nsounds; ++i)
 	{

--- a/src/ScreenTestSound.h
+++ b/src/ScreenTestSound.h
@@ -16,7 +16,7 @@ public:
 
 	virtual bool Input( const InputEventPlus &input );
 
-	void Update(float f);
+	void UpdateInternal(int32_t tween_delta);
 	void UpdateText(int n);
 
 	struct Sound {

--- a/src/ScreenTextEntry.cpp
+++ b/src/ScreenTextEntry.cpp
@@ -190,9 +190,9 @@ void ScreenTextEntry::UpdateAnswerText()
 	m_textAnswer.SetText( s );
 }
 
-void ScreenTextEntry::Update( float fDelta )
+void ScreenTextEntry::UpdateInternal(int32_t tween_delta)
 {
-	ScreenWithMenuElements::Update( fDelta );
+	ScreenWithMenuElements::UpdateInternal(tween_delta);
 
 	if( m_timerToggleCursor.PeekDeltaTime() > 0.25f )
 	{

--- a/src/ScreenTextEntry.h
+++ b/src/ScreenTextEntry.h
@@ -102,7 +102,7 @@ public:
 	virtual void Init();
 	virtual void BeginScreen();
 
-	virtual void Update( float fDelta );
+	virtual void UpdateInternal(int32_t tween_delta);
 	virtual bool Input( const InputEventPlus &input );
 
 	static RString s_sLastAnswer;

--- a/src/ScreenWithMenuElements.cpp
+++ b/src/ScreenWithMenuElements.cpp
@@ -250,9 +250,9 @@ void ScreenWithMenuElements::StartPlayingMusic()
 	}
 }
 
-void ScreenWithMenuElements::Update( float fDeltaTime )
+void ScreenWithMenuElements::UpdateInternal(int32_t tween_delta)
 {
-	Screen::Update( fDeltaTime );
+	Screen::UpdateInternal(tween_delta);
 }
 
 void ScreenWithMenuElements::ResetTimer()
@@ -280,9 +280,9 @@ void ScreenWithMenuElements::StartTransitioningScreen( ScreenMessage smSendWhenD
 	{
 		// Time the transition so that it finishes exactly when all actors have 
 		// finished tweening.
-		float fSecondsUntilFinished = GetTweenTimeLeft();
-		float fSecondsUntilBeginOff = max( fSecondsUntilFinished - m_Out.GetTweenTimeLeft(), 0 );
-		m_Out.SetHibernate( fSecondsUntilBeginOff );
+		int32_t time_until_finished= GetTweenTimeLeft();
+		int32_t time_until_begin_off= max(time_until_finished - m_Out.GetTweenTimeLeft(), 0);
+		m_Out.SetHibernateInternal(time_until_begin_off);
 	}
 }
 

--- a/src/ScreenWithMenuElements.h
+++ b/src/ScreenWithMenuElements.h
@@ -18,7 +18,7 @@ public:
 	virtual ~ScreenWithMenuElements();
 
 	virtual void HandleScreenMessage( const ScreenMessage SM );
-	void Update( float fDeltaTime );
+	void UpdateInternal(int32_t tween_delta);
 	void StartTransitioningScreen( ScreenMessage smSendWhenDone );
 	virtual void Cancel( ScreenMessage smSendWhenDone );
 	bool IsTransitioning();

--- a/src/Sprite.h
+++ b/src/Sprite.h
@@ -15,8 +15,7 @@ public:
 	struct State
 	{
 		RectF rect;
-		/** @brief The number of "seconds to show". */
-		float fDelay;
+		int32_t delay;
 	};
 
 	Sprite();
@@ -33,7 +32,7 @@ public:
 
 	virtual bool EarlyAbortDraw() const;
 	virtual void DrawPrimitives();
-	virtual void Update( float fDeltaTime );
+	virtual void UpdateInternal(int32_t tween_delta);
 
 	void UpdateAnimationState();	// take m_fSecondsIntoState, and move to a new state
 
@@ -54,8 +53,8 @@ public:
 	virtual int GetNumStates() const;
 	virtual void SetState( int iNewState );
 	int GetState() { return m_iCurState; }
-	virtual float GetAnimationLengthSeconds() const;
-	virtual void SetSecondsIntoAnimation( float fSeconds );
+	virtual int32_t GetAnimationLength() const;
+	virtual void SetSecondsIntoAnimation(float seconds);
 	void SetStateProperties(const vector<State>& new_states)
 	{ m_States= new_states; SetState(0); }
 
@@ -88,7 +87,7 @@ public:
 	// Commands
 	virtual void PushSelf( lua_State *L );
 
-	void SetAllStateDelays(float fDelay);
+	void SetAllStateDelays(float delay);
 
 	bool m_DecodeMovie;
 
@@ -104,8 +103,7 @@ private:
 
 	vector<State> m_States;
 	int		m_iCurState;
-	/** @brief The number of seconds that have elapsed since we switched to this frame. */
-	float	m_fSecsIntoState;
+	int32_t m_time_into_state;
 
 	EffectMode m_EffectMode;
 	bool m_bUsingCustomTexCoords;

--- a/src/StepMania.cpp
+++ b/src/StepMania.cpp
@@ -1209,6 +1209,21 @@ int sm_main(int argc, char* argv[])
 	// Run the main loop.
 	GameLoop::RunGameLoop();
 
+	PRINT_TOT_CALL_END(actor_update);
+	PRINT_TOT_CALL_PAIR(game_loop_body);
+	PRINT_TOTAL_TIME(check_focus);
+	PRINT_TOTAL_TIME(soundman_update);
+	PRINT_TOTAL_TIME(sound_update);
+	PRINT_TOTAL_TIME(textureman_update);
+	PRINT_TOTAL_TIME(gamestate_update);
+	PRINT_TOTAL_TIME(screenman_update);
+	PRINT_TOTAL_TIME(memcardman_update);
+	PRINT_TOTAL_TIME(nsman_update);
+	PRINT_TOTAL_TIME(handle_input);
+	PRINT_TOTAL_TIME(devices_changed);
+	PRINT_TOTAL_TIME(lightsman_update);
+	PRINT_TOTAL_TIME(screenman_draw);
+
 	PREFSMAN->SavePrefsToDisk();
 
 	ShutdownGame();

--- a/src/StreamDisplay.cpp
+++ b/src/StreamDisplay.cpp
@@ -61,12 +61,16 @@ void StreamDisplay::Load( const RString & /* unreferenced: _sMetricsGroup  */)
 	}
 }
 
-void StreamDisplay::Update( float fDeltaSecs )
+void StreamDisplay::UpdateInternal(int32_t tween_delta)
 {
-	ActorFrame::Update( fDeltaSecs );
+	ActorFrame::UpdateInternal(tween_delta);
+	float delta_secs= tween_time_to_secs(tween_delta);
 
 	// HACK:  Tweaking these values is very difficult.  Update the
 	// "physics" many times so that the spring motion appears faster
+
+	// Can I just say that seems like a mistake that impedes tweaking?  And now
+	// we're stuck with that mistake because of brokewards compatibility. -Kyz
 	for( int i=0; i<10; i++ )
 	{
 		const float fDelta = m_fPercent - m_fTrailingPercent;
@@ -83,16 +87,16 @@ void StreamDisplay::Update( float fDeltaSecs )
 		else
 		{
 			const float fSpringForce = fDelta * SPRING_MULTIPLIER;
-			m_fVelocity += fSpringForce * fDeltaSecs;
+			m_fVelocity += fSpringForce * delta_secs;
 
 			const float fViscousForce = -m_fVelocity * VISCOSITY_MULTIPLIER;
 			if( !m_bAlwaysBounce )
-				m_fVelocity += fViscousForce * fDeltaSecs;
+				m_fVelocity += fViscousForce * delta_secs;
 		}
 
 		CLAMP( m_fVelocity, VELOCITY_MIN, VELOCITY_MAX );
 
-		m_fTrailingPercent += m_fVelocity * fDeltaSecs;
+		m_fTrailingPercent += m_fVelocity * delta_secs;
 	}
 
 	// Don't clamp life percentage a little outside the visible range so

--- a/src/StreamDisplay.h
+++ b/src/StreamDisplay.h
@@ -21,7 +21,7 @@ class StreamDisplay : public ActorFrame
 public:
 	StreamDisplay();
 
-	virtual void Update( float fDeltaSecs );
+	virtual void UpdateInternal(int32_t tween_delta);
 
 	void Load( const RString &sMetricsGroup );
 

--- a/src/Transition.cpp
+++ b/src/Transition.cpp
@@ -18,7 +18,7 @@ void Transition::Load( RString sBGAniDir )
 }
 
 
-void Transition::UpdateInternal( float fDeltaTime )
+void Transition::UpdateInternal(int32_t tween_delta)
 {
 	if( m_State != transitioning )
 		return;
@@ -31,7 +31,7 @@ void Transition::UpdateInternal( float fDeltaTime )
 		SCREENMAN->SendMessageToTopScreen( m_MessageToSendWhenDone );
 	}
 
-	ActorFrame::UpdateInternal( fDeltaTime );
+	ActorFrame::UpdateInternal(tween_delta);
 }
 
 void Transition::Reset()
@@ -64,7 +64,7 @@ void Transition::StartTransitioning( ScreenMessage send_when_done )
 	m_State = transitioning;
 }
 
-float Transition::GetTweenTimeLeft() const
+int64_t Transition::GetTweenTimeLeft() const
 {
 	if( m_State != transitioning )
 		return 0;

--- a/src/Transition.h
+++ b/src/Transition.h
@@ -15,11 +15,11 @@ public:
 
 	void Load( RString sBGAniDir );
 
-	virtual void UpdateInternal( float fDeltaTime );
+	virtual void UpdateInternal(int32_t tween_delta);
 
 	virtual void StartTransitioning( ScreenMessage send_when_done = SM_None );
 	virtual bool EarlyAbortDraw() const;
-	virtual float GetTweenTimeLeft() const;
+	virtual int64_t GetTweenTimeLeft() const;
 	void Reset(); // explicitly allow transitioning again
 
 	bool IsTransitioning() const	{ return m_State == transitioning; };

--- a/src/WheelBase.cpp
+++ b/src/WheelBase.cpp
@@ -156,9 +156,10 @@ void WheelBase::SetPositions()
 	}
 }
 
-void WheelBase::Update( float fDeltaTime )
+void WheelBase::UpdateInternal(int32_t tween_delta)
 {
-	ActorFrame::Update( fDeltaTime );
+	ActorFrame::UpdateInternal(tween_delta);
+	float fDeltaTime= tween_time_to_secs(tween_delta);
 
 	// If tweens aren't controlling the position of the wheel, set positions.
 	if( !GetTweenTimeLeft() )
@@ -337,7 +338,7 @@ void WheelBase::TweenOnScreenForSort()
 
 	this->PlayCommand( "SortOn" );
 
-	m_fTimeLeftInState = GetTweenTimeLeft();
+	m_fTimeLeftInState = GetTweenSecsLeft();
 }
 
 void WheelBase::TweenOffScreenForSort()
@@ -346,7 +347,7 @@ void WheelBase::TweenOffScreenForSort()
 
 	this->PlayCommand( "SortOff" );
 
-	m_fTimeLeftInState = GetTweenTimeLeft();
+	m_fTimeLeftInState = GetTweenSecsLeft();
 }
 
 void WheelBase::ChangeMusicUnlessLocked( int n )

--- a/src/WheelBase.h
+++ b/src/WheelBase.h
@@ -37,7 +37,7 @@ public:
 	virtual void Load( RString sType );
 	void BeginScreen();
 
-	virtual void Update( float fDeltaTime );
+	virtual void UpdateInternal(int32_t tween_delta);
 
 	virtual void Move(int n);
 	void ChangeMusicUnlessLocked( int n ); /* +1 or -1 */

--- a/src/WheelNotifyIcon.cpp
+++ b/src/WheelNotifyIcon.cpp
@@ -76,7 +76,7 @@ bool WheelNotifyIcon::EarlyAbortDraw() const
 	return Sprite::EarlyAbortDraw();
 }
 
-void WheelNotifyIcon::Update( float fDeltaTime )
+void WheelNotifyIcon::UpdateInternal(int32_t tween_delta)
 {
 	if( m_vIconsToShow.size() > 0 )
 	{
@@ -88,7 +88,7 @@ void WheelNotifyIcon::Update( float fDeltaTime )
 		Sprite::SetState( m_vIconsToShow[index] );
 	}
 
-	Sprite::Update( fDeltaTime );
+	Sprite::UpdateInternal(tween_delta);
 }
 
 /*

--- a/src/WheelNotifyIcon.h
+++ b/src/WheelNotifyIcon.h
@@ -19,7 +19,7 @@ public:
 
 	void SetFlags( Flags flags );
 
-	virtual void Update( float fDeltaTime );
+	virtual void UpdateInternal(int32_t tween_delta);
 	virtual bool EarlyAbortDraw() const;
 
 protected:


### PR DESCRIPTION
This is intended to eliminate the possibility of precision loss related problems in the tweening system.
The profiling code in GameLoop is just there to show how I tested to see whether there was any performance benefit, no performance change was measured.  The profiling code will be removed when this pull request is finalized.

This also changes all classes that derive from Actor to use UpdateInternal because of this comment in Actor.h:
	// TODO: make Update non virtual and change all classes to override UpdateInternal instead.

If moving to integer math is considered good by other devs, my next target is TimingData, where a simfile with thousands of stops or bpm changes probably accumulates measurable error from all the additions.