### PR TITLE
Sample length for songs with preview file can now be length of preview file

### DIFF
--- a/src/NotesLoaderBMS.cpp
+++ b/src/NotesLoaderBMS.cpp
@@ -1488,6 +1488,7 @@ void BMSSongLoader::AddToSong()
 		{
 			Steps *steps = loadedSteps[i].steps;
 			steps->SetDifficulty( Difficulty_Medium );
+			// todo: recognise #difficulty tag
 
 			RString title = loadedSteps[i].info.title;
 
@@ -1581,6 +1582,7 @@ void BMSSongLoader::AddToSong()
 
 		out->m_sMusicFile = main.info.musicFile;
 		out->m_PreviewFile= main.info.previewFile;
+		out->m_fMusicSampleLengthSeconds = 0.00f; // to ensure whole preview file is heard
 		out->m_SongTiming = main.steps->m_Timing;
 	}
 

--- a/src/Song.cpp
+++ b/src/Song.cpp
@@ -748,26 +748,56 @@ void Song::TidyUpData( bool from_cache, bool /* duringCache */ )
 				m_fMusicLengthSeconds);
 			m_fMusicLengthSeconds = 0;
 		}
-		if(m_fMusicSampleStartSeconds == -1 ||
-			m_fMusicSampleLengthSeconds == 0 ||
-			m_fMusicSampleStartSeconds+m_fMusicSampleLengthSeconds > this->m_fMusicLengthSeconds)
-		{
-			const TimingData &timing = this->m_SongTiming;
-			m_fMusicSampleStartSeconds = timing.GetElapsedTimeFromBeat(100);
-
-			if(m_fMusicSampleStartSeconds+m_fMusicSampleLengthSeconds > this->m_fMusicLengthSeconds)
+		if(!m_PreviewFile.empty() && m_fMusicSampleLengthSeconds <= 0.00f) { // if there's a preview file and sample length isn't specified, set sample length to length of preview file
+			RString error;
+			RageSoundReader *Sample = RageSoundReader_FileReader::OpenFile(GetPreviewMusicPath(), error);
+			if(Sample == NULL && m_sMusicFile != "")
 			{
-				// Attempt to get a reasonable default.
-				int iBeat = lrintf(this->m_SongTiming.GetBeatFromElapsedTime(this->GetLastSecond())/2);
-				iBeat -= iBeat%4;
-				m_fMusicSampleStartSeconds = timing.GetElapsedTimeFromBeat((float)iBeat);
-			}
-		}
+				LOG->UserLog("Sound file", GetPreviewMusicPath(), "couldn't be opened: %s", error.c_str());
 
-		// The old logic meant that you couldn't have sample lengths that go forever,
-		// e.g. those in Donkey Konga. I never liked that. -freem
-		if(m_fMusicSampleLengthSeconds <= 0.00f)
-		{ m_fMusicSampleLengthSeconds = DEFAULT_MUSIC_SAMPLE_LENGTH; }
+				// Don't use this file.
+				m_PreviewFile = "";
+				m_fMusicSampleLengthSeconds = DEFAULT_MUSIC_SAMPLE_LENGTH;
+			}
+			else if(Sample != NULL)
+			{
+				m_fMusicSampleLengthSeconds = Sample->GetLength() / 1000.0f;
+				delete Sample;
+
+				if(m_fMusicSampleLengthSeconds < 0)
+				{
+					// It failed; bad file or something. It's already logged a warning.
+					m_fMusicSampleLengthSeconds = DEFAULT_MUSIC_SAMPLE_LENGTH;
+				}
+				else if(m_fMusicSampleLengthSeconds == 0)
+				{
+					LOG->UserLog("Sound file", GetPreviewMusicPath(), "is empty.");
+				}
+			}
+		} else { // no preview file, calculate sample from music as normal
+		
+			if(m_fMusicSampleStartSeconds == -1 ||
+				m_fMusicSampleLengthSeconds == 0 ||
+				m_fMusicSampleStartSeconds+m_fMusicSampleLengthSeconds > this->m_fMusicLengthSeconds)
+			{
+				const TimingData &timing = this->m_SongTiming;
+				m_fMusicSampleStartSeconds = timing.GetElapsedTimeFromBeat(100);
+
+				if(m_fMusicSampleStartSeconds+m_fMusicSampleLengthSeconds > this->m_fMusicLengthSeconds)
+				{
+					// Attempt to get a reasonable default.
+					int iBeat = lrintf(this->m_SongTiming.GetBeatFromElapsedTime(this->GetLastSecond())/2);
+					iBeat -= iBeat%4;
+					m_fMusicSampleStartSeconds = timing.GetElapsedTimeFromBeat((float)iBeat);
+				}
+			}
+
+			// The old logic meant that you couldn't have sample lengths that go forever,
+			// e.g. those in Donkey Konga. I never liked that. -freem
+			if(m_fMusicSampleLengthSeconds <= 0.00f)
+			{ m_fMusicSampleLengthSeconds = DEFAULT_MUSIC_SAMPLE_LENGTH; }
+		
+		}
 
 		// Here's the problem:  We have a directory full of images. We want to
 		// determine which image is the banner, which is the background, and


### PR DESCRIPTION
For songs with a seperate preview file, the sample length can now be the same as the length of the preview file so the entire preview file is heard. A sample length can still be specified if preferred.
