### PR TITLE
BackInEventMode code now works for both players (new version)

### DIFF
--- a/src/StepMania.cpp
+++ b/src/StepMania.cpp
@@ -1587,7 +1587,6 @@ void HandleInputEvents(float fDeltaTime)
 		if( GAMESTATE->IsEventMode() &&
 			CodeDetector::EnteredCode(input.GameI.controller,CODE_BACK_IN_EVENT_MODE) )
 		{
-			input.pn = PLAYER_1;
 			input.MenuI = GAME_BUTTON_BACK;
 		}
 


### PR DESCRIPTION
Previously, inputting the code for BackInEventMode would only work if player 1 was active. Now the code works for both players.
