### PR TITLE
BackInEventMode code now works for both players

### DIFF
--- a/src/StepMania.cpp
+++ b/src/StepMania.cpp
@@ -1589,6 +1589,8 @@ void HandleInputEvents(float fDeltaTime)
 		{
 			input.pn = PLAYER_1;
 			input.MenuI = GAME_BUTTON_BACK;
+			SCREENMAN->Input( input );
+			input.pn = PLAYER_2;
 		}
 
 		SCREENMAN->Input( input );


### PR DESCRIPTION
Previously, inputting the code for BackInEventMode would only work if player 1 was active. Now the code works for both players.