### PR TITLE
Prove that submodules can work.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "extern/cppformat"]
+	path = extern/cppformat
+	url = https://github.com/cppformat/cppformat.git

--- a/Build/README.md
+++ b/Build/README.md
@@ -3,6 +3,10 @@ Warning
 Using CMake is considered stable, but not every single combination is known to work.
 Using the defaults as suggested should cause minimal problems.
 
+Prerequisites
+==
+Before you you can use CMake, make sure the git submodules are initialized. In the parent directory, run `git submodule init` and `git submodule update` to have the submodules initialized.
+
 CMake Installation
 ==
 There are two ways of working with cmake: the command line and the GUI.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ Advanced cross-platform rhythm game for home and arcade use.
 
 StepMania can be compiled using [CMake](http://www.cmake.org/). More information about using CMake can be found in both the `Build` directory and CMake's documentation.
 
+###Submodules###
+
+This repository now uses submodules to attempt to keep the repository size down. Utilize `git submodule init` and `git submodule update` to get the necessary submodules.
+
 ##Build Status##
 
 We use Travis as our continuous integration server. The status can be found below.

--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -1,5 +1,6 @@
 include(CMakeProject-lua.cmake)
 include(CMakeProject-glew.cmake)
+include(CMakeProject-cppformat.cmake)
 include(CMakeProject-json.cmake)
 if (NOT SYSTEM_PCRE_FOUND)
   include(CMakeProject-pcre.cmake)

--- a/extern/CMakeProject-cppformat.cmake
+++ b/extern/CMakeProject-cppformat.cmake
@@ -1,0 +1,32 @@
+list(APPEND CPPFORMAT_SRC
+  "cppformat/format.cc"
+)
+
+list(APPEND CPPFORMAT_HPP
+  "cppformat/format.h"
+)
+
+source_group("" FILES ${CPPFORMAT_SRC} ${CPPFORMAT_HPP})
+
+add_library("cppformat" ${CPPFORMAT_SRC} ${CPPFORMAT_HPP})
+
+set_property(TARGET "cppformat" PROPERTY FOLDER "External Libraries")
+
+disable_project_warnings("cppformat")
+
+target_include_directories("cppformat" PUBLIC "cppformat")
+
+if (MSVC)
+  sm_add_compile_definition("cppformat" _CRT_SECURE_NO_WARNINGS)
+elseif(APPLE)
+  set_target_properties("cppformat" PROPERTIES
+    XCODE_ATTRIBUTE_CLANG_CXX_LANGUAGE_STANDARD "gnu++14"
+    XCODE_ATTRIBUTE_CLANG_CXX_LIBRARY "libc++"
+  )
+else() # Unix
+  sm_add_compile_flag("cppformat" "-std=gnu++11")
+  if (CMAKE_CXX_COMPILER MATCHES "clang")
+    sm_add_compile_flag("cppformat" "-stdlib=libc++")
+  endif()
+endif()
+

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -410,6 +410,7 @@ list(APPEND SMDATA_LINK_LIB
   "tomcrypt"
   "tommath"
   "zlib"
+  "cppformat"
   "jsoncpp"
   "mad"
   "png"
@@ -485,6 +486,7 @@ elseif(APPLE)
     "tomcrypt"
     "tommath"
     "zlib"
+    "cppformat"
     "jsoncpp"
     "mad"
     "png"
@@ -601,6 +603,7 @@ list(APPEND SM_INCLUDE_DIRS
   "${SM_EXTERN_DIR}/vorbis"
   "${SM_EXTERN_DIR}/libtommath"
   "${SM_EXTERN_DIR}/libtomcrypt/src/headers"
+  "${SM_EXTERN_DIR}/cppformat"
 )
 if(NOT APPLE)
   list(APPEND SM_INCLUDE_DIRS


### PR DESCRIPTION
This is the cppformat library to be used with std::string calls.

This will be part of a bigger project to utilize std::string instead of StdString::CStdString, aka RString.

Remember to read the updated documentation: usage of `git submodule init` and `git submodule update` are required.