### PR TITLE
Added missing lines of FindJACK.cmake - now finds JACK successfully

### DIFF
--- a/CMake/Modules/FindJACK.cmake
+++ b/CMake/Modules/FindJACK.cmake
@@ -52,6 +52,20 @@ else (JACK_LIBRARIES AND JACK_INCLUDE_DIRS)
       /sw/lib
   )
 
+  if (JACK_LIBRARY AND JACK_INCLUDE_DIR)	
+    set(JACK_FOUND TRUE)
+    	
+    set(JACK_INCLUDE_DIRS	
+      ${JACK_INCLUDE_DIR}	
+    )
+    
+    set(JACK_LIBRARIES
+      ${JACK_LIBRARIES}
+      ${JACK_LIBRARY}
+    )
+
+  endif (JACK_LIBRARY AND JACK_INCLUDE_DIR)
+
   include(FindPackageHandleStandardArgs)
   find_package_handle_standard_args(JACK DEFAULT_MSG
     JACK_INCLUDE_DIRS JACK_LIBRARIES)


### PR DESCRIPTION
Some missing lines in FindJACK.cmake resulted in cmake not finding jack. Missing lines added and JACK is now found as expected.