### PR TITLE
Music wheel preview fadeout time is now adjustable by the metric [ScreenSelectMusic] SampleMusicFadeOutSeconds.

### DIFF
--- a/Themes/_fallback/metrics.ini
+++ b/Themes/_fallback/metrics.ini
@@ -2100,6 +2100,7 @@ DefaultSort=GAMESTATE:IsCourseMode() and "Group" or "AllCourses"
 SampleMusicPreviewMode='SampleMusicPreviewMode_Normal'
 SampleMusicLoops=true
 SampleMusicFallbackFadeInSeconds=0
+SampleMusicFadeOutSeconds=1.5
 #
 UseOptionsList=false
 OptionsListTimeout=0.25

--- a/src/ScreenSelectMusic.cpp
+++ b/src/ScreenSelectMusic.cpp
@@ -85,6 +85,7 @@ void ScreenSelectMusic::Init()
 	SAMPLE_MUSIC_LOOPS.Load( m_sName, "SampleMusicLoops" );
 	SAMPLE_MUSIC_PREVIEW_MODE.Load( m_sName, "SampleMusicPreviewMode" );
 	SAMPLE_MUSIC_FALLBACK_FADE_IN_SECONDS.Load( m_sName, "SampleMusicFallbackFadeInSeconds" );
+	SAMPLE_MUSIC_FADE_OUT_SECONDS.Load( m_sName, "SampleMusicFadeOutSeconds" );
 	DO_ROULETTE_ON_MENU_TIMER.Load( m_sName, "DoRouletteOnMenuTimer" );
 	ROULETTE_TIMER_SECONDS.Load( m_sName, "RouletteTimerSeconds" );
 	ALIGN_MUSIC_BEATS.Load( m_sName, "AlignMusicBeat" );
@@ -383,7 +384,7 @@ void ScreenSelectMusic::CheckBackgroundRequests( bool bForce )
 		PlayParams.bForceLoop = SAMPLE_MUSIC_LOOPS;
 		PlayParams.fStartSecond = m_fSampleStartSeconds;
 		PlayParams.fLengthSeconds = m_fSampleLengthSeconds;
-		PlayParams.fFadeOutLengthSeconds = 1.5f;
+		PlayParams.fFadeOutLengthSeconds = SAMPLE_MUSIC_FADE_OUT_SECONDS;
 		PlayParams.bAlignBeat = ALIGN_MUSIC_BEATS;
 		PlayParams.bApplyMusicRate = true;
 

--- a/src/ScreenSelectMusic.h
+++ b/src/ScreenSelectMusic.h
@@ -78,6 +78,7 @@ protected:
 	ThemeMetric<bool>		SAMPLE_MUSIC_LOOPS;
 	ThemeMetric<SampleMusicPreviewMode> SAMPLE_MUSIC_PREVIEW_MODE;
 	ThemeMetric<float>		SAMPLE_MUSIC_FALLBACK_FADE_IN_SECONDS;
+	ThemeMetric<float>		SAMPLE_MUSIC_FADE_OUT_SECONDS;
 	ThemeMetric<bool>		DO_ROULETTE_ON_MENU_TIMER;
 	ThemeMetric<float>		ROULETTE_TIMER_SECONDS;
 	ThemeMetric<bool>		ALIGN_MUSIC_BEATS;


### PR DESCRIPTION
Music wheel preview fadeout time is now adjustable, allowing for perfect loops if desired. Fallback theme metric added accordingly, corresponding to original hardcoded value.