### PR TITLE
Setting sample length for songs with preview file to 0 uses length of preview file

### DIFF
--- a/src/NotesLoaderBMS.cpp
+++ b/src/NotesLoaderBMS.cpp
@@ -1588,6 +1588,7 @@ void BMSSongLoader::AddToSong()
 
 		out->m_sMusicFile = main.info.musicFile;
 		out->m_PreviewFile= main.info.previewFile;
+		out->m_fMusicSampleLengthSeconds = 0.00f; // to ensure whole preview file is heard
 		out->m_SongTiming = main.steps->m_Timing;
 	}
 


### PR DESCRIPTION
For songs with a preview file, setting the sample length to 0 now causes Stepmania to automatically set the sample length to the length of the whole preview file. For BMS files, this is done automatically.