### PR TITLE
BMS loader now supports #difficulty tag.

### DIFF
--- a/src/NotesLoaderBMS.cpp
+++ b/src/NotesLoaderBMS.cpp
@@ -891,6 +891,13 @@ void BMSChartReader::ReadHeaders()
 		{
 			out->SetMeter( StringToInt(it->second) );
 		}
+		else if( it->first == "#difficulty")
+		{
+		    // only set the difficulty if the #difficulty tag is between 1 and 6 (beginner~edit)
+		    int diff = StringToInt(it->second)-1; // BMS uses 1 to 6, SM uses 0 to 5
+		    if(diff>=0 && diff<NUM_Difficulty)
+                out->SetDifficulty( (Difficulty)diff );
+		}
 		else if (it->first == "#music")
 		{
 			info.overrideMusicFile = it->second;
@@ -1472,7 +1479,7 @@ void BMSSongLoader::AddToSong()
 		for( unsigned i = 0; i < loadedSteps.size(); i ++ )
 		{
 			Steps *steps = loadedSteps[i].steps;
-			steps->SetDifficulty( Difficulty_Medium );
+			//steps->SetDifficulty( Difficulty_Medium );
 
 			RString title = loadedSteps[i].info.title;
 
@@ -1487,7 +1494,7 @@ void BMSSongLoader::AddToSong()
 		for( unsigned i = 0; i < loadedSteps.size(); i ++ )
 		{
 			Steps *steps = loadedSteps[i].steps;
-			steps->SetDifficulty( Difficulty_Medium );
+			//steps->SetDifficulty( Difficulty_Medium );
 
 			RString title = loadedSteps[i].info.title;
 


### PR DESCRIPTION
#difficulty tag in BMS files now works as expected (#difficulty 1 = beginner, #difficulty 4 = hard, etc.).