### PR TITLE
fix LoadingWindow splash image for OS X

### DIFF
--- a/src/arch/LoadingWindow/LoadingWindow_MacOSX.h
+++ b/src/arch/LoadingWindow/LoadingWindow_MacOSX.h
@@ -9,7 +9,7 @@ public:
 	LoadingWindow_MacOSX();
 	~LoadingWindow_MacOSX();
 	void SetText( RString str );
-	void SetSplash( const RageSurface *pSplash ) {}
+	void SetSplash( const RageSurface *pSplash );
 	void SetProgress( const int progress );
 	void SetTotalWork( const int totalWork );
 	void SetIndeterminate( bool indeterminate );
@@ -23,7 +23,7 @@ public:
  * @author Steve Checkoway (c) 2003-2005, 2008
  * @section LICENSE
  * All rights reserved.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the
  * "Software"), to deal in the Software without restriction, including
@@ -33,7 +33,7 @@ public:
  * copyright notice(s) and this permission notice appear in all copies of
  * the Software and that both the above copyright notice(s) and this
  * permission notice appear in supporting documentation.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
  * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
  * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF


### PR DESCRIPTION
This commit allows OS X users to enjoy their current theme's custom splash graphic if it is available at ```./Graphics/Common splash.png```  I have been wanting to fix this for a fairly long time.

My fix is probably not the cleanest or proper way to do this.  StepMania.cpp [already looks up the current theme's "Common splash.png"](https://github.com/stepmania/stepmania/blob/master/src/StepMania.cpp#L1119-L1126) and passes it off to the arch-appropriate LoadingWindow as a RageSurface.  This fix ignores that Ragesurface, repeats the lookup in LoadingWindow_MacOSX.mm, and loads the splash image into a Ragefile which is easily loaded into an NSImage.

Still, my fix does work, and if you actually know how to work with a Ragesurface and can help out here, I'll give you a cookie. :)