### PR TITLE
How NOT to remove StdString::CStdString. (DO NOT MERGE!)

### DIFF
--- a/src/Actor.cpp
+++ b/src/Actor.cpp
@@ -1022,13 +1022,35 @@ void Actor::ScaleTo( const RectF &rect, StretchType st )
 
 void Actor::SetEffectClockString( const RString &s )
 {
-	if     (s.EqualsNoCase("timer"))	this->SetEffectClock( CLOCK_TIMER );
-	else if(s.EqualsNoCase("timerglobal"))	this->SetEffectClock( CLOCK_TIMER_GLOBAL );
-	else if(s.EqualsNoCase("beat"))		this->SetEffectClock( CLOCK_BGM_BEAT );
-	else if(s.EqualsNoCase("music"))	this->SetEffectClock( CLOCK_BGM_TIME );
-	else if(s.EqualsNoCase("bgm"))		this->SetEffectClock( CLOCK_BGM_BEAT ); // compat, deprecated
-	else if(s.EqualsNoCase("musicnooffset"))this->SetEffectClock( CLOCK_BGM_TIME_NO_OFFSET );
-	else if(s.EqualsNoCase("beatnooffset"))	this->SetEffectClock( CLOCK_BGM_BEAT_NO_OFFSET );
+	ci_string effect(s.c_str());
+	if(effect == "timer")
+	{
+		this->SetEffectClock( CLOCK_TIMER );
+	}
+	else if(effect == "timerglobal")
+	{
+		this->SetEffectClock( CLOCK_TIMER_GLOBAL );
+	}
+	else if(effect == "beat")
+	{
+		this->SetEffectClock( CLOCK_BGM_BEAT );
+	}
+	else if(effect == "music")
+	{
+		this->SetEffectClock( CLOCK_BGM_TIME );
+	}
+	else if(effect == "bgm")
+	{
+		this->SetEffectClock( CLOCK_BGM_BEAT ); // compat, deprecated
+	}
+	else if(effect == "musicnooffset")
+	{
+		this->SetEffectClock( CLOCK_BGM_TIME_NO_OFFSET );
+	}
+	else if(effect == "beatnooffset")
+	{
+		this->SetEffectClock( CLOCK_BGM_BEAT_NO_OFFSET );
+	}
 	else
 	{
 		CabinetLight cl = StringToCabinetLight( s );

--- a/src/Actor.cpp
+++ b/src/Actor.cpp
@@ -138,7 +138,7 @@ void Actor::InitState()
 
 static bool GetMessageNameFromCommandName( const RString &sCommandName, RString &sMessageNameOut )
 {
-	if( sCommandName.Right(7) == "Message" )
+	if( EndsWith(sCommandName, "Message"))
 	{
 		sMessageNameOut = head(sCommandName, -7);
 		return true;

--- a/src/Actor.cpp
+++ b/src/Actor.cpp
@@ -1867,7 +1867,7 @@ public:
 	static int GetHAlign( T* p, lua_State *L )	{ lua_pushnumber( L, p->GetHorizAlign() ); return 1; }
 	static int GetVAlign( T* p, lua_State *L )	{ lua_pushnumber( L, p->GetVertAlign() ); return 1; }
 
-	static int GetName( T* p, lua_State *L )		{ lua_pushstring( L, p->GetName() ); return 1; }
+	static int GetName( T* p, lua_State *L )		{ lua_pushstring( L, p->GetName().c_str() ); return 1; }
 	static int GetParent( T* p, lua_State *L )
 	{
 		Actor *pParent = p->GetParent();

--- a/src/Actor.cpp
+++ b/src/Actor.cpp
@@ -140,7 +140,7 @@ static bool GetMessageNameFromCommandName( const RString &sCommandName, RString 
 {
 	if( sCommandName.Right(7) == "Message" )
 	{
-		sMessageNameOut = sCommandName.Left(sCommandName.size()-7);
+		sMessageNameOut = head(sCommandName, -7);
 		return true;
 	}
 	else
@@ -275,7 +275,7 @@ void Actor::LoadFromNode( const XNode* pNode )
 			LuaReference *pRef = new LuaReference;
 			pValue->PushValue( L );
 			pRef->SetFromStack( L );
-			RString sCmdName = sKeyName.Left( sKeyName.size()-7 );
+			RString sCmdName = head(sKeyName, -7);
 			AddCommand( sCmdName, apActorCommands( pRef ) );
 		}
 		else if( sKeyName == "Name" )			SetName( pValue->GetValue<RString>() );
@@ -773,10 +773,14 @@ void Actor::UpdateTweening( float fDeltaTime )
 			// access TI or TS after, since this may modify the tweening queue.
 			if( !sCommand.empty() )
 			{
-				if( sCommand.Left(1) == "!" )
+				if( BeginsWith(sCommand, "!"))
+				{
 					MESSAGEMAN->Broadcast( sCommand.substr(1) );
+				}
 				else
+				{
 					this->PlayCommand( sCommand );
+				}
 			}
 		}
 	}

--- a/src/ActorFrameTexture.cpp
+++ b/src/ActorFrameTexture.cpp
@@ -16,7 +16,7 @@ ActorFrameTexture::ActorFrameTexture()
 	m_bPreserveTexture = false;
 	static uint64_t i = 0;
 	++i;
-	m_sTextureName = ssprintf( ConvertI64FormatString("ActorFrameTexture %lli"), i );
+	m_sTextureName = fmt::format("ActorFrameTexture {0}", i);
 
 	m_pRenderTarget = NULL;
 }

--- a/src/ActorUtil.cpp
+++ b/src/ActorUtil.cpp
@@ -132,8 +132,9 @@ namespace
 		RString sFile;
 		if (pActor->GetAttrValue("File", sFile) && sFile != "")
 		{
+			ci_string ciFile(sFile.c_str());
 			// Backward compatibility hacks for "special" filenames
-			if (sFile.EqualsNoCase("songbackground"))
+			if (ciFile == "songbackground")
 			{
 				XNodeStringValue *pVal = new XNodeStringValue;
 				Song *pSong = GAMESTATE->m_pCurSong;
@@ -144,7 +145,7 @@ namespace
 				pActor->AppendAttrFrom("Texture", pVal, false);
 				return "Sprite";
 			}
-			else if (sFile.EqualsNoCase("songbanner"))
+			else if (ciFile == "songbanner")
 			{
 				XNodeStringValue *pVal = new XNodeStringValue;
 				Song *pSong = GAMESTATE->m_pCurSong;
@@ -155,7 +156,7 @@ namespace
 				pActor->AppendAttrFrom("Texture", pVal, false);
 				return "Sprite";
 			}
-			else if (sFile.EqualsNoCase("coursebanner"))
+			else if (ciFile == "coursebanner")
 			{
 				XNodeStringValue *pVal = new XNodeStringValue;
 				Course *pCourse = GAMESTATE->m_pCurCourse;

--- a/src/ActorUtil.cpp
+++ b/src/ActorUtil.cpp
@@ -600,7 +600,7 @@ void ActorUtil::AddTypeExtensionsToList(FileType ft, vector<RString>& add_to)
 FileType ActorUtil::GetFileType( const RString &sPath )
 {
 	RString sExt = GetExtension( sPath );
-	sExt.MakeLower();
+	std::transform(sExt.begin(), sExt.end(), sExt.begin(), GetAsciiLower);
 
 	etft_cont_t::iterator conversion_entry= ExtensionToFileType.find(sExt);
 	if(conversion_entry != ExtensionToFileType.end())

--- a/src/ActorUtil.cpp
+++ b/src/ActorUtil.cpp
@@ -205,10 +205,14 @@ Actor *ActorUtil::LoadFromNode( const XNode* _pNode, Actor *pParentActor )
 		{
 			RString sPath;
 			// Handle absolute paths correctly
-			if (sFile.Left(1) == "/")
+			if (BeginsWith(sFile, "/"))
+			{
 				sPath = sFile;
+			}
 			else
+			{
 				sPath = Dirname(GetSourcePath(&node)) + sFile;
+			}
 			if (ResolvePath(sPath, GetWhere(&node)))
 			{
 				Actor *pNewActor = MakeActor(sPath, pParentActor);
@@ -414,7 +418,7 @@ bool ActorUtil::GetAttrPath( const XNode *pNode, const RString &sName, RString &
 	if( !pNode->GetAttrValue(sName, sOut) )
 		return false;
 
-	bool bIsRelativePath = sOut.Left(1) != "/";
+	bool bIsRelativePath = !BeginsWith(sOut, "/");
 	if( bIsRelativePath )
 	{
 		RString sDir;

--- a/src/ActorUtil.cpp
+++ b/src/ActorUtil.cpp
@@ -599,8 +599,7 @@ void ActorUtil::AddTypeExtensionsToList(FileType ft, vector<RString>& add_to)
 
 FileType ActorUtil::GetFileType( const RString &sPath )
 {
-	RString sExt = GetExtension( sPath );
-	std::transform(sExt.begin(), sExt.end(), sExt.begin(), GetAsciiLower);
+	RString sExt = MakeLower(GetExtension( sPath ));
 
 	etft_cont_t::iterator conversion_entry= ExtensionToFileType.find(sExt);
 	if(conversion_entry != ExtensionToFileType.end())

--- a/src/ActorUtil.cpp
+++ b/src/ActorUtil.cpp
@@ -338,7 +338,7 @@ Actor* ActorUtil::MakeActor( const RString &sPath_, Actor *pParentActor )
 		}
 	case FT_Directory:
 		{
-			if( sPath.Right(1) != "/" )
+			if( !EndsWith(sPath, "/"))
 				sPath += '/';
 
 			RString sXml = sPath + "default.xml";

--- a/src/AdjustSync.cpp
+++ b/src/AdjustSync.cpp
@@ -317,7 +317,7 @@ void AdjustSync::GetSyncChangeTextGlobal( vector<RString> &vsAddTo )
 
 		if( fabsf(fDelta) > 0.0001f )
 		{
-			vsAddTo.push_back( ssprintf(
+			vsAddTo.push_back( fmt::sprintf(
 				GLOBAL_OFFSET_FROM.GetValue(),
 				fOld, fNew,
 				(fDelta > 0 ? EARLIER:LATER).GetValue().c_str() ));
@@ -347,7 +347,7 @@ void AdjustSync::GetSyncChangeTextSong( vector<RString> &vsAddTo )
 
 			if( fabsf(fDelta) > 0.0001f )
 			{
-				vsAddTo.push_back( ssprintf(
+				vsAddTo.push_back( fmt::sprintf(
 					SONG_OFFSET_FROM.GetValue(),
 					fOld,
 					fNew,
@@ -372,8 +372,7 @@ void AdjustSync::GetSyncChangeTextSong( vector<RString> &vsAddTo )
 				break;
 			}
 
-			RString s = ssprintf( TEMPO_SEGMENT_FROM.GetValue(),
-					FormatNumberAndSuffix(i+1).c_str(), fOld, fNew );
+      			RString s = fmt::sprintf( TEMPO_SEGMENT_FROM.GetValue(), FormatNumberAndSuffix(i+1).c_str(), fOld, fNew );
 
 			vsAddTo.push_back( s );
 		}
@@ -397,7 +396,7 @@ void AdjustSync::GetSyncChangeTextSong( vector<RString> &vsAddTo )
 				break;
 			}
 
-			RString s = ssprintf( CHANGED_STOP.GetValue(), i+1, fOld, fNew, fDelta );
+			RString s = fmt::sprintf( CHANGED_STOP.GetValue(), i+1, fOld, fNew, fDelta );
 			vsAddTo.push_back( s );
 		}
 
@@ -423,18 +422,17 @@ void AdjustSync::GetSyncChangeTextSong( vector<RString> &vsAddTo )
 				break;
 			}
 
-			RString s = ssprintf( CHANGED_STOP.GetValue(),
-				i+1, fOld, fNew, fDelta );
+			RString s = fmt::sprintf( CHANGED_STOP.GetValue(), i+1, fOld, fNew, fDelta );
 			vsAddTo.push_back( s );
 		}
 
 		if( vsAddTo.size() > iOriginalSize && s_fAverageError > 0.0f )
 		{
-			vsAddTo.push_back( ssprintf(ERROR.GetValue(), s_fAverageError) );
+			vsAddTo.push_back( fmt::sprintf(ERROR.GetValue(), s_fAverageError) );
 		}
 		if( vsAddTo.size() > iOriginalSize && s_iStepsFiltered > 0 )
 		{
-			vsAddTo.push_back( ssprintf(TAPS_IGNORED.GetValue(), s_iStepsFiltered) );
+			vsAddTo.push_back( fmt::sprintf(TAPS_IGNORED.GetValue(), s_iStepsFiltered) );
 		}
 #undef SEGMENTS_MISMATCH_MESSAGE
 	}

--- a/src/AnnouncerManager.cpp
+++ b/src/AnnouncerManager.cpp
@@ -121,9 +121,10 @@ RString AnnouncerManager::GetPathTo( RString sAnnouncerName, RString sFolderName
 
 	/* Search for the announcer folder in the list of aliases. */
 	int i;
+	ci_string ciFolderName(sFolderName.c_str());
 	for(i = 0; aliases[i][0] != NULL; ++i)
 	{
-		if(!sFolderName.EqualsNoCase(aliases[i][0]))
+		if(ciFolderName != aliases[i][0])
 			continue; /* no match */
 
 		if( !DirectoryIsEmpty(AnnouncerPath+aliases[i][1]+"/") )
@@ -166,8 +167,12 @@ void AnnouncerManager::NextAnnouncer()
 	{
 		unsigned i;
 		for( i=0; i<as.size(); i++ )
-			if( as[i].EqualsNoCase(m_sCurAnnouncerName) )
+		{
+			ci_string announcer(as[i].c_str());
+			ci_string currName(m_sCurAnnouncerName.c_str());
+			if( announcer == currName )
 				break;
+		}
 		if( i==as.size()-1 )
 			SwitchAnnouncer( "" );
 		else

--- a/src/AnnouncerManager.cpp
+++ b/src/AnnouncerManager.cpp
@@ -37,10 +37,15 @@ void AnnouncerManager::GetAnnouncerNames( vector<RString>& AddTo )
 	StripCvsAndSvn( AddTo );
 	StripMacResourceForks( AddTo );
 
+	ci_string ciEmpty(EMPTY_ANNOUNCER_NAME.c_str());
 	// strip out the empty announcer folder
 	for( int i=AddTo.size()-1; i>=0; i-- )
-		if( !stricmp( AddTo[i], EMPTY_ANNOUNCER_NAME ) )
+	{
+		if (ciEmpty == AddTo[i].c_str())
+		{
 			AddTo.erase(AddTo.begin()+i, AddTo.begin()+i+1 );
+		}
+	}
 }
 
 bool AnnouncerManager::DoesAnnouncerExist( RString sAnnouncerName )
@@ -50,10 +55,11 @@ bool AnnouncerManager::DoesAnnouncerExist( RString sAnnouncerName )
 
 	vector<RString> asAnnouncerNames;
 	GetAnnouncerNames( asAnnouncerNames );
-	for( unsigned i=0; i<asAnnouncerNames.size(); i++ )
-		if( 0==stricmp(sAnnouncerName, asAnnouncerNames[i]) )
-			return true;
-	return false;
+	ci_string ciName(sAnnouncerName.c_str());
+	auto doesExist = [&ciName](RString const &name) {
+		return ciName == name.c_str();
+	};
+	return std::any_of(asAnnouncerNames.begin(), asAnnouncerNames.end(), doesExist);
 }
 
 RString AnnouncerManager::GetAnnouncerDirFromName( RString sAnnouncerName )

--- a/src/AnnouncerManager.cpp
+++ b/src/AnnouncerManager.cpp
@@ -206,7 +206,7 @@ public:
 		}
 		else
 		{
-			lua_pushstring(L, s );
+			lua_pushstring(L, s.c_str() );
 		}
 		return 1;
 	}

--- a/src/AttackDisplay.cpp
+++ b/src/AttackDisplay.cpp
@@ -15,7 +15,7 @@ RString GetAttackPieceName( const RString &sAttack )
 
 	/* 1.5x -> 1_5x.  If we pass a period to THEME->GetPathTo, it'll think
 	 * we're looking for a specific file and not search. */
-	ret.Replace( ".", "_" );
+	std::replace(ret.begin(), ret.end(), '.', '_');
 
 	return ret;
 }

--- a/src/BGAnimation.cpp
+++ b/src/BGAnimation.cpp
@@ -25,9 +25,9 @@ static bool CompareLayerNames( const RString& s1, const RString& s2 )
 	int i1, i2;
 	int ret;
 
-	ret = sscanf( s1, "Layer%d", &i1 );
+	ret = sscanf( s1.c_str(), "Layer%d", &i1 );
 	ASSERT( ret == 1 );
-	ret = sscanf( s2, "Layer%d", &i2 );
+	ret = sscanf( s2.c_str(), "Layer%d", &i2 );
 	ASSERT( ret == 1 );
 	return i1 < i2;
 }
@@ -40,7 +40,7 @@ void BGAnimation::AddLayersFromAniDir( const RString &_sAniDir, const XNode *pNo
 		vector<RString> vsLayerNames;
 		FOREACH_CONST_Child( pNode, pLayer )
 		{
-			if( strncmp(pLayer->GetName(), "Layer", 5) == 0 )
+			if( strncmp(pLayer->GetName().c_str(), "Layer", 5) == 0 )
 				vsLayerNames.push_back( pLayer->GetName() );
 		}
 

--- a/src/BGAnimation.cpp
+++ b/src/BGAnimation.cpp
@@ -147,8 +147,10 @@ void BGAnimation::LoadFromAniDir( const RString &_sAniDir )
 		for( unsigned i=0; i<asImagePaths.size(); i++ )
 		{
 			const RString sPath = asImagePaths[i];
-			if( Basename(sPath).Left(1) == "_" )
+			if( BeginsWith(Basename(sPath), "_"))
+			{
 				continue; // don't directly load files starting with an underscore
+			}
 			BGAnimationLayer* pLayer = new BGAnimationLayer;
 			pLayer->LoadFromAniLayerFile( asImagePaths[i] );
 			AddChild( pLayer );

--- a/src/BGAnimation.cpp
+++ b/src/BGAnimation.cpp
@@ -63,7 +63,7 @@ void BGAnimation::AddLayersFromAniDir( const RString &_sAniDir, const XNode *pNo
 				sImportDir = sAniDir + sImportDir;
 				CollapsePath( sImportDir );
 
-				if( sImportDir.Right(1) != "/" )
+				if( !EndsWith(sImportDir, "/"))
 					sImportDir += "/";
 
 				ASSERT_M( IsADirectory(sImportDir), sImportDir + " isn't a directory" );
@@ -94,7 +94,7 @@ void BGAnimation::LoadFromAniDir( const RString &_sAniDir )
 		 return;
 
 	RString sAniDir = _sAniDir;
-	if( sAniDir.Right(1) != "/" )
+	if( !EndsWith(sAniDir, "/"))
 		sAniDir += "/";
 
 	ASSERT_M( IsADirectory(sAniDir), sAniDir + " isn't a directory" );

--- a/src/BGAnimationLayer.cpp
+++ b/src/BGAnimationLayer.cpp
@@ -75,7 +75,7 @@ void BGAnimationLayer::LoadFromAniLayerFile( const RString& sPath )
 	/* Generic BGAs are new.  Animation directories with no INI are old and obsolete.
 	 * Don't combine them. */
 	RString lcPath = sPath;
-	lcPath.MakeLower();
+	std::transform(lcPath.begin(), lcPath.end(), lcPath.begin(), GetAsciiLower);
 
 	if( lcPath.find("usesongbg") != RString::npos )
 	{
@@ -349,7 +349,7 @@ void BGAnimationLayer::LoadFromAniLayerFile( const RString& sPath )
 
 
 	RString sHint = sPath;
-	sHint.MakeLower();
+	std::transform(sHint.begin(), sHint.end(), sHint.begin(), GetAsciiLower);
 
 	if( sHint.find("cyclecolor") != RString::npos )
 		for( unsigned i=0; i<m_SubActors.size(); i++ )

--- a/src/BGAnimationLayer.cpp
+++ b/src/BGAnimationLayer.cpp
@@ -384,7 +384,7 @@ void BGAnimationLayer::LoadFromNode( const XNode* pNode )
 	{
 		RString type = "sprite";
 		pNode->GetAttrValue( "Type", type );
-		type.MakeLower();
+		ci_string ciType(type.c_str());
 
 		/* The preferred way of stretching a sprite to fit the screen is "Type=sprite"
 		 * and "stretch=1".  "type=1" is for backwards-compatibility. */
@@ -393,15 +393,15 @@ void BGAnimationLayer::LoadFromNode( const XNode* pNode )
 		// Check for string match first, then do integer match.
 		// "if(StringType(type)==0)" was matching against all string matches.
 		// -Chris
-		if( type.EqualsNoCase("sprite") )
+		if( ciType == "sprite" )
 		{
 			m_Type = TYPE_SPRITE;
 		}
-		else if( type.EqualsNoCase("particles") )
+		else if( ciType == "particles" )
 		{
 			m_Type = TYPE_PARTICLES;
 		}
-		else if( type.EqualsNoCase("tiles") )
+		else if( ciType == "tiles" )
 		{
 			m_Type = TYPE_TILES;
 		}

--- a/src/BGAnimationLayer.cpp
+++ b/src/BGAnimationLayer.cpp
@@ -74,8 +74,7 @@ void BGAnimationLayer::LoadFromAniLayerFile( const RString& sPath )
 {
 	/* Generic BGAs are new.  Animation directories with no INI are old and obsolete.
 	 * Don't combine them. */
-	RString lcPath = sPath;
-	std::transform(lcPath.begin(), lcPath.end(), lcPath.begin(), GetAsciiLower);
+	RString lcPath = MakeLower(sPath);
 
 	if( lcPath.find("usesongbg") != RString::npos )
 	{
@@ -348,8 +347,7 @@ void BGAnimationLayer::LoadFromAniLayerFile( const RString& sPath )
 	}
 
 
-	RString sHint = sPath;
-	std::transform(sHint.begin(), sHint.end(), sHint.begin(), GetAsciiLower);
+	RString sHint = MakeLower(sPath);
 
 	if( sHint.find("cyclecolor") != RString::npos )
 		for( unsigned i=0; i<m_SubActors.size(); i++ )

--- a/src/BPMDisplay.cpp
+++ b/src/BPMDisplay.cpp
@@ -342,7 +342,7 @@ public:
 		}
 		COMMON_RETURN_SELF;
 	}
-	static int GetText( T* p, lua_State *L )		{ lua_pushstring( L, p->GetText() ); return 1; }
+	static int GetText( T* p, lua_State *L )		{ lua_pushstring( L, p->GetText().c_str() ); return 1; }
 
 	LunaBPMDisplay()
 	{

--- a/src/BPMDisplay.cpp
+++ b/src/BPMDisplay.cpp
@@ -81,9 +81,9 @@ void BPMDisplay::Update( float fDeltaTime )
 		{
 			m_fBPMFrom = -1;
 			if( (bool)SHOW_QMARKS )
-				SetText( (RandomFloat(0,1)>0.90f) ? (RString)QUESTIONMARKS_TEXT : ssprintf((RString)BPM_FORMAT_STRING,RandomFloat(0,999)) );
+				SetText( (RandomFloat(0,1)>0.90f) ? (RString)QUESTIONMARKS_TEXT : fmt::sprintf(BPM_FORMAT_STRING.GetValue(),RandomFloat(0,999)) );
 			else
-				SetText( ssprintf((RString)BPM_FORMAT_STRING, RandomFloat(0,999)) );
+				SetText( fmt::sprintf(BPM_FORMAT_STRING.GetValue(), RandomFloat(0,999)) );
 		}
 		else if(m_fBPMFrom == -1)
 		{
@@ -94,7 +94,7 @@ void BPMDisplay::Update( float fDeltaTime )
 	if( m_fBPMTo != -1)
 	{
 		const float fActualBPM = GetActiveBPM();
-		SetText( ssprintf((RString)BPM_FORMAT_STRING, fActualBPM) );
+		SetText( fmt::sprintf(BPM_FORMAT_STRING.GetValue(), fActualBPM) );
 	}
 }
 

--- a/src/BackgroundUtil.cpp
+++ b/src/BackgroundUtil.cpp
@@ -113,7 +113,7 @@ static void StripCvsAndSvn( vector<RString> &vsPathsToStrip, vector<RString> &vs
 	ASSERT( vsPathsToStrip.size() == vsNamesToStrip.size() );
 	for( unsigned i=0; i<vsNamesToStrip.size(); i++ )
 	{
-		if( vsNamesToStrip[i].Right(3).CompareNoCase("CVS") == 0 || vsNamesToStrip[i] == ".svn" )
+		if( tail(vsNamesToStrip[i], 3).CompareNoCase("CVS") == 0 || vsNamesToStrip[i] == ".svn" )
 		{
 			vsPathsToStrip.erase( vsPathsToStrip.begin()+i );
 			vsNamesToStrip.erase( vsNamesToStrip.begin()+i );
@@ -377,7 +377,7 @@ void BackgroundUtil::GetGlobalRandomMovies(
 
 	for (auto const &s: vsPathsOut)
 	{
-		RString sName = s.Right( s.size() - RANDOMMOVIES_DIR.size() - 1 );
+		RString sName = tail(s, s.size() - RANDOMMOVIES_DIR.size() - 1 );
 		vsNamesOut.push_back( sName );
 	}
 	StripCvsAndSvn( vsPathsOut, vsNamesOut );

--- a/src/BackgroundUtil.cpp
+++ b/src/BackgroundUtil.cpp
@@ -113,7 +113,8 @@ static void StripCvsAndSvn( vector<RString> &vsPathsToStrip, vector<RString> &vs
 	ASSERT( vsPathsToStrip.size() == vsNamesToStrip.size() );
 	for( unsigned i=0; i<vsNamesToStrip.size(); i++ )
 	{
-		if( tail(vsNamesToStrip[i], 3).CompareNoCase("CVS") == 0 || vsNamesToStrip[i] == ".svn" )
+        ci_string cvs(tail(vsNamesToStrip[i], 3).c_str());
+		if( cvs == "CVS" || vsNamesToStrip[i] == ".svn" )
 		{
 			vsPathsToStrip.erase( vsPathsToStrip.begin()+i );
 			vsNamesToStrip.erase( vsNamesToStrip.begin()+i );

--- a/src/BitmapText.cpp
+++ b/src/BitmapText.cpp
@@ -968,7 +968,7 @@ public:
 	static int jitter( T* p, lua_State *L )			{ p->SetJitter( BArg(1) ); COMMON_RETURN_SELF; }
 	static int distort( T* p, lua_State *L) { p->SetDistortion( FArg(1) ); COMMON_RETURN_SELF; }
 	static int undistort( T* p, lua_State *L) { p->UnSetDistortion(); COMMON_RETURN_SELF; }
-	static int GetText( T* p, lua_State *L )		{ lua_pushstring( L, p->GetText() ); return 1; }
+	static int GetText( T* p, lua_State *L )		{ lua_pushstring( L, p->GetText().c_str() ); return 1; }
 	static int AddAttribute( T* p, lua_State *L )
 	{
 		size_t iPos = IArg(1);

--- a/src/BitmapText.cpp
+++ b/src/BitmapText.cpp
@@ -952,13 +952,13 @@ public:
 		 * it's confusing for :: to work in some strings and not others.
 		 * Eventually, all strings should be Lua expressions, but until then,
 		 * continue to support this. */
-		s.Replace("::","\n");
+		ReplaceAll(s, "::", "\n");
 		FontCharAliases::ReplaceMarkers( s );
 
 		if( lua_gettop(L) > 1 )
 		{
 			sAlt = SArg(2);
-			sAlt.Replace("::","\n");
+			ReplaceAll(sAlt, "::", "\n");
 			FontCharAliases::ReplaceMarkers( sAlt );
 		}
 

--- a/src/BitmapText.cpp
+++ b/src/BitmapText.cpp
@@ -456,7 +456,7 @@ void BitmapText::SetText( const RString& _sText, const RString& _sAlternateText,
 
 	if( m_bUppercase )
 	{
-		std::transform(sNewText.begin(), sNewText.end(), sNewText.begin(), GetAsciiUpper);
+		sNewText = MakeUpper(sNewText);
 	}
 	if( iWrapWidthPixels == -1 )	// wrap not specified
 		iWrapWidthPixels = m_iWrapWidthPixels;

--- a/src/BitmapText.cpp
+++ b/src/BitmapText.cpp
@@ -455,8 +455,9 @@ void BitmapText::SetText( const RString& _sText, const RString& _sAlternateText,
 	RString sNewText = StringWillUseAlternate(_sText,_sAlternateText) ? _sAlternateText : _sText;
 
 	if( m_bUppercase )
-		sNewText.MakeUpper();
-
+	{
+		std::transform(sNewText.begin(), sNewText.end(), sNewText.begin(), GetAsciiUpper);
+	}
 	if( iWrapWidthPixels == -1 )	// wrap not specified
 		iWrapWidthPixels = m_iWrapWidthPixels;
 

--- a/src/Character.cpp
+++ b/src/Character.cpp
@@ -16,7 +16,7 @@ Character::Character(): m_sCharDir(""), m_sCharacterID(""),
 bool Character::Load( RString sCharDir )
 {
 	// Save character directory
-	if( sCharDir.Right(1) != "/" )
+	if( !EndsWith(sCharDir, "/"))
 		sCharDir += "/";
 	m_sCharDir = sCharDir;
 

--- a/src/Character.cpp
+++ b/src/Character.cpp
@@ -212,17 +212,17 @@ void Character::UndemandGraphics()
 class LunaCharacter: public Luna<Character>
 {
 public:
-	static int GetCardPath( T* p, lua_State *L )			{ lua_pushstring(L, p->GetCardPath() ); return 1; }
-	static int GetIconPath( T* p, lua_State *L )			{ lua_pushstring(L, p->GetIconPath() ); return 1; }
-	static int GetSongSelectIconPath( T* p, lua_State *L )	{ lua_pushstring(L, p->GetSongSelectIconPath() ); return 1; }
-	static int GetStageIconPath( T* p, lua_State *L )		{ lua_pushstring(L, p->GetStageIconPath() ); return 1; }
-	static int GetModelPath( T* p, lua_State *L )			{ lua_pushstring(L, p->GetModelPath() ); return 1; }
-	static int GetRestAnimationPath( T* p, lua_State *L )			{ lua_pushstring(L, p->GetRestAnimationPath() ); return 1; }
-	static int GetWarmUpAnimationPath( T* p, lua_State *L )			{ lua_pushstring(L, p->GetWarmUpAnimationPath() ); return 1; }
-	static int GetDanceAnimationPath( T* p, lua_State *L )			{ lua_pushstring(L, p->GetDanceAnimationPath() ); return 1; }
-	static int GetCharacterDir( T* p, lua_State *L )			{ lua_pushstring(L, p->m_sCharDir ); return 1; }
-	static int GetCharacterID( T* p, lua_State *L )			{ lua_pushstring(L, p->m_sCharacterID ); return 1; }
-	static int GetDisplayName( T* p, lua_State *L )			{ lua_pushstring(L, p->GetDisplayName() ); return 1; }
+	static int GetCardPath( T* p, lua_State *L )			{ lua_pushstring(L, p->GetCardPath().c_str() ); return 1; }
+	static int GetIconPath( T* p, lua_State *L )			{ lua_pushstring(L, p->GetIconPath().c_str() ); return 1; }
+	static int GetSongSelectIconPath( T* p, lua_State *L )	{ lua_pushstring(L, p->GetSongSelectIconPath().c_str() ); return 1; }
+	static int GetStageIconPath( T* p, lua_State *L )		{ lua_pushstring(L, p->GetStageIconPath().c_str() ); return 1; }
+	static int GetModelPath( T* p, lua_State *L )			{ lua_pushstring(L, p->GetModelPath().c_str() ); return 1; }
+	static int GetRestAnimationPath( T* p, lua_State *L )			{ lua_pushstring(L, p->GetRestAnimationPath().c_str() ); return 1; }
+	static int GetWarmUpAnimationPath( T* p, lua_State *L )			{ lua_pushstring(L, p->GetWarmUpAnimationPath().c_str() ); return 1; }
+	static int GetDanceAnimationPath( T* p, lua_State *L )			{ lua_pushstring(L, p->GetDanceAnimationPath().c_str() ); return 1; }
+	static int GetCharacterDir( T* p, lua_State *L )			{ lua_pushstring(L, p->m_sCharDir.c_str() ); return 1; }
+	static int GetCharacterID( T* p, lua_State *L )			{ lua_pushstring(L, p->m_sCharacterID.c_str() ); return 1; }
+	static int GetDisplayName( T* p, lua_State *L )			{ lua_pushstring(L, p->GetDisplayName().c_str() ); return 1; }
 
 	LunaCharacter()
 	{

--- a/src/Character.h
+++ b/src/Character.h
@@ -30,7 +30,8 @@ public:
 
 	bool IsDefaultCharacter() const
 	{
-		return m_sCharacterID.CompareNoCase("default") == 0;
+		ci_string defChar("default");
+		return defChar == m_sCharacterID.c_str();
 	}
 
 	void DemandGraphics();

--- a/src/CharacterManager.cpp
+++ b/src/CharacterManager.cpp
@@ -31,20 +31,25 @@ CharacterManager::CharacterManager()
 	StripMacResourceForks( as );
 
 	bool FoundDefault = false;
+	ci_string defChar("default");
 	for( unsigned i=0; i<as.size(); i++ )
 	{
 		RString sCharName, sDummy;
 		splitpath(as[i], sDummy, sCharName, sDummy);
-		sCharName.MakeLower();
-
-		if( sCharName.CompareNoCase("default")==0 )
+		if (defChar == sCharName.c_str())
+		{
 			FoundDefault = true;
+		}
 
 		Character* pChar = new Character;
 		if( pChar->Load( as[i] ) )
+		{
 			m_pCharacters.push_back( pChar );
+		}
 		else
+		{
 			delete pChar;
+		}
 	}
 
 	if( !FoundDefault )

--- a/src/CommandLineActions.cpp
+++ b/src/CommandLineActions.cpp
@@ -47,7 +47,7 @@ static void Nsis()
 		const LanguageInfo *pLI = GetLanguageInfo(sLangCode);
 
 		RString sLangNameUpper = pLI->szEnglishName;
-		sLangNameUpper.MakeUpper();
+		std::transform(sLangNameUpper.begin(), sLangNameUpper.end(), sLangNameUpper.begin(), GetAsciiUpper);
 
 		IniFile ini;
 		if(!ini.ReadFile(INSTALLER_LANGUAGES_DIR + s))

--- a/src/CommandLineActions.cpp
+++ b/src/CommandLineActions.cpp
@@ -46,8 +46,7 @@ static void Nsis()
 		splitpath(s, sThrowAway, sLangCode, sThrowAway);
 		const LanguageInfo *pLI = GetLanguageInfo(sLangCode);
 
-		RString sLangNameUpper = pLI->szEnglishName;
-		std::transform(sLangNameUpper.begin(), sLangNameUpper.end(), sLangNameUpper.begin(), GetAsciiUpper);
+		RString sLangNameUpper = MakeUpper(pLI->szEnglishName);
 
 		IniFile ini;
 		if(!ini.ReadFile(INSTALLER_LANGUAGES_DIR + s))

--- a/src/CommandLineActions.cpp
+++ b/src/CommandLineActions.cpp
@@ -57,7 +57,7 @@ static void Nsis()
 			{
 				RString sName = attr->first;
 				RString sValue = attr->second->GetValue<RString>();
-				sValue.Replace("\\n", "$\\n");
+				ReplaceAll(sValue, "\\n", "$\\n");
 				RString sLine = ssprintf("LangString %s ${LANG_%s} \"%s\"", sName.c_str(), sLangNameUpper.c_str(), sValue.c_str());
 				out.PutLine(sLine);
 			}

--- a/src/CommonMetrics.cpp
+++ b/src/CommonMetrics.cpp
@@ -31,7 +31,7 @@ ThemeMetricDifficultiesToShow::ThemeMetricDifficultiesToShow( const RString& sGr
 }
 void ThemeMetricDifficultiesToShow::Read()
 {
-	ASSERT( GetName().Right(6) == "ToShow" );
+	ASSERT( EndsWith(GetName(), "ToShow"));
 
 	ThemeMetric<RString>::Read();
 
@@ -70,7 +70,7 @@ ThemeMetricCourseDifficultiesToShow::ThemeMetricCourseDifficultiesToShow( const 
 }
 void ThemeMetricCourseDifficultiesToShow::Read()
 {
-	ASSERT( GetName().Right(6) == "ToShow" );
+	ASSERT( EndsWith(GetName(), "ToShow"));
 
 	ThemeMetric<RString>::Read();
 
@@ -129,7 +129,7 @@ ThemeMetricStepsTypesToShow::ThemeMetricStepsTypesToShow( const RString& sGroup,
 }
 void ThemeMetricStepsTypesToShow::Read()
 {
-	ASSERT( GetName().Right(6) == "ToHide" );
+	ASSERT( EndsWith(GetName(), "ToHide"));
 
 	ThemeMetric<RString>::Read();
 

--- a/src/Course.cpp
+++ b/src/Course.cpp
@@ -1055,8 +1055,8 @@ class LunaCourse: public Luna<Course>
 {
 public:
 	DEFINE_METHOD( GetPlayMode, GetPlayMode() )
-	static int GetDisplayFullTitle( T* p, lua_State *L )	{ lua_pushstring(L, p->GetDisplayFullTitle() ); return 1; }
-	static int GetTranslitFullTitle( T* p, lua_State *L )	{ lua_pushstring(L, p->GetTranslitFullTitle() ); return 1; }
+	static int GetDisplayFullTitle( T* p, lua_State *L )	{ lua_pushstring(L, p->GetDisplayFullTitle().c_str() ); return 1; }
+	static int GetTranslitFullTitle( T* p, lua_State *L )	{ lua_pushstring(L, p->GetTranslitFullTitle().c_str() ); return 1; }
 	static int HasMods( T* p, lua_State *L )		{ lua_pushboolean(L, p->HasMods() ); return 1; }
 	static int HasTimedMods( T* p, lua_State *L )		{ lua_pushboolean( L, p->HasTimedMods() ); return 1; }
 	DEFINE_METHOD( GetCourseType, GetCourseType() )
@@ -1080,12 +1080,12 @@ public:
 	}
 	static int GetBannerPath( T* p, lua_State *L )		{ RString s = p->GetBannerPath(); if( s.empty() ) return 0; LuaHelpers::Push(L, s); return 1; }
 	static int GetBackgroundPath( T* p, lua_State *L )		{ RString s = p->GetBackgroundPath(); if( s.empty() ) return 0; LuaHelpers::Push(L, s); return 1; }
-	static int GetCourseDir( T* p, lua_State *L )			{ lua_pushstring(L, p->m_sPath ); return 1; }
-	static int GetGroupName( T* p, lua_State *L )		{ lua_pushstring(L, p->m_sGroupName ); return 1; }
+	static int GetCourseDir( T* p, lua_State *L )			{ lua_pushstring(L, p->m_sPath.c_str() ); return 1; }
+	static int GetGroupName( T* p, lua_State *L )		{ lua_pushstring(L, p->m_sGroupName.c_str() ); return 1; }
 	static int IsAutogen( T* p, lua_State *L )		{ lua_pushboolean(L, p->m_bIsAutogen ); return 1; }
 	static int GetEstimatedNumStages( T* p, lua_State *L )	{ lua_pushnumber(L, p->GetEstimatedNumStages() ); return 1; }
-	static int GetScripter( T* p, lua_State *L )		{ lua_pushstring(L, p->m_sScripter ); return 1; }
-	static int GetDescription( T* p, lua_State *L )		{ lua_pushstring(L, p->m_sDescription ); return 1; }
+	static int GetScripter( T* p, lua_State *L )		{ lua_pushstring(L, p->m_sScripter.c_str() ); return 1; }
+	static int GetDescription( T* p, lua_State *L )		{ lua_pushstring(L, p->m_sDescription.c_str() ); return 1; }
 	static int GetTotalSeconds( T* p, lua_State *L )
 	{
 		StepsType st = Enum::Check<StepsType>(L, 1);

--- a/src/Course.cpp
+++ b/src/Course.cpp
@@ -986,7 +986,7 @@ void Course::CalculateRadarValues()
 bool Course::Matches( RString sGroup, RString sCourse ) const
 {
 	ci_string ciGroup(sGroup.c_str());
-	if( sGroup.size() && ci_string != this->m_sGroupName.c_str())
+	if( sGroup.size() && ciGroup != this->m_sGroupName.c_str())
 	{
 		return false;
 	}

--- a/src/Course.cpp
+++ b/src/Course.cpp
@@ -986,6 +986,7 @@ bool Course::Matches( RString sGroup, RString sCourse ) const
 	if( sGroup.size() && sGroup.CompareNoCase(this->m_sGroupName) != 0)
 		return false;
 
+	ci_string ciCourse(sCourse.c_str());
 	RString sFile = m_sPath;
 	if( !sFile.empty() )
 	{
@@ -993,11 +994,11 @@ bool Course::Matches( RString sGroup, RString sCourse ) const
 		vector<RString> bits;
 		split( sFile, "/", bits );
 		const RString &sLastBit = bits[bits.size()-1];
-		if( sCourse.EqualsNoCase(sLastBit) )
+		if( ciCourse == sLastBit.c_str() )
 			return true;
 	}
 
-	if( sCourse.EqualsNoCase(this->GetTranslitFullTitle()) )
+	if( ciCourse == this->GetTranslitFullTitle().c_str() )
 		return true;
 
 	return false;

--- a/src/Course.cpp
+++ b/src/Course.cpp
@@ -718,9 +718,10 @@ const Style *Course::GetCourseStyle( const Game *pGame, int iNumPlayers ) const
 
 	for (auto const *pStyle: vpStyles)
 	{
+		ci_string ciStyle(pStyle->m_szName);
 		for (auto const &style: m_setStyles)
 		{
-			if( !style.CompareNoCase(pStyle->m_szName) )
+			if( ciStyle == style.c_str() )
 			{
 				return pStyle;
 			}
@@ -917,12 +918,13 @@ bool Course::IsRanking() const
 	vector<RString> rankingsongs;
 
 	split(THEME->GetMetric("ScreenRanking", "CoursesToShow"), ",", rankingsongs);
-
-	for(unsigned i=0; i < rankingsongs.size(); i++)
-		if (rankingsongs[i].CompareNoCase(m_sPath))
-			return true;
-
-	return false;
+	ci_string ciPath(m_sPath.c_str());
+	
+	return std::any_of(rankingsongs.begin(), rankingsongs.end(), [&ciPath] (RString const &song) {
+		// This feels inverted. It was previously just CompareNoCase,
+		// which returns 0 on a match.
+		return ciPath != song.c_str();
+	});
 }
 
 const CourseEntry *Course::FindFixedSong( const Song *pSong ) const
@@ -983,9 +985,11 @@ void Course::CalculateRadarValues()
 
 bool Course::Matches( RString sGroup, RString sCourse ) const
 {
-	if( sGroup.size() && sGroup.CompareNoCase(this->m_sGroupName) != 0)
+	ci_string ciGroup(sGroup.c_str());
+	if( sGroup.size() && ci_string != this->m_sGroupName.c_str())
+	{
 		return false;
-
+	}
 	ci_string ciCourse(sCourse.c_str());
 	RString sFile = m_sPath;
 	if( !sFile.empty() )

--- a/src/Course.cpp
+++ b/src/Course.cpp
@@ -994,7 +994,7 @@ bool Course::Matches( RString sGroup, RString sCourse ) const
 	RString sFile = m_sPath;
 	if( !sFile.empty() )
 	{
-		sFile.Replace("\\","/");
+		std::replace(sFile.begin(), sFile.end(), '\\', '/');
 		vector<RString> bits;
 		split( sFile, "/", bits );
 		const RString &sLastBit = bits[bits.size()-1];

--- a/src/CourseLoaderCRS.cpp
+++ b/src/CourseLoaderCRS.cpp
@@ -89,7 +89,7 @@ bool CourseLoaderCRS::LoadFromMsd( const RString &sPath, const MsdFile &msd, Cou
 		else if( sValueName == "REPEAT" )
 		{
 			RString str = sParams[1];
-			str.MakeLower();
+			std::transform(str.begin(), str.end(), str.begin(), GetAsciiLower);
 			if( str.find("yes") != string::npos )
 				out.m_bRepeat = true;
 		}

--- a/src/CourseLoaderCRS.cpp
+++ b/src/CourseLoaderCRS.cpp
@@ -172,7 +172,7 @@ bool CourseLoaderCRS::LoadFromMsd( const RString &sPath, const MsdFile &msd, Cou
 			// most played
 			if( BeginsWith(sParams[1], "BEST"))
 			{
-				int iChooseIndex = StringToInt( sParams[1].Right(sParams[1].size()-strlen("BEST")) ) - 1;
+				int iChooseIndex = StringToInt( tail(sParams[1], -4)) - 1;
 				if( iChooseIndex > iNumSongs )
 				{
 					// looking up a song that doesn't exist.
@@ -189,7 +189,7 @@ bool CourseLoaderCRS::LoadFromMsd( const RString &sPath, const MsdFile &msd, Cou
 			// least played
 			else if( BeginsWith(sParams[1], "WORST"))
 			{
-				int iChooseIndex = StringToInt( sParams[1].Right(sParams[1].size()-strlen("BEST")) ) - 1;
+				int iChooseIndex = StringToInt( tail(sParams[1], -5)) - 1;
 				if( iChooseIndex > iNumSongs )
 				{
 					// looking up a song that doesn't exist.
@@ -206,14 +206,14 @@ bool CourseLoaderCRS::LoadFromMsd( const RString &sPath, const MsdFile &msd, Cou
 			// best grades
 			else if( BeginsWith(sParams[1], "GRADEBEST"))
 			{
-				new_entry.iChooseIndex = StringToInt( sParams[1].Right(sParams[1].size()-strlen("GRADEBEST")) ) - 1;
+				new_entry.iChooseIndex = StringToInt( tail(sParams[1], -9)) - 1;
 				CLAMP( new_entry.iChooseIndex, 0, 500 );
 				new_entry.songSort = SongSort_TopGrades;
 			}
 			// worst grades
 			else if( BeginsWith(sParams[1], "GRADEWORST"))
 			{
-				new_entry.iChooseIndex = StringToInt( sParams[1].Right(sParams[1].size()-strlen("GRADEWORST")) ) - 1;
+				new_entry.iChooseIndex = StringToInt( tail(sParams[1], -10)) - 1;
 				CLAMP( new_entry.iChooseIndex, 0, 500 );
 				new_entry.songSort = SongSort_LowestGrades;
 			}
@@ -222,7 +222,7 @@ bool CourseLoaderCRS::LoadFromMsd( const RString &sPath, const MsdFile &msd, Cou
 				//new_entry.bSecret = true;
 			}
 			// group random
-			else if( sParams[1].Right(1) == "*" )
+			else if( EndsWith(sParams[1], "*"))
 			{
 				//new_entry.bSecret = true;
 				RString sSong = sParams[1];

--- a/src/CourseLoaderCRS.cpp
+++ b/src/CourseLoaderCRS.cpp
@@ -245,7 +245,7 @@ bool CourseLoaderCRS::LoadFromMsd( const RString &sPath, const MsdFile &msd, Cou
 			{
 				//new_entry.bSecret = true;
 				RString sSong = sParams[1];
-				sSong.Replace( "\\", "/" );
+				std::replace(sSong.begin(), sSong.end(), '\\', '/');
 				vector<RString> bits;
 				split( sSong, "/", bits );
 				if( bits.size() == 2 )
@@ -269,7 +269,7 @@ bool CourseLoaderCRS::LoadFromMsd( const RString &sPath, const MsdFile &msd, Cou
 			else
 			{
 				RString sSong = sParams[1];
-				sSong.Replace( "\\", "/" );
+				std::replace(sSong.begin(), sSong.end(), '\\', '/');
 				vector<RString> bits;
 				split( sSong, "/", bits );
 

--- a/src/CourseLoaderCRS.cpp
+++ b/src/CourseLoaderCRS.cpp
@@ -40,9 +40,14 @@ const char *g_CRSDifficultyNames[] =
  */
 static CourseDifficulty CRSStringToDifficulty( const RString& s )
 {
+	ci_string diff(s.c_str());
 	FOREACH_ENUM( Difficulty,i)
-		if( !s.CompareNoCase(g_CRSDifficultyNames[i]) )
+	{
+		if (diff == g_CRSDifficultyNames[i])
+		{
 			return i;
+		}
+	}
 	return Difficulty_Invalid;
 }
 

--- a/src/CourseLoaderCRS.cpp
+++ b/src/CourseLoaderCRS.cpp
@@ -63,17 +63,25 @@ bool CourseLoaderCRS::LoadFromMsd( const RString &sPath, const MsdFile &msd, Cou
 	{
 		RString sValueName = msd.GetParam(i, 0);
 		const MsdFile::value_t &sParams = msd.GetValue(i);
-
+		ci_string ciValueName(sValueName.c_str());
 		// handle the data
-		if( sValueName.EqualsNoCase("COURSE") )
+		if( sValueName == "COURSE" )
+		{
 			out.m_sMainTitle = sParams[1];
-		else if( sValueName.EqualsNoCase("COURSETRANSLIT") )
+		}
+		else if( sValueName == "COURSETRANSLIT" )
+		{
 			out.m_sMainTitleTranslit = sParams[1];
-		else if( sValueName.EqualsNoCase("SCRIPTER") )
+		}
+		else if( sValueName == "SCRIPTER" )
+		{
 			out.m_sScripter = sParams[1];
-		else if( sValueName.EqualsNoCase("DESCRIPTION") )
+		}
+		else if( sValueName == "DESCRIPTION" )
+		{
 			out.m_sDescription = sParams[1];
-		else if( sValueName.EqualsNoCase("REPEAT") )
+		}
+		else if( sValueName == "REPEAT" )
 		{
 			RString str = sParams[1];
 			str.MakeLower();
@@ -81,23 +89,23 @@ bool CourseLoaderCRS::LoadFromMsd( const RString &sPath, const MsdFile &msd, Cou
 				out.m_bRepeat = true;
 		}
 
-		else if( sValueName.EqualsNoCase("BANNER") )
+		else if( sValueName == "BANNER" )
 		{
 			out.m_sBannerPath = sParams[1];
 		}
-		else if( sValueName.EqualsNoCase("BACKGROUND") )
+		else if( sValueName == "BACKGROUND" )
 		{
 			out.m_sBackgroundPath = sParams[1];
 		}
-		else if( sValueName.EqualsNoCase("LIVES") )
+		else if( sValueName == "LIVES" )
 		{
 			out.m_iLives = max( StringToInt(sParams[1]), 0 );
 		}
-		else if( sValueName.EqualsNoCase("GAINSECONDS") )
+		else if( sValueName == "GAINSECONDS" )
 		{
 			fGainSeconds = StringToFloat( sParams[1] );
 		}
-		else if( sValueName.EqualsNoCase("METER") )
+		else if( sValueName == "METER" )
 		{
 			if( sParams.params.size() == 2 )
 			{
@@ -115,7 +123,7 @@ bool CourseLoaderCRS::LoadFromMsd( const RString &sPath, const MsdFile &msd, Cou
 			}
 		}
 
-		else if( sValueName.EqualsNoCase("MODS") )
+		else if( sValueName == "MODS" )
 		{
 			Attack attack;
 			float end = -9999;
@@ -127,13 +135,20 @@ bool CourseLoaderCRS::LoadFromMsd( const RString &sPath, const MsdFile &msd, Cou
 					continue;
 
 				Trim( sBits[0] );
-				if( !sBits[0].CompareNoCase("TIME") )
+				ci_string ciBits(sBits[0].c_str());
+				if( ciBits == "TIME")
+				{
 					attack.fStartSecond = max( StringToFloat(sBits[1]), 0.0f );
-				else if( !sBits[0].CompareNoCase("LEN") )
+				}
+				else if( ciBits == "LEN")
+				{
 					attack.fSecsRemaining = StringToFloat( sBits[1] );
-				else if( !sBits[0].CompareNoCase("END") )
+				}
+				else if( ciBits == "END")
+				{
 					end = StringToFloat( sBits[1] );
-				else if( !sBits[0].CompareNoCase("MODS") )
+				}
+				else if( ciBits == "MODS")
 				{
 					attack.sModifiers = sBits[1];
 
@@ -161,7 +176,7 @@ bool CourseLoaderCRS::LoadFromMsd( const RString &sPath, const MsdFile &msd, Cou
 			}
 
 		}
-		else if( sValueName.EqualsNoCase("SONG") )
+		else if( sValueName == "SONG" )
 		{
 			CourseEntry new_entry;
 
@@ -281,7 +296,7 @@ bool CourseLoaderCRS::LoadFromMsd( const RString &sPath, const MsdFile &msd, Cou
         new_entry.stepsCriteria.m_difficulty = StringToDifficulty( sParams[2] );
 			if( new_entry.stepsCriteria.m_difficulty == Difficulty_Invalid )
 			{
-				int retval = sscanf( sParams[2], "%d..%d", &new_entry.stepsCriteria.m_iLowMeter, &new_entry.stepsCriteria.m_iHighMeter );
+				int retval = sscanf( sParams[2].c_str(), "%d..%d", &new_entry.stepsCriteria.m_iLowMeter, &new_entry.stepsCriteria.m_iHighMeter );
 				if( retval == 1 )
 					new_entry.stepsCriteria.m_iHighMeter = new_entry.stepsCriteria.m_iLowMeter;
 				else if( retval != 2 )
@@ -305,16 +320,35 @@ bool CourseLoaderCRS::LoadFromMsd( const RString &sPath, const MsdFile &msd, Cou
 					RString &sMod = mods[j];
 					TrimLeft( sMod );
 					TrimRight( sMod );
-					if( !sMod.CompareNoCase("showcourse") )
+					ci_string ciMod(sMod.c_str());
+					if( ciMod == "showcourse")
+					{
 						new_entry.bSecret = false;
-					else if( !sMod.CompareNoCase("noshowcourse") )
+					}
+					else if( ciMod == "noshowcourse")
+					{
 						new_entry.bSecret = true;
-					else if( !sMod.CompareNoCase("nodifficult") )
+					}
+					else if( ciMod == "nodifficult")
+					{
 						new_entry.bNoDifficult = true;
-					else if( sMod.length() > 5 && !head(sMod, 5).CompareNoCase("award") )
-						new_entry.iGainLives = StringToInt( sMod.substr(5) );
+					}
+					else if (ciMod.length() > 5)
+					{
+						ci_string awardMod(head(sMod, 5).c_str());
+						if (awardMod == "award")
+						{
+							new_entry.iGainLives = StringToInt(sMod.substr(5));
+						}
+						else
+						{
+							continue;
+						}
+					}
 					else
+					{
 						continue;
+					}
 					mods.erase( mods.begin() + j );
 				}
 				new_entry.sModifiers = join( ",", mods );
@@ -326,13 +360,13 @@ bool CourseLoaderCRS::LoadFromMsd( const RString &sPath, const MsdFile &msd, Cou
 
 			out.m_vEntries.push_back( new_entry );
 		}
-		else if( !sValueName.EqualsNoCase("DISPLAYCOURSE") || !sValueName.EqualsNoCase("COMBO") ||
-			 !sValueName.EqualsNoCase("COMBOMODE") )
+		else if( sValueName == "DISPLAYCOURSE" || sValueName == "COMBO" ||
+			 sValueName == "COMBOMODE" )
 		{
 			// Ignore
 		}
 
-		else if( bFromCache && !sValueName.EqualsNoCase("RADAR") )
+		else if( bFromCache && sValueName == "RADAR" )
 		{
 			StepsType st = (StepsType) StringToInt(sParams[1]);
 			CourseDifficulty cd = (CourseDifficulty) StringToInt( sParams[2] );
@@ -341,7 +375,7 @@ bool CourseLoaderCRS::LoadFromMsd( const RString &sPath, const MsdFile &msd, Cou
 			rv.FromString( sParams[3] );
 			out.m_RadarCache[Course::CacheEntry(st, cd)] = rv;
 		}
-		else if( sValueName.EqualsNoCase("STYLE") )
+		else if( sValueName == "STYLE" )
 		{
 			RString sStyles = sParams[1];
 			vector<RString> asStyles;

--- a/src/CourseLoaderCRS.cpp
+++ b/src/CourseLoaderCRS.cpp
@@ -88,8 +88,7 @@ bool CourseLoaderCRS::LoadFromMsd( const RString &sPath, const MsdFile &msd, Cou
 		}
 		else if( sValueName == "REPEAT" )
 		{
-			RString str = sParams[1];
-			std::transform(str.begin(), str.end(), str.begin(), GetAsciiLower);
+			RString str = MakeLower(sParams[1]);
 			if( str.find("yes") != string::npos )
 				out.m_bRepeat = true;
 		}

--- a/src/CourseLoaderCRS.cpp
+++ b/src/CourseLoaderCRS.cpp
@@ -170,7 +170,7 @@ bool CourseLoaderCRS::LoadFromMsd( const RString &sPath, const MsdFile &msd, Cou
 			// to a lack of songs. -aj
 			int iNumSongs = SONGMAN->GetNumSongs();
 			// most played
-			if( sParams[1].Left(strlen("BEST")) == "BEST" )
+			if( BeginsWith(sParams[1], "BEST"))
 			{
 				int iChooseIndex = StringToInt( sParams[1].Right(sParams[1].size()-strlen("BEST")) ) - 1;
 				if( iChooseIndex > iNumSongs )
@@ -187,7 +187,7 @@ bool CourseLoaderCRS::LoadFromMsd( const RString &sPath, const MsdFile &msd, Cou
 				new_entry.songSort = SongSort_MostPlays;
 			}
 			// least played
-			else if( sParams[1].Left(strlen("WORST")) == "WORST" )
+			else if( BeginsWith(sParams[1], "WORST"))
 			{
 				int iChooseIndex = StringToInt( sParams[1].Right(sParams[1].size()-strlen("BEST")) ) - 1;
 				if( iChooseIndex > iNumSongs )
@@ -204,14 +204,14 @@ bool CourseLoaderCRS::LoadFromMsd( const RString &sPath, const MsdFile &msd, Cou
 				new_entry.songSort = SongSort_FewestPlays;
 			}
 			// best grades
-			else if( sParams[1].Left(strlen("GRADEBEST")) == "GRADEBEST" )
+			else if( BeginsWith(sParams[1], "GRADEBEST"))
 			{
 				new_entry.iChooseIndex = StringToInt( sParams[1].Right(sParams[1].size()-strlen("GRADEBEST")) ) - 1;
 				CLAMP( new_entry.iChooseIndex, 0, 500 );
 				new_entry.songSort = SongSort_TopGrades;
 			}
 			// worst grades
-			else if( sParams[1].Left(strlen("GRADEWORST")) == "GRADEWORST" )
+			else if( BeginsWith(sParams[1], "GRADEWORST"))
 			{
 				new_entry.iChooseIndex = StringToInt( sParams[1].Right(sParams[1].size()-strlen("GRADEWORST")) ) - 1;
 				CLAMP( new_entry.iChooseIndex, 0, 500 );
@@ -311,7 +311,7 @@ bool CourseLoaderCRS::LoadFromMsd( const RString &sPath, const MsdFile &msd, Cou
 						new_entry.bSecret = true;
 					else if( !sMod.CompareNoCase("nodifficult") )
 						new_entry.bNoDifficult = true;
-					else if( sMod.length() > 5 && !sMod.Left(5).CompareNoCase("award") )
+					else if( sMod.length() > 5 && !head(sMod, 5).CompareNoCase("award") )
 						new_entry.iGainLives = StringToInt( sMod.substr(5) );
 					else
 						continue;

--- a/src/CourseUtil.cpp
+++ b/src/CourseUtil.cpp
@@ -20,9 +20,9 @@ using std::vector;
 // Sorting stuff
 static bool CompareCoursePointersByName( const Course* pCourse1, const Course* pCourse2 )
 {
-	RString sName1 = pCourse1->GetDisplayFullTitle();
+	ci_string sName1 = pCourse1->GetDisplayFullTitle().c_str();
 	RString sName2 = pCourse2->GetDisplayFullTitle();
-	return sName1.CompareNoCase( sName2 ) < 0;
+	return sName1 < sName2.c_str();
 }
 
 static bool CompareCoursePointersByAutogen( const Course* pCourse1, const Course* pCourse2 )

--- a/src/CourseUtil.cpp
+++ b/src/CourseUtil.cpp
@@ -427,9 +427,9 @@ bool EditCourseUtil::ValidateEditCourseName( const RString &sAnswer, RString &sE
 	}
 
 	static const RString sInvalidChars = "\\/:*?\"<>|";
-	if( strpbrk(sAnswer, sInvalidChars) != NULL )
+	if( std::strpbrk(sAnswer.c_str(), sInvalidChars.c_str()) != NULL )
 	{
-		sErrorOut = ssprintf( EDIT_NAME_CANNOT_CONTAIN.GetValue(), sInvalidChars.c_str() );
+		sErrorOut = fmt::sprintf( EDIT_NAME_CANNOT_CONTAIN.GetValue(), sInvalidChars.c_str() );
 		return false;
 	}
 

--- a/src/CourseUtil.cpp
+++ b/src/CourseUtil.cpp
@@ -552,7 +552,7 @@ void CourseID::FromCourse( const Course *p )
 
 	// HACK for backwards compatibility:
 	// Strip off leading "/".  2005/05/21 file layer changes added a leading slash.
-	if( sPath.Left(1) == "/" )
+	if( BeginsWith(sPath, "/"))
 		sPath.erase( sPath.begin() );
 
 	m_Cache.Unset();
@@ -563,7 +563,7 @@ Course *CourseID::ToCourse() const
 	// HACK for backwards compatibility:
 	// Re-add the leading "/".  2005/05/21 file layer changes added a leading slash.
 	RString sPath2 = sPath;
-	if( sPath2.Left(1) != "/" )
+	if( !BeginsWith(sPath2, "/"))
 		sPath2 = "/" + sPath2;
 
 	Course *pCourse = NULL;

--- a/src/CreateZip.cpp
+++ b/src/CreateZip.cpp
@@ -1011,12 +1011,12 @@ RString MakeDestZipFileName( RString fn )
 }
 bool CreateZip::AddFile(RString fn)
 {
-	lasterrorZ = hz->Add(MakeDestZipFileName(fn),fn,ZIP_FILENAME);
+	lasterrorZ = hz->Add(MakeDestZipFileName(fn).c_str(),fn.c_str(),ZIP_FILENAME);
 	return lasterrorZ == ZR_OK;
 }
 bool CreateZip::AddDir(RString fn)
 {
-	lasterrorZ = hz->Add(MakeDestZipFileName(fn),NULL,ZIP_FOLDER);
+	lasterrorZ = hz->Add(MakeDestZipFileName(fn).c_str(),NULL,ZIP_FOLDER);
 	return lasterrorZ == ZR_OK;
 }
 bool CreateZip::Finish()

--- a/src/CryptManager.cpp
+++ b/src/CryptManager.cpp
@@ -455,37 +455,32 @@ class LunaCryptManager: public Luna<CryptManager>
 public:
 	static int MD5String( T* p, lua_State *L )
 	{
-		RString md5out;
-		md5out = p->GetMD5ForString(SArg(1));
-		lua_pushstring( L, md5out );
+		RString md5out = p->GetMD5ForString(SArg(1));
+		lua_pushstring( L, md5out.c_str() );
 		return 1;
 	}
 	static int MD5File( T* p, lua_State *L )
 	{
-		RString md5fout;
-		md5fout = p->GetMD5ForFile(SArg(1));
-		lua_pushstring( L, md5fout );
+		RString md5fout = p->GetMD5ForFile(SArg(1));
+		lua_pushstring( L, md5fout.c_str() );
 		return 1;
 	}
 	static int SHA1String( T* p, lua_State *L )
 	{
-		RString sha1out;
-		sha1out = p->GetSHA1ForString(SArg(1));
-		lua_pushstring( L, sha1out );
+		RString sha1out = p->GetSHA1ForString(SArg(1));
+		lua_pushstring( L, sha1out.c_str() );
 		return 1;
 	}
 	static int SHA1File( T* p, lua_State *L )
 	{
-		RString sha1fout;
-		sha1fout = p->GetSHA1ForFile(SArg(1));
-		lua_pushstring( L, sha1fout );
+		RString sha1fout = p->GetSHA1ForFile(SArg(1));
+		lua_pushstring( L, sha1fout.c_str() );
 		return 1;
 	}
 	static int GenerateRandomUUID( T* p, lua_State *L )
 	{
-		RString uuidOut;
-		uuidOut = p->GenerateRandomUUID();
-		lua_pushstring( L, uuidOut );
+		RString uuidOut = p->GenerateRandomUUID();
+		lua_pushstring( L, uuidOut.c_str() );
 		return 1;
 	}
 

--- a/src/DateTime.cpp
+++ b/src/DateTime.cpp
@@ -114,7 +114,7 @@ bool DateTime::FromString( const RString sDateTime )
 
 	int ret;
 
-	ret = sscanf( sDateTime, "%d-%d-%d %d:%d:%d", 
+	ret = sscanf( sDateTime.c_str(), "%d-%d-%d %d:%d:%d",
 		&tm_year,
 		&tm_mon,
 		&tm_mday,
@@ -123,7 +123,7 @@ bool DateTime::FromString( const RString sDateTime )
 		&tm_sec );
 	if( ret != 6 )
 	{
-		ret = sscanf( sDateTime, "%d-%d-%d", 
+		ret = sscanf( sDateTime.c_str(), "%d-%d-%d",
 			&tm_year,
 			&tm_mon,
 			&tm_mday );
@@ -148,7 +148,7 @@ RString DayInYearToString( int iDayInYear )
 int StringToDayInYear( RString sDayInYear )
 {
 	int iDayInYear;
-	if( sscanf( sDayInYear, "DayInYear%d", &iDayInYear ) != 1 )
+	if( sscanf( sDayInYear.c_str(), "DayInYear%d", &iDayInYear ) != 1 )
 		return -1;
 	return iDayInYear;
 }

--- a/src/DateTime.cpp
+++ b/src/DateTime.cpp
@@ -222,16 +222,16 @@ RString LastWeekToString( int iLastWeekIndex )
 RString LastDayToLocalizedString( int iLastDayIndex )
 {
 	RString s = LastDayToString( iLastDayIndex );
-	s.Replace( "Day", "" );
-	s.Replace( "Ago", " Ago" );
+	ReplaceAll(s, "Day", "");
+	ReplaceAll(s, "Ago", " Ago");
 	return s;
 }
 
 RString LastWeekToLocalizedString( int iLastWeekIndex )
 {
 	RString s = LastWeekToString( iLastWeekIndex );
-	s.Replace( "Week", "" );
-	s.Replace( "Ago", " Ago" );
+	ReplaceAll(s, "Week", "");
+	ReplaceAll(s, "Ago", " Ago");
 	return s;
 }
 

--- a/src/Difficulty.cpp
+++ b/src/Difficulty.cpp
@@ -80,8 +80,7 @@ struct OldStyleStringToDifficultyMapHolder
 OldStyleStringToDifficultyMapHolder OldStyleStringToDifficulty_converter;
 Difficulty OldStyleStringToDifficulty( const RString& sDC )
 {
-	RString s2 = sDC;
-	std::transform(s2.begin(), s2.end(), s2.begin(), GetAsciiLower);
+	RString s2 = MakeLower(sDC);
 	std::map<RString, Difficulty>::iterator diff=
 		OldStyleStringToDifficulty_converter.conversion_map.find(s2);
 	if(diff != OldStyleStringToDifficulty_converter.conversion_map.end())

--- a/src/Difficulty.cpp
+++ b/src/Difficulty.cpp
@@ -81,7 +81,7 @@ OldStyleStringToDifficultyMapHolder OldStyleStringToDifficulty_converter;
 Difficulty OldStyleStringToDifficulty( const RString& sDC )
 {
 	RString s2 = sDC;
-	s2.MakeLower();
+	std::transform(s2.begin(), s2.end(), s2.begin(), GetAsciiLower);
 	std::map<RString, Difficulty>::iterator diff=
 		OldStyleStringToDifficulty_converter.conversion_map.find(s2);
 	if(diff != OldStyleStringToDifficulty_converter.conversion_map.end())

--- a/src/EnumHelper.cpp
+++ b/src/EnumHelper.cpp
@@ -31,7 +31,7 @@ int CheckEnum( lua_State *L, LuaReference &table, int iPos, int iInvalid, const 
 		// Get the string and lowercase it
 		lua_pushvalue( L, iPos );
 		LuaHelpers::Pop( L, sLower );
-		std::transform(sLower.begin(), sLower.end(), sLower.begin(), GetAsciiLower);
+		sLower = MakeLower(sLower);
 
 		// Try again to read the value
 		table.PushSelf( L );

--- a/src/EnumHelper.cpp
+++ b/src/EnumHelper.cpp
@@ -31,7 +31,7 @@ int CheckEnum( lua_State *L, LuaReference &table, int iPos, int iInvalid, const 
 		// Get the string and lowercase it
 		lua_pushvalue( L, iPos );
 		LuaHelpers::Pop( L, sLower );
-		sLower.MakeLower();
+		std::transform(sLower.begin(), sLower.end(), sLower.begin(), GetAsciiLower);
 
 		// Try again to read the value
 		table.PushSelf( L );

--- a/src/EnumHelper.h
+++ b/src/EnumHelper.h
@@ -141,7 +141,7 @@ static void Lua##X(lua_State* L) \
 		lua_pushnumber( L, i ); /* 0-based */ \
 		lua_rawset( L, -3 ); \
 		/* Compatibility with old, case-insensitive values */ \
-		std::transform(s.begin(), s.end(), s.begin(), GetAsciiLower); \
+		s = MakeLower(s); \
 		lua_pushstring( L, s.c_str() ); \
 		lua_pushnumber( L, i ); /* 0-based */ \
 		lua_rawset( L, -3 ); \

--- a/src/EnumHelper.h
+++ b/src/EnumHelper.h
@@ -97,9 +97,12 @@ const RString &X##ToLocalizedString( X x ) \
 X StringTo##X(const RString&); \
 X StringTo##X( const RString& s ) \
 {	\
+	ci_string tmpName(s.c_str()); \
 	for( unsigned i = 0; i < ARRAYLEN(X##Names); ++i )	\
-		if( !s.CompareNoCase(X##Names[i]) )	\
-			return (X)i;	\
+		if (tmpName == X##Names[i]) \
+		{ \
+			return (X)i; \
+		} \
 	return X##_Invalid;	\
 } \
 namespace StringConversion \

--- a/src/EnumHelper.h
+++ b/src/EnumHelper.h
@@ -123,7 +123,7 @@ static void Lua##X(lua_State* L) \
 	FOREACH_ENUM( X, i ) \
 	{ \
 		RString s = X##ToString( i ); \
-		lua_pushstring( L, (#X "_")+s ); \
+		lua_pushstring( L, ((#X "_")+s).c_str() ); \
 		lua_rawseti( L, -2, i+1 ); /* 1-based */ \
 	} \
 	EnumTraits<X>::EnumToString.SetFromStack( L ); \
@@ -134,12 +134,12 @@ static void Lua##X(lua_State* L) \
 	FOREACH_ENUM( X, i ) \
 	{ \
 		RString s = X##ToString( i ); \
-		lua_pushstring( L, (#X "_")+s ); \
+		lua_pushstring( L, ((#X "_")+s).c_str() ); \
 		lua_pushnumber( L, i ); /* 0-based */ \
 		lua_rawset( L, -3 ); \
 		/* Compatibility with old, case-insensitive values */ \
-		s.MakeLower(); \
-		lua_pushstring( L, s ); \
+		std::transform(s.begin(), s.end(), s.begin(), ::tolower); \
+		lua_pushstring( L, s.c_str() ); \
 		lua_pushnumber( L, i ); /* 0-based */ \
 		lua_rawset( L, -3 ); \
 		/* Compatibility with old, raw values */ \

--- a/src/EnumHelper.h
+++ b/src/EnumHelper.h
@@ -141,7 +141,7 @@ static void Lua##X(lua_State* L) \
 		lua_pushnumber( L, i ); /* 0-based */ \
 		lua_rawset( L, -3 ); \
 		/* Compatibility with old, case-insensitive values */ \
-		std::transform(s.begin(), s.end(), s.begin(), ::tolower); \
+		std::transform(s.begin(), s.end(), s.begin(), GetAsciiLower); \
 		lua_pushstring( L, s.c_str() ); \
 		lua_pushnumber( L, i ); /* 0-based */ \
 		lua_rawset( L, -3 ); \

--- a/src/FileDownload.cpp
+++ b/src/FileDownload.cpp
@@ -107,7 +107,7 @@ void FileTransfer::StartTransfer( TransferType type, const RString &sURL, const 
 		m_sBaseAddress += ssprintf( ":%d", Port );
 	m_sBaseAddress += "/";
 
-	if( sAddress.Right(1) != "/" )
+	if( !EndsWith(sAddress, "/"))
 	{
 		m_sEndName = Basename( sAddress );
 		m_sBaseAddress += Dirname( sAddress );

--- a/src/FileDownload.cpp
+++ b/src/FileDownload.cpp
@@ -210,7 +210,7 @@ void FileTransfer::StartTransfer( TransferType type, const RString &sURL, const 
 	m_wSocket.SendData( sHeader.c_str(), sHeader.length() );
 	m_wSocket.SendData( "\r\n" );
 
-	m_wSocket.SendData( sRequestPayload.GetBuffer(), sRequestPayload.size() );
+	m_wSocket.SendData( sRequestPayload.c_str(), sRequestPayload.size() );
 
 	m_sStatus = "Header Sent.";
 	m_wSocket.blocking = false;

--- a/src/Font.cpp
+++ b/src/Font.cpp
@@ -674,7 +674,8 @@ void Font::LoadFontPageSettings( FontPageSettings &cfg, IniFile &ini, const RStr
 
 RString FontPageSettings::MapRange( RString sMapping, int iMapOffset, int iGlyphNo, int iCount )
 {
-	if( !sMapping.CompareNoCase("Unicode") )
+	ci_string uni("Unicode");
+	if (uni == sMapping.c_str())
 	{
 		// Special case.
 		if( iCount == -1 )
@@ -751,7 +752,8 @@ static vector<RString> LoadStack;
  */
 void Font::Load( const RString &sIniPath, RString sChars )
 {
-	if(GetExtension(sIniPath).CompareNoCase("ini"))
+	ci_string ini("ini");
+	if (ini != GetExtension(sIniPath).c_str())
 	{
 		LuaHelpers::ReportScriptErrorFmt(
 			"%s is not an ini file.  Fonts can only be loaded from ini files.",

--- a/src/Font.cpp
+++ b/src/Font.cpp
@@ -427,7 +427,7 @@ void Font::GetFontPaths( const RString &sFontIniPath, vector<RString> &asTexture
 
 	for( unsigned i = 0; i < asFiles.size(); ++i )
 	{
-		if( !asFiles[i].Right(4).EqualsNoCase(".ini") )
+		if( !tail(asFiles[i], 4).EqualsNoCase(".ini") )
 			asTexturePathsOut.push_back( asFiles[i] );
 	}
 }

--- a/src/Font.cpp
+++ b/src/Font.cpp
@@ -425,10 +425,13 @@ void Font::GetFontPaths( const RString &sFontIniPath, vector<RString> &asTexture
 	vector<RString> asFiles;
 	GetDirListing( sPrefix + "*", asFiles, false, true );
 
-	for( unsigned i = 0; i < asFiles.size(); ++i )
+	for (auto const &file: asFiles)
 	{
-		if( !tail(asFiles[i], 4).EqualsNoCase(".ini") )
-			asTexturePathsOut.push_back( asFiles[i] );
+		ci_string ext(tail(file, 4).c_str());
+		if (ext != ".ini")
+		{
+			asTexturePathsOut.push_back(file);
+		}
 	}
 }
 

--- a/src/Font.cpp
+++ b/src/Font.cpp
@@ -489,9 +489,8 @@ void Font::LoadFontPageSettings( FontPageSettings &cfg, IniFile &ini, const RStr
 	{
 		FOREACH_CONST_Attr( pNode, pAttr )
 		{
-			RString sName = pAttr->first;
+			RString sName = MakeUpper(pAttr->first);
 			const XNodeValue *pValue = pAttr->second;
-			std::transform(sName.begin(), sName.end(), sName.begin(), GetAsciiUpper);
 
 			// If val is an integer, it's a width, eg. "10=27".
 			if( IsAnInt(sName) )

--- a/src/Font.cpp
+++ b/src/Font.cpp
@@ -491,8 +491,7 @@ void Font::LoadFontPageSettings( FontPageSettings &cfg, IniFile &ini, const RStr
 		{
 			RString sName = pAttr->first;
 			const XNodeValue *pValue = pAttr->second;
-
-			sName.MakeUpper();
+			std::transform(sName.begin(), sName.end(), sName.begin(), GetAsciiUpper);
 
 			// If val is an integer, it's a width, eg. "10=27".
 			if( IsAnInt(sName) )

--- a/src/Font.cpp
+++ b/src/Font.cpp
@@ -752,8 +752,8 @@ static vector<RString> LoadStack;
  */
 void Font::Load( const RString &sIniPath, RString sChars )
 {
-	ci_string ini("ini");
-	if (ini != GetExtension(sIniPath).c_str())
+	ci_string ext("ini");
+	if (ext != GetExtension(sIniPath).c_str())
 	{
 		LuaHelpers::ReportScriptErrorFmt(
 			"%s is not an ini file.  Fonts can only be loaded from ini files.",

--- a/src/Font.cpp
+++ b/src/Font.cpp
@@ -43,7 +43,7 @@ void FontPage::Load( const FontPageSettings &cfg )
 	// "arial 20 16x16 [main].png" => "arial 20 16x16 [main-stroke].png"
 	if( ID2.filename.find("]") != string::npos )
 	{
-		ID2.filename.Replace( "]", "-stroke]" );
+		ReplaceAll(ID2.filename, "]", "-stroke]");
 		if( IsAFile(ID2.filename) )
 		{
 			m_FontPageTextures.m_pTextureStroke = TEXTUREMAN->LoadTexture( ID2 );

--- a/src/FontCharAliases.cpp
+++ b/src/FontCharAliases.cpp
@@ -364,7 +364,7 @@ static void InitCharAliases()
 	{
 		RString from = i->first;
 		RString to = WcharToUTF8(i->second);
-		from.MakeLower();
+		std::transform(from.begin(), from.end(), from.begin(), GetAsciiLower);
 		CharAliasRepl[from] = to;
 	}
 }

--- a/src/FontCharAliases.cpp
+++ b/src/FontCharAliases.cpp
@@ -7,7 +7,7 @@
 #include <map>
 
 // Map from "&foo;" to a UTF-8 string.
-typedef std::map<RString, wchar_t, StdString::StdStringLessNoCase> aliasmap;
+typedef std::map<RString, wchar_t, ci_std_string_lt> aliasmap;
 static aliasmap CharAliases;
 static std::map<RString,RString> CharAliasRepl;
 

--- a/src/FontCharAliases.cpp
+++ b/src/FontCharAliases.cpp
@@ -362,9 +362,8 @@ static void InitCharAliases()
 
 	for(aliasmap::const_iterator i = CharAliases.begin(); i != CharAliases.end(); ++i)
 	{
-		RString from = i->first;
+		RString from = MakeLower(i->first);
 		RString to = WcharToUTF8(i->second);
-		std::transform(from.begin(), from.end(), from.begin(), GetAsciiLower);
 		CharAliasRepl[from] = to;
 	}
 }

--- a/src/FontCharmaps.cpp
+++ b/src/FontCharmaps.cpp
@@ -2,6 +2,7 @@
 #include "FontCharmaps.h"
 
 #include <map>
+#include "RageUtil.h"
 
 const wchar_t FontCharmaps::M_SKIP = 0xFEFF;
 
@@ -221,8 +222,7 @@ static void Init()
 const wchar_t *FontCharmaps::get_char_map(RString name)
 {
 	Init();
-
-	name.MakeLower();
+	std::transform(name.begin(), name.end(), name.begin(), GetAsciiLower);
 
 	auto i = charmaps.find(name);
 	if(i == charmaps.end())

--- a/src/FontCharmaps.cpp
+++ b/src/FontCharmaps.cpp
@@ -222,9 +222,9 @@ static void Init()
 const wchar_t *FontCharmaps::get_char_map(RString name)
 {
 	Init();
-	std::transform(name.begin(), name.end(), name.begin(), GetAsciiLower);
+	RString lowerName = MakeLower(name);
 
-	auto i = charmaps.find(name);
+	auto i = charmaps.find(lowerName);
 	if(i == charmaps.end())
 		return NULL;
 

--- a/src/Game.h
+++ b/src/Game.h
@@ -29,6 +29,7 @@ class Style;
 struct Game
 {
 	const char *		m_szName;
+	// TODO: Make this a proper collection of styles.
 	const Style * const*	m_apStyles;
 
 	/** @brief Do we count multiple notes in a row as separate notes, or as one note? */

--- a/src/GameCommand.cpp
+++ b/src/GameCommand.cpp
@@ -476,8 +476,8 @@ void GameCommand::LoadOne( const Command& cmd )
 		if( cmd.m_vsArgs.size() == 3 )
 		{
 			m_bFadeMusic = true;
-			m_fMusicFadeOutVolume = static_cast<float>(atof( cmd.m_vsArgs[1] ));
-			m_fMusicFadeOutSeconds = static_cast<float>(atof( cmd.m_vsArgs[2] ));
+			m_fMusicFadeOutVolume = static_cast<float>(std::atof( cmd.m_vsArgs[1].c_str() ));
+			m_fMusicFadeOutSeconds = static_cast<float>(std::atof( cmd.m_vsArgs[2].c_str() ));
 		}
 		else
 		{

--- a/src/GameCommand.cpp
+++ b/src/GameCommand.cpp
@@ -837,8 +837,8 @@ void GameCommand::ApplySelf( const vector<PlayerNumber> &vpns ) const
 	{
 		Lua *L = LUA->Get();
 		GAMESTATE->m_Environment->PushSelf(L);
-		lua_pushstring( L, i->first );
-		lua_pushstring( L, i->second );
+		lua_pushstring( L, i->first.c_str() );
+		lua_pushstring( L, i->second.c_str() );
 		lua_settable( L, -3 );
 		lua_pop( L, 1 );
 		LUA->Release(L);
@@ -989,23 +989,23 @@ bool GameCommand::IsZero() const
 class LunaGameCommand: public Luna<GameCommand>
 {
 public:
-	static int GetName( T* p, lua_State *L )	{ lua_pushstring(L, p->m_sName ); return 1; }
-	static int GetText( T* p, lua_State *L )	{ lua_pushstring(L, p->m_sText ); return 1; }
+	static int GetName( T* p, lua_State *L )	{ lua_pushstring(L, p->m_sName.c_str() ); return 1; }
+	static int GetText( T* p, lua_State *L )	{ lua_pushstring(L, p->m_sText.c_str() ); return 1; }
 	static int GetIndex( T* p, lua_State *L )	{ lua_pushnumber(L, p->m_iIndex ); return 1; }
 	static int GetMultiPlayer( T* p, lua_State *L )	{ lua_pushnumber(L, p->m_MultiPlayer); return 1; }
 	static int GetStyle( T* p, lua_State *L )	{ if(p->m_pStyle==NULL) lua_pushnil(L); else {Style *pStyle = (Style*)p->m_pStyle; pStyle->PushSelf(L);} return 1; }
-	static int GetScreen( T* p, lua_State *L )	{ lua_pushstring(L, p->m_sScreen ); return 1; }
-	static int GetProfileID( T* p, lua_State *L )	{ lua_pushstring(L, p->m_sProfileID ); return 1; }
+	static int GetScreen( T* p, lua_State *L )	{ lua_pushstring(L, p->m_sScreen.c_str() ); return 1; }
+	static int GetProfileID( T* p, lua_State *L )	{ lua_pushstring(L, p->m_sProfileID.c_str() ); return 1; }
 	static int GetSong( T* p, lua_State *L )	{ if(p->m_pSong==NULL) lua_pushnil(L); else p->m_pSong->PushSelf(L); return 1; }
 	static int GetSteps( T* p, lua_State *L )	{ if(p->m_pSteps==NULL) lua_pushnil(L); else p->m_pSteps->PushSelf(L); return 1; }
 	static int GetCourse( T* p, lua_State *L )	{ if(p->m_pCourse==NULL) lua_pushnil(L); else p->m_pCourse->PushSelf(L); return 1; }
 	static int GetTrail( T* p, lua_State *L )	{ if(p->m_pTrail==NULL) lua_pushnil(L); else p->m_pTrail->PushSelf(L); return 1; }
 	static int GetCharacter( T* p, lua_State *L )	{ if(p->m_pCharacter==NULL) lua_pushnil(L); else p->m_pCharacter->PushSelf(L); return 1; }
-	static int GetSongGroup( T* p, lua_State *L )	{ lua_pushstring(L, p->m_sSongGroup ); return 1; }
-	static int GetUrl( T* p, lua_State *L )	{ lua_pushstring(L, p->m_sUrl ); return 1; }
-	static int GetAnnouncer( T* p, lua_State *L )	{ lua_pushstring(L, p->m_sAnnouncer ); return 1; }
-	static int GetPreferredModifiers( T* p, lua_State *L )	{ lua_pushstring(L, p->m_sPreferredModifiers ); return 1; }
-	static int GetStageModifiers( T* p, lua_State *L )	{ lua_pushstring(L, p->m_sStageModifiers ); return 1; }
+	static int GetSongGroup( T* p, lua_State *L )	{ lua_pushstring(L, p->m_sSongGroup.c_str() ); return 1; }
+	static int GetUrl( T* p, lua_State *L )	{ lua_pushstring(L, p->m_sUrl.c_str() ); return 1; }
+	static int GetAnnouncer( T* p, lua_State *L )	{ lua_pushstring(L, p->m_sAnnouncer.c_str() ); return 1; }
+	static int GetPreferredModifiers( T* p, lua_State *L )	{ lua_pushstring(L, p->m_sPreferredModifiers.c_str() ); return 1; }
+	static int GetStageModifiers( T* p, lua_State *L )	{ lua_pushstring(L, p->m_sStageModifiers.c_str() ); return 1; }
 
 	DEFINE_METHOD( GetCourseDifficulty,	m_CourseDifficulty )
 	DEFINE_METHOD( GetDifficulty,	m_dc )

--- a/src/GameCommand.cpp
+++ b/src/GameCommand.cpp
@@ -620,7 +620,8 @@ bool GameCommand::IsPlayable( RString *why ) const
 		}
 	}
 
-	if( !m_sScreen.CompareNoCase("ScreenEditCoursesMenu") )
+	ci_string ciScreen(m_sScreen.c_str());
+	if (ciScreen == "ScreenEditCoursesMenu")
 	{
 		vector<Course*> vCourses;
 		SONGMAN->GetAllCourses( vCourses, false );
@@ -633,9 +634,8 @@ bool GameCommand::IsPlayable( RString *why ) const
 		}
 	}
 
-	if( (!m_sScreen.CompareNoCase("ScreenJukeboxMenu") ||
-		!m_sScreen.CompareNoCase("ScreenEditMenu") ||
-		!m_sScreen.CompareNoCase("ScreenEditCoursesMenu")) )
+	if (ciScreen == "ScreenJukeboxMenu" || ciScreen == "ScreenEditMenu" ||
+		ciScreen == "ScreenEditCoursesMenu")
 	{
 		if( SONGMAN->GetNumSongs() == 0 )
 		{

--- a/src/GameConstantsAndTypes.cpp
+++ b/src/GameConstantsAndTypes.cpp
@@ -52,7 +52,7 @@ RString StepsTypeToString( StepsType st )
 {
 	RString s = GAMEMAN->GetStepsTypeInfo( st ).szName; // "dance-single"
 	/* foo-bar -> Foo_Bar */
-	s.Replace('-','_');
+	std::transform(s.begin(), s.end(), '-', '_');
 
 	bool bCapitalizeNextLetter = true;
 	for( int i=0; i<(int)s.length(); i++ )

--- a/src/GameConstantsAndTypes.cpp
+++ b/src/GameConstantsAndTypes.cpp
@@ -52,7 +52,7 @@ RString StepsTypeToString( StepsType st )
 {
 	RString s = GAMEMAN->GetStepsTypeInfo( st ).szName; // "dance-single"
 	/* foo-bar -> Foo_Bar */
-	std::transform(s.begin(), s.end(), '-', '_');
+	ReplaceAll(s, "-", "_");
 
 	bool bCapitalizeNextLetter = true;
 	for( int i=0; i<(int)s.length(); i++ )

--- a/src/GameInput.cpp
+++ b/src/GameInput.cpp
@@ -46,7 +46,7 @@ bool GameInput::FromString( const InputScheme* pInputs, const RString &s )
 	char szController[32] = "";
 	char szButton[32] = "";
 
-	if( 2 != sscanf( s, "%31[^_]_%31[^_]", szController, szButton ) )
+	if( 2 != sscanf( s.c_str(), "%31[^_]_%31[^_]", szController, szButton ) )
 	{
 		controller = GameController_Invalid;
 		return false;

--- a/src/GameLoop.cpp
+++ b/src/GameLoop.cpp
@@ -187,7 +187,7 @@ namespace
 		// game type.  So if a theme name isn't passed in, fetch from the prefs.
 		if(g_NewTheme.empty())
 		{
-			g_NewTheme= PREFSMAN->m_sTheme;
+			g_NewTheme = PREFSMAN->m_sTheme.Get();
 		}
 		if(g_NewTheme != THEME->GetCurThemeName() && THEME->IsThemeSelectable(g_NewTheme))
 		{

--- a/src/GameManager.cpp
+++ b/src/GameManager.cpp
@@ -3467,9 +3467,14 @@ RString GameManager::StyleToLocalizedString( const Style* style )
 
 const Game* GameManager::StringToGame( RString sGame )
 {
-	for( size_t i=0; i<ARRAYLEN(g_Games); ++i )
-		if( !sGame.CompareNoCase(g_Games[i]->m_szName) )
-			return g_Games[i];
+	ci_string ciGame(sGame.c_str());
+	for (auto const *game: g_Games)
+	{
+		if (ciGame == game->m_szName)
+		{
+			return game;
+		}
+	}
 
 	return NULL;
 }
@@ -3477,11 +3482,15 @@ const Game* GameManager::StringToGame( RString sGame )
 
 const Style* GameManager::GameAndStringToStyle( const Game *game, RString sStyle )
 {
+	ci_string ciStyle(sStyle.c_str());
+	
 	for( int s=0; game->m_apStyles[s]; ++s )
 	{
 		const Style* style = game->m_apStyles[s];
-		if( sStyle.CompareNoCase(style->m_szName) == 0 )
+		if( ciStyle == style->m_szName )
+		{
 			return style;
+		}
 	}
 
 	return NULL;

--- a/src/GameManager.cpp
+++ b/src/GameManager.cpp
@@ -3446,10 +3446,10 @@ const StepsTypeInfo &GameManager::GetStepsTypeInfo( StepsType st )
 
 StepsType GameManager::StringToStepsType( RString sStepsType )
 {
-	std::transform(sStepsType.begin(), sStepsType.end(), sStepsType.begin(), GetAsciiLower);
+	RString stepType = MakeLower(sStepsType);
 
 	for( int i=0; i<NUM_StepsType; i++ )
-		if( g_StepsTypeInfos[i].szName == sStepsType )
+		if( g_StepsTypeInfos[i].szName == stepType )
 			return StepsType(i);
 
 	return StepsType_Invalid;

--- a/src/GameManager.cpp
+++ b/src/GameManager.cpp
@@ -3446,7 +3446,7 @@ const StepsTypeInfo &GameManager::GetStepsTypeInfo( StepsType st )
 
 StepsType GameManager::StringToStepsType( RString sStepsType )
 {
-	sStepsType.MakeLower();
+	std::transform(sStepsType.begin(), sStepsType.end(), sStepsType.begin(), GetAsciiLower);
 
 	for( int i=0; i<NUM_StepsType; i++ )
 		if( g_StepsTypeInfos[i].szName == sStepsType )

--- a/src/GameManager.cpp
+++ b/src/GameManager.cpp
@@ -3503,7 +3503,7 @@ const Style* GameManager::GameAndStringToStyle( const Game *game, RString sStyle
 class LunaGameManager: public Luna<GameManager>
 {
 public:
-	static int StepsTypeToLocalizedString( T* p, lua_State *L )	{ lua_pushstring(L, p->GetStepsTypeInfo(Enum::Check<StepsType>(L, 1)).GetLocalizedString() ); return 1; }
+	static int StepsTypeToLocalizedString( T* p, lua_State *L )	{ lua_pushstring(L, p->GetStepsTypeInfo(Enum::Check<StepsType>(L, 1)).GetLocalizedString().c_str() ); return 1; }
 	static int GetFirstStepsTypeForGame( T* p, lua_State *L )
 	{
 		Game *pGame = Luna<Game>::check( L, 1 );

--- a/src/GameSoundManager.cpp
+++ b/src/GameSoundManager.cpp
@@ -104,7 +104,8 @@ static GameSoundManager::PlayMusicParams g_FallbackMusicParams;
 static void StartMusic( MusicToPlay &ToPlay )
 {
 	LockMutex L( *g_Mutex );
-	if( g_Playing->m_Music->IsPlaying() && g_Playing->m_Music->GetLoadedFilePath().EqualsNoCase(ToPlay.m_sFile) )
+	ci_string musicPath(g_Playing->m_Music->GetLoadedFilePath().c_str());
+	if( g_Playing->m_Music->IsPlaying() && musicPath == ToPlay.m_sFile.c_str() )
 		return;
 
 	/* We're changing or stopping the music.  If we were dimming, reset. */

--- a/src/GameSoundManager.cpp
+++ b/src/GameSoundManager.cpp
@@ -288,7 +288,7 @@ static void DoPlayOnceFromDir( RString sPath )
 		return;
 
 	// make sure there's a slash at the end of this path
-	if( sPath.Right(1) != "/" )
+	if( !EndsWith(sPath, "/") )
 		sPath += "/";
 
 	vector<RString> arraySoundFiles;

--- a/src/GameSoundManager.cpp
+++ b/src/GameSoundManager.cpp
@@ -356,7 +356,7 @@ static void StartQueuedSounds()
 			StartMusic( aMusicsToPlay[i] );
 		else
 		{
-			CHECKPOINT;
+			CHECKPOINT_M("Stopping old sound");
 			/* StopPlaying() can take a while, so don't hold the lock while we stop the sound. */
 			g_Mutex->Lock();
 			RageSound *pOldSound = g_Playing->m_Music;

--- a/src/GameState.cpp
+++ b/src/GameState.cpp
@@ -2011,7 +2011,7 @@ void GameState::GetRankingFeats( PlayerNumber pn, vector<RankingFeat> &asFeatsOu
 	case PLAY_MODE_BATTLE:
 	case PLAY_MODE_RAVE:
 		{
-			CHECKPOINT;
+			CHECKPOINT_M("Getting the proper combination.");
 
 			StepsType st = GetCurrentStyle(pn)->m_StepsType;
 
@@ -2033,14 +2033,14 @@ void GameState::GetRankingFeats( PlayerNumber pn, vector<RankingFeat> &asFeatsOu
 				ASSERT( sas.pSteps != NULL );
 				vSongAndSteps.push_back( sas );
 			}
-			CHECKPOINT;
+			CHECKPOINT_M("About to sort the findings.");
 
 			sort( vSongAndSteps.begin(), vSongAndSteps.end() );
 
 			vector<SongAndSteps>::iterator toDelete = unique( vSongAndSteps.begin(), vSongAndSteps.end() );
 			vSongAndSteps.erase(toDelete, vSongAndSteps.end());
 
-			CHECKPOINT;
+			CHECKPOINT_M("Finding the records.");
 			for( unsigned i=0; i<vSongAndSteps.size(); i++ )
 			{
 				Song* pSong = vSongAndSteps[i].pSong;
@@ -2106,7 +2106,7 @@ void GameState::GetRankingFeats( PlayerNumber pn, vector<RankingFeat> &asFeatsOu
 				}
 			}
 
-			CHECKPOINT;
+			CHECKPOINT_M("About to get the final stats.");
 			StageStats stats;
 			STATSMAN->GetFinalEvalStageStats( stats );
 
@@ -2166,7 +2166,7 @@ void GameState::GetRankingFeats( PlayerNumber pn, vector<RankingFeat> &asFeatsOu
 	case PLAY_MODE_ONI:
 	case PLAY_MODE_ENDLESS:
 		{
-			CHECKPOINT;
+			CHECKPOINT_M("Course style records.");
 			Course* pCourse = m_pCurCourse;
 			ASSERT( pCourse != NULL );
 			Trail *pTrail = m_pCurTrail[pn];

--- a/src/GameState.cpp
+++ b/src/GameState.cpp
@@ -2244,7 +2244,7 @@ bool GameState::AnyPlayerHasRankingFeats() const
 void GameState::StoreRankingName( PlayerNumber pn, RString sName )
 {
 	// The theme can upper it if desired. -Kyz
-	// sName.MakeUpper();
+	// sName = MakeUpper(sName);
 
 	if( USE_NAME_BLACKLIST )
 	{
@@ -2261,7 +2261,7 @@ void GameState::StoreRankingName( PlayerNumber pn, RString sName )
 					break;
 				}
 
-				std::transform(sLine.begin(), sLine.end(), sLine.begin(), GetAsciiUpper);
+				sLine = MakeUpper(sLine);
 				if( !sLine.empty() && sName.find(sLine) != string::npos )	// name contains a bad word
 				{
 					LOG->Trace( "entered '%s' matches blacklisted item '%s'", sName.c_str(), sLine.c_str() );

--- a/src/GameState.cpp
+++ b/src/GameState.cpp
@@ -2838,7 +2838,7 @@ public:
 	{
 		SongOptions so;
 		p->GetDefaultSongOptions( so );
-		lua_pushstring(L, so.GetString());
+		lua_pushstring(L, so.GetString().c_str());
 		return 1;
 	}
 	static int ApplyPreferredSongOptionsToOtherLevels(T* p, lua_State* L)
@@ -2923,8 +2923,8 @@ public:
 			const Steps* pSteps = vpStepsToShow[i];
 			RString sDifficulty = CustomDifficultyToLocalizedString( GetCustomDifficulty( pSteps->m_StepsType, pSteps->GetDifficulty(), CourseType_Invalid ) );
 
-			lua_pushstring( L, sDifficulty );
-			lua_pushstring( L, pSteps->GetDescription() );
+			lua_pushstring( L, sDifficulty.c_str() );
+			lua_pushstring( L, pSteps->GetDescription().c_str() );
 		}
 
 		return vpStepsToShow.size()*2;
@@ -3004,7 +3004,7 @@ public:
 			p->m_pCurCharacters[Enum::Check<PlayerNumber>(L, 1)] = c;
 		COMMON_RETURN_SELF;
 	}
-	static int GetExpandedSectionName( T* p, lua_State *L )				{ lua_pushstring(L, p->sExpandedSectionName); return 1; }
+	static int GetExpandedSectionName( T* p, lua_State *L )				{ lua_pushstring(L, p->sExpandedSectionName.c_str()); return 1; }
 	static int AddStageToPlayer( T* p, lua_State *L )				{ p->AddStageToPlayer(Enum::Check<PlayerNumber>(L, 1)); COMMON_RETURN_SELF; }
 	static int InsertCoin( T* p, lua_State *L )
 	{

--- a/src/GameState.cpp
+++ b/src/GameState.cpp
@@ -2261,7 +2261,7 @@ void GameState::StoreRankingName( PlayerNumber pn, RString sName )
 					break;
 				}
 
-				sLine.MakeUpper();
+				std::transform(sLine.begin(), sLine.end(), sLine.begin(), GetAsciiUpper);
 				if( !sLine.empty() && sName.find(sLine) != string::npos )	// name contains a bad word
 				{
 					LOG->Trace( "entered '%s' matches blacklisted item '%s'", sName.c_str(), sLine.c_str() );

--- a/src/Grade.cpp
+++ b/src/Grade.cpp
@@ -50,8 +50,7 @@ RString GradeToOldString( Grade g )
 
 Grade StringToGrade( const RString &sGrade )
 {
-	RString s = sGrade;
-	std::transform(s.begin(), s.end(), s.begin(), GetAsciiUpper);
+	RString s = MakeUpper(sGrade);
 
 	// new style
 	int iTier;

--- a/src/Grade.cpp
+++ b/src/Grade.cpp
@@ -51,7 +51,7 @@ RString GradeToOldString( Grade g )
 Grade StringToGrade( const RString &sGrade )
 {
 	RString s = sGrade;
-	s.MakeUpper();
+	std::transform(s.begin(), s.end(), s.begin(), GetAsciiUpper);
 
 	// new style
 	int iTier;

--- a/src/HighScore.cpp
+++ b/src/HighScore.cpp
@@ -501,10 +501,10 @@ void Screenshot::LoadFromNode( const XNode* pNode )
 class LunaHighScore: public Luna<HighScore>
 {
 public:
-	static int GetName( T* p, lua_State *L )			{ lua_pushstring(L, p->GetName() ); return 1; }
+	static int GetName( T* p, lua_State *L )			{ lua_pushstring(L, p->GetName().c_str() ); return 1; }
 	static int GetScore( T* p, lua_State *L )			{ lua_pushnumber(L, p->GetScore() ); return 1; }
 	static int GetPercentDP( T* p, lua_State *L )			{ lua_pushnumber(L, p->GetPercentDP() ); return 1; }
-	static int GetDate( T* p, lua_State *L )			{ lua_pushstring(L, p->GetDateTime().GetString() ); return 1; }
+	static int GetDate( T* p, lua_State *L )			{ lua_pushstring(L, p->GetDateTime().GetString().c_str() ); return 1; }
 	static int GetSurvivalSeconds( T* p, lua_State *L )			{ lua_pushnumber(L, p->GetSurvivalSeconds() ); return 1; }
 	static int IsFillInMarker( T* p, lua_State *L )
 	{
@@ -517,7 +517,7 @@ public:
 		return 1;
 	}
 	static int GetMaxCombo( T* p, lua_State *L )			{ lua_pushnumber(L, p->GetMaxCombo() ); return 1; }
-	static int GetModifiers( T* p, lua_State *L )			{ lua_pushstring(L, p->GetModifiers() ); return 1; }
+	static int GetModifiers( T* p, lua_State *L )			{ lua_pushstring(L, p->GetModifiers().c_str() ); return 1; }
 	static int GetTapNoteScore( T* p, lua_State *L )			{ lua_pushnumber(L, p->GetTapNoteScore( Enum::Check<TapNoteScore>(L, 1) ) ); return 1; }
 	static int GetHoldNoteScore( T* p, lua_State *L )			{ lua_pushnumber(L, p->GetHoldNoteScore( Enum::Check<HoldNoteScore>(L, 1) ) ); return 1; }
 	static int GetRadarValues( T* p, lua_State *L )

--- a/src/IniFile.cpp
+++ b/src/IniFile.cpp
@@ -96,8 +96,8 @@ bool IniFile::ReadFile( RageFileBasic &f )
 				size_t iEqualIndex = line.find("=");
 				if( iEqualIndex != string::npos )
 				{
-                    RString valuename = head(line, iEqualIndex);
-                    RString value = line.Right(line.size()-valuename.size()-1);
+					RString valuename = head(line, iEqualIndex);
+					RString value = tail(line, line.size()-valuename.size()-1);
 					Trim(valuename);
 					if(!valuename.empty())
 					{

--- a/src/IniFile.cpp
+++ b/src/IniFile.cpp
@@ -96,8 +96,8 @@ bool IniFile::ReadFile( RageFileBasic &f )
 				size_t iEqualIndex = line.find("=");
 				if( iEqualIndex != string::npos )
 				{
-					RString valuename = line.Left((int) iEqualIndex);
-					RString value = line.Right(line.size()-valuename.size()-1);
+                    RString valuename = head(line, iEqualIndex);
+                    RString value = line.Right(line.size()-valuename.size()-1);
 					Trim(valuename);
 					if(!valuename.empty())
 					{

--- a/src/InputMapper.cpp
+++ b/src/InputMapper.cpp
@@ -1058,10 +1058,14 @@ MultiPlayer InputMapper::InputDeviceToMultiPlayer( InputDevice id )
 
 GameButton InputScheme::ButtonNameToIndex( const RString &sButtonName ) const
 {
+	ci_string ciName(sButtonName.c_str());
 	for( GameButton gb=(GameButton) 0; gb<m_iButtonsPerController; gb=(GameButton)(gb+1) )
-		if( stricmp(GetGameButtonName(gb), sButtonName) == 0 )
+	{
+		if (ciName == GetGameButtonName(gb))
+		{
 			return gb;
-
+		}
+	}
 	return GameButton_Invalid;
 }
 

--- a/src/InputMapper.cpp
+++ b/src/InputMapper.cpp
@@ -614,11 +614,13 @@ void InputMapper::AutoMapJoysticksForCurrentGame()
 		}
 
 		// hard-coded automaps
-		for( unsigned j=0; j<ARRAYLEN(g_AutoMappings); j++ )
+		ci_string schemeName(m_pInputScheme->m_szName);
+		for (auto const &mapping: g_AutoMappings)
 		{
-			const AutoMappings& mapping = g_AutoMappings[j];
-			if( mapping.m_sGame.EqualsNoCase(m_pInputScheme->m_szName) )
-				vAutoMappings.push_back( mapping );
+			if ( schemeName == mapping.m_sGame.c_str() )
+			{
+				vAutoMappings.push_back(mapping);
+			}
 		}
 	}
 

--- a/src/InputQueue.cpp
+++ b/src/InputQueue.cpp
@@ -191,25 +191,25 @@ bool InputQueueCode::Load( RString sButtonsNames )
 
 			bool bHold = false;
 			bool bNotHold = false;
-			while(1)
+			for(;;)
 			{
-				if( sButtonName.Left(1) == "+" )
+				if( BeginsWith(sButtonName, "+"))
 				{
 					m_aPresses.back().m_InputTypes[IET_REPEAT] = true;
 					sButtonName.erase(0, 1);
 				}
-				else if( sButtonName.Left(1) == "~" )
+				else if( BeginsWith(sButtonName, "~"))
 				{
 					m_aPresses.back().m_InputTypes[IET_FIRST_PRESS] = false;
 					m_aPresses.back().m_InputTypes[IET_RELEASE] = true;
 					sButtonName.erase(0, 1);
 				}
-				else if( sButtonName.Left(1) == "@" )
+				else if( BeginsWith(sButtonName, "@"))
 				{
 					sButtonName.erase(0, 1);
 					bHold = true;
 				}
-				else if( sButtonName.Left(1) == "!" )
+				else if( BeginsWith(sButtonName, "!"))
 				{
 					sButtonName.erase(0, 1);
 					bNotHold = true;

--- a/src/LifeMeterBattery.cpp
+++ b/src/LifeMeterBattery.cpp
@@ -241,7 +241,7 @@ int LifeMeterBattery::GetRemainingLives() const
 }
 void LifeMeterBattery::Refresh()
 {
-	m_textNumLives.SetText( ssprintf(LIVES_FORMAT.GetValue(), m_iLivesLeft) );
+	m_textNumLives.SetText( fmt::sprintf(LIVES_FORMAT.GetValue(), m_iLivesLeft) );
 	if( m_iLivesLeft < 0 )
 	{
 		// hide text to avoid showing -1

--- a/src/LuaBinding.cpp
+++ b/src/LuaBinding.cpp
@@ -75,7 +75,7 @@ void LuaBinding::Register( lua_State *L )
 	int methods = lua_gettop( L );
 
 	/* Create a metatable for the userdata objects. */
-	luaL_newmetatable( L, GetClassName() );
+	luaL_newmetatable( L, GetClassName().c_str() );
 	int metatable = lua_gettop( L );
 
 	// We use the metatable to determine the type of the table, so don't
@@ -128,7 +128,7 @@ void LuaBinding::Register( lua_State *L )
 			lua_rawset( L, iHeirarchyTable );
 			++iIndex;
 
-			luaL_getmetatable( L, sClass );
+			luaL_getmetatable( L, sClass.c_str() );
 			ASSERT( !lua_isnil(L, -1) );
 			lua_getfield( L, -1, "base" );
 
@@ -159,7 +159,7 @@ void LuaBinding::CreateMethodsTable( lua_State *L, const RString &sName )
 {
 	lua_newtable( L );
 	lua_pushvalue( L, -1 );
-	lua_setfield( L, LUA_GLOBALSINDEX, sName );
+	lua_setfield( L, LUA_GLOBALSINDEX, sName.c_str() );
 }
 
 int LuaBinding::PushEqual( lua_State *L )
@@ -290,7 +290,7 @@ void LuaBinding::ApplyDerivedType( Lua *L, const RString &sClassName, void *pSel
 		lua_settop( L, iTable );
 	}
 
-	luaL_getmetatable( L, sClassName );
+	luaL_getmetatable( L, sClassName.c_str() );
 	lua_setmetatable( L, iTable );
 }
 

--- a/src/LuaBinding.cpp
+++ b/src/LuaBinding.cpp
@@ -123,7 +123,7 @@ void LuaBinding::Register( lua_State *L )
 		int iIndex = 0;
 		while( !sClass.empty() )
 		{
-			lua_pushstring( L, sClass );
+			lua_pushstring( L, sClass.c_str() );
 			lua_pushinteger( L, iIndex );
 			lua_rawset( L, iHeirarchyTable );
 			++iIndex;

--- a/src/LuaBinding.cpp
+++ b/src/LuaBinding.cpp
@@ -101,17 +101,17 @@ void LuaBinding::Register( lua_State *L )
 	// to the base class.
 	if( IsDerivedClass() )
 	{
-		lua_getfield( L, LUA_GLOBALSINDEX, GetBaseClassName() );
+		lua_getfield( L, LUA_GLOBALSINDEX, GetBaseClassName().c_str() );
 		lua_setfield( L, methods_metatable, "__index" );
 
-		lua_pushstring( L, GetBaseClassName() );
+		lua_pushstring( L, GetBaseClassName().c_str() );
 		lua_setfield( L, metatable, "base" );
 	}
 
-	lua_pushstring( L, GetClassName() );
+	lua_pushstring( L, GetClassName().c_str() );
 	lua_setfield( L, methods_metatable, "class" );
 
-	lua_pushstring( L, GetClassName() );
+	lua_pushstring( L, GetClassName().c_str() );
 	LuaHelpers::PushValueFunc( L, 1 );
 	lua_setfield( L, metatable, "__type" ); // for luaL_pushtype
 

--- a/src/LuaBinding.cpp
+++ b/src/LuaBinding.cpp
@@ -217,7 +217,7 @@ bool LuaBinding::Equal( lua_State *L )
  * Get a userdata, and check that it's either szType or a type
  * derived from szType, by checking the heirarchy table.
  */
-bool LuaBinding::CheckLuaObjectType( lua_State *L, int iArg, const char *szType )
+bool LuaBinding::CheckLuaObjectType( lua_State *L, int iArg, std::string const &szType )
 {
 #if defined(FAST_LUA)
 	return true;
@@ -233,7 +233,7 @@ bool LuaBinding::CheckLuaObjectType( lua_State *L, int iArg, const char *szType 
 		return false;
 	}
 
-	lua_getfield( L, -1, szType );
+	lua_getfield( L, -1, szType.c_str() );
 	bool bRet = !lua_isnil( L, -1 );
 	lua_pop( L, 2 );
 

--- a/src/LuaBinding.h
+++ b/src/LuaBinding.h
@@ -20,7 +20,7 @@ public:
 	virtual const RString &GetBaseClassName() const = 0;
 
 	static void ApplyDerivedType( Lua *L, const RString &sClassname, void *pSelf );
-	static bool CheckLuaObjectType( lua_State *L, int narg, const char *szType );
+	static bool CheckLuaObjectType( lua_State *L, int narg, std::string const &szType );
 
 protected:
 	virtual void Register( Lua *L, int iMethods, int iMetatable ) = 0;

--- a/src/LuaBinding.h
+++ b/src/LuaBinding.h
@@ -73,7 +73,7 @@ public:
 		if( !LuaBinding::CheckLuaObjectType(L, narg, m_sClassName) )
 		{
 			if( bIsSelf )
-				luaL_typerror( L, narg, m_sClassName );
+				luaL_typerror( L, narg, m_sClassName.c_str() );
 			else
 				LuaHelpers::TypeError( L, narg, m_sClassName );
 		}

--- a/src/LuaManager.cpp
+++ b/src/LuaManager.cpp
@@ -137,7 +137,7 @@ namespace
 
 		FOREACH_CONST_Attr( pNode, pAttr )
 		{
-			lua_pushstring( L, pAttr->first );			// push key
+			lua_pushstring( L, pAttr->first.c_str() );			// push key
 			pNode->PushAttrValue( L, pAttr->first );	// push value
 
 			//add key-value pair to our table
@@ -147,7 +147,7 @@ namespace
 		FOREACH_CONST_Child( pNode, c )
 		{
 			const XNode *pChild = c;
-			lua_pushstring( L, pChild->m_sName ); // push key
+			lua_pushstring( L, pChild->m_sName.c_str() ); // push key
 
 			// push value (more correctly, build this child's table and leave it there)
 			CreateTableFromXNodeRecursive( L, pChild );

--- a/src/LuaManager.cpp
+++ b/src/LuaManager.cpp
@@ -1002,7 +1002,7 @@ void LuaHelpers::ParseCommandList( Lua *L, const RString &sCommands, const RStri
 
 /* Like luaL_typerror, but without the special case for argument 1 being "self"
  * in method calls, so we give a correct error message after we remove self. */
-int LuaHelpers::TypeError( Lua *L, int iArgNo, const char *szName )
+int LuaHelpers::TypeError( Lua *L, int iArgNo, std::string const &szName )
 {
 	RString sType;
 	luaL_pushtype( L, iArgNo );
@@ -1012,13 +1012,13 @@ int LuaHelpers::TypeError( Lua *L, int iArgNo, const char *szName )
 	if( !lua_getstack( L, 0, &debug ) )
 	{
 		return luaL_error( L, "invalid type (%s expected, got %s)",
-			szName, sType.c_str() );
+			szName.c_str(), sType.c_str() );
 	}
 	else
 	{
 		lua_getinfo( L, "n", &debug );
 		return luaL_error( L, "bad argument #%d to \"%s\" (%s expected, got %s)",
-			iArgNo, debug.name? debug.name:"(unknown)", szName, sType.c_str() );
+			iArgNo, debug.name? debug.name:"(unknown)", szName.c_str(), sType.c_str() );
 	}
 }
 

--- a/src/LuaManager.cpp
+++ b/src/LuaManager.cpp
@@ -943,7 +943,7 @@ void LuaHelpers::ParseCommandList( Lua *L, const RString &sCommands, const RStri
 			RString sCmdName = cmd.GetName();
 			if( bLegacy )
 			{
-				std::transform(sCmdName.begin(), sCmdName.end(), sCmdName.begin(), GetAsciiLower);
+				sCmdName = MakeLower(sCmdName);
 			}
 			s << "\tself:" << sCmdName << "(";
 

--- a/src/LuaManager.cpp
+++ b/src/LuaManager.cpp
@@ -58,7 +58,7 @@ void LuaManager::SetGlobal( const RString &sName, int val )
 {
 	Lua *L = Get();
 	LuaHelpers::Push( L, val );
-	lua_setglobal( L, sName );
+	lua_setglobal( L, sName.c_str() );
 	Release( L );
 }
 
@@ -66,7 +66,7 @@ void LuaManager::SetGlobal( const RString &sName, const RString &val )
 {
 	Lua *L = Get();
 	LuaHelpers::Push( L, val );
-	lua_setglobal( L, sName );
+	lua_setglobal( L, sName.c_str() );
 	Release( L );
 }
 
@@ -74,7 +74,7 @@ void LuaManager::UnsetGlobal( const RString &sName )
 {
 	Lua *L = Get();
 	lua_pushnil( L );
-	lua_setglobal( L, sName );
+	lua_setglobal( L, sName.c_str() );
 	Release( L );
 }
 
@@ -801,7 +801,7 @@ bool LuaHelpers::RunScriptFile( const RString &sFile )
 bool LuaHelpers::LoadScript( Lua *L, const RString &sScript, const RString &sName, RString &sError )
 {
 	// load string
-	int ret = luaL_loadbuffer( L, sScript.data(), sScript.size(), sName );
+	int ret = luaL_loadbuffer( L, sScript.data(), sScript.size(), sName.c_str() );
 	if( ret )
 	{
 		LuaHelpers::Pop( L, sError );

--- a/src/LuaManager.cpp
+++ b/src/LuaManager.cpp
@@ -969,7 +969,7 @@ void LuaHelpers::ParseCommandList( Lua *L, const RString &sCommands, const RStri
 
 				if( i==1 && bFirstParamIsString ) // string literal, legacy only
 				{
-					sArg.Replace( "'", "\\'" );	// escape quote
+					ReplaceAll(sArg, "'", "\\'"); // escape quote
 					s << "'" << sArg << "'";
 				}
 				else if( sArg[0] == '#' )	// HTML color

--- a/src/LuaManager.cpp
+++ b/src/LuaManager.cpp
@@ -942,7 +942,9 @@ void LuaHelpers::ParseCommandList( Lua *L, const RString &sCommands, const RStri
 		{
 			RString sCmdName = cmd.GetName();
 			if( bLegacy )
-				sCmdName.MakeLower();
+			{
+				std::transform(sCmdName.begin(), sCmdName.end(), sCmdName.begin(), GetAsciiLower);
+			}
 			s << "\tself:" << sCmdName << "(";
 
 			bool bFirstParamIsString = bLegacy && (

--- a/src/LuaManager.h
+++ b/src/LuaManager.h
@@ -153,7 +153,7 @@ namespace LuaHelpers
 		}
 	}
 
-	int TypeError( Lua *L, int narg, const char *tname );
+	int TypeError( Lua *L, int narg, std::string const &tname );
 	inline int AbsIndex( Lua *L, int i ) { if( i > 0 || i <= LUA_REGISTRYINDEX ) return i; return lua_gettop( L ) + i + 1; }
 }
 

--- a/src/LuaReference.cpp
+++ b/src/LuaReference.cpp
@@ -190,14 +190,14 @@ void LuaTable::Set( Lua *L, const RString &sKey )
 	int iTop = lua_gettop( L );
 	this->PushSelf( L );
 	lua_pushvalue( L, iTop ); // push the value
-	lua_setfield( L, -2, sKey );
+	lua_setfield( L, -2, sKey.c_str() );
 	lua_settop( L, iTop-1 ); // remove all of the above
 }
 
 void LuaTable::Get( Lua *L, const RString &sKey )
 {
 	this->PushSelf( L );
-	lua_getfield( L, -1, sKey );
+	lua_getfield( L, -1, sKey.c_str() );
 	lua_remove( L, -2 ); // remove self
 }
 

--- a/src/LyricsLoader.cpp
+++ b/src/LyricsLoader.cpp
@@ -97,7 +97,7 @@ bool LyricsLoader::LoadFromLRCFile(const RString& sPath, Song& out)
 			seg.m_fStartTime = HHMMSSToSeconds(sValueName);
 			seg.m_sLyric = sValueData;
 
-			seg.m_sLyric.Replace( "|","\n" ); // Pipe symbols denote a new line in LRC files
+			ReplaceAll(seg.m_sLyric, "|", "\n"); // Pipe symbols denote a new line in LRC files
 			out.AddLyricSegment( seg );
 		}
 	}

--- a/src/LyricsLoader.cpp
+++ b/src/LyricsLoader.cpp
@@ -65,7 +65,8 @@ bool LyricsLoader::LoadFromLRCFile(const RString& sPath, Song& out)
 		StripCrnl(sValueData);
 
 		// handle the data
-		if( sValueName.EqualsNoCase("COLOUR") || sValueName.EqualsNoCase("COLOR") )
+		ci_string ciValueName(sValueName.c_str());
+		if( ciValueName == "COLOUR" || ciValueName == "COLOR" )
 		{
 			// set color var here for this segment
 			int r, g, b;

--- a/src/MemoryCardManager.cpp
+++ b/src/MemoryCardManager.cpp
@@ -683,7 +683,7 @@ bool MemoryCardManager::PathIsMemCard( RString sDir ) const
 {
 	FOREACH_PlayerNumber( p )
 	{
-		if( !sDir.Left(MEM_CARD_MOUNT_POINT[p].size()).CompareNoCase( MEM_CARD_MOUNT_POINT[p] ) )
+		if( !head(sDir, MEM_CARD_MOUNT_POINT[p].size()).CompareNoCase( MEM_CARD_MOUNT_POINT[p] ) )
 			return true;
 	}
 	return false;

--- a/src/MemoryCardManager.cpp
+++ b/src/MemoryCardManager.cpp
@@ -376,9 +376,11 @@ void MemoryCardManager::UpdateAssignments()
 
 		for (auto d = vUnassignedDevices.begin(); d != vUnassignedDevices.end(); ++d)
 		{
+			auto &mount = m_sMemoryCardOsMountPoint[p].Get();
+			ci_string ciMount(mount.c_str());
+			
 			// search for card dir match
-			if( !m_sMemoryCardOsMountPoint[p].Get().empty() &&
-				d->sOsMountDir.CompareNoCase(m_sMemoryCardOsMountPoint[p].Get()) )
+			if( !mount.empty() && ciMount != d->sOsMountDir.c_str())
 				continue; // not a match
 
 			// search for USB bus match
@@ -683,8 +685,11 @@ bool MemoryCardManager::PathIsMemCard( RString sDir ) const
 {
 	FOREACH_PlayerNumber( p )
 	{
-		if( !head(sDir, MEM_CARD_MOUNT_POINT[p].size()).CompareNoCase( MEM_CARD_MOUNT_POINT[p] ) )
+		ci_string mount(MEM_CARD_MOUNT_POINT[p].c_str());
+		if (mount == head(sDir, MEM_CARD_MOUNT_POINT[p].size()).c_str())
+		{
 			return true;
+		}
 	}
 	return false;
 }

--- a/src/MemoryCardManager.cpp
+++ b/src/MemoryCardManager.cpp
@@ -742,7 +742,7 @@ public:
 	static int GetName( T* p, lua_State *L )
 	{
 		PlayerNumber pn = Enum::Check<PlayerNumber>(L, 1);
-		lua_pushstring(L, p->GetName(pn) );
+		lua_pushstring(L, p->GetName(pn).c_str() );
 		return 1;
 	}
 

--- a/src/ModIcon.cpp
+++ b/src/ModIcon.cpp
@@ -65,7 +65,7 @@ void ModIcon::Set( const RString &_sText )
 	}
 	else
 	{
-		std::transform(sText.begin(), sText.end(), ' ', '\n');
+		ReplaceAll(sText, " ", "\n");
 	}
 	m_sprFilled->SetVisible( !bVacant );
 	m_sprEmpty->SetVisible( bVacant );

--- a/src/ModIcon.cpp
+++ b/src/ModIcon.cpp
@@ -65,7 +65,7 @@ void ModIcon::Set( const RString &_sText )
 	}
 	else
 	{
-		sText.Replace( " ", "\n" );
+		std::transform(sText.begin(), sText.end(), ' ', '\n');
 	}
 	m_sprFilled->SetVisible( !bVacant );
 	m_sprEmpty->SetVisible( bVacant );

--- a/src/ModIcon.cpp
+++ b/src/ModIcon.cpp
@@ -54,14 +54,19 @@ void ModIcon::Load( RString sMetricsGroup )
 void ModIcon::Set( const RString &_sText )
 {
 	RString sText = _sText;
-
-	for( unsigned i = 0; i < m_vStopWords.size(); i++ )
-		if( sText.EqualsNoCase(m_vStopWords[i]) )
-			sText = "";
-
-	sText.Replace( " ", "\n" );
-
-	bool bVacant = (sText=="");
+	ci_string ciText(sText.c_str());
+	
+	bool bVacant = std::any_of(m_vStopWords.begin(), m_vStopWords.end(), [&ciText] (RString const &stop) {
+		return ciText == stop.c_str();
+	});
+	if (bVacant)
+	{
+		sText = "";
+	}
+	else
+	{
+		sText.Replace( " ", "\n" );
+	}
 	m_sprFilled->SetVisible( !bVacant );
 	m_sprEmpty->SetVisible( bVacant );
 

--- a/src/Model.cpp
+++ b/src/Model.cpp
@@ -63,9 +63,11 @@ void Model::Load( const RString &sFile )
 	if( sFile == "" ) return;
 
 	RString sExt = GetExtension(sFile);
-	sExt.MakeLower();
-	if( sExt=="txt" )
+	ci_string ciExt(sExt.c_str());
+	if (ciExt == "txt")
+	{
 		LoadMilkshapeAscii( sFile );
+	}
 	RecalcAnimationLengthSeconds();
 }
 
@@ -145,16 +147,16 @@ void Model::LoadMaterialsFromMilkshapeAscii( const RString &_sPath )
 	{
 		iLineNum++;
 
-		if( !strncmp (sLine, "//", 2) )
+		if( !strncmp (sLine.c_str(), "//", 2) )
 			continue;
 
 		int nFrame;
-		if( sscanf(sLine, "Frames: %d", &nFrame) == 1 )
+		if( sscanf(sLine.c_str(), "Frames: %d", &nFrame) == 1 )
 		{
 			// ignore
 			// m_pModel->nTotalFrames = nFrame;
 		}
-		if( sscanf(sLine, "Frame: %d", &nFrame) == 1 )
+		if( sscanf(sLine.c_str(), "Frame: %d", &nFrame) == 1 )
 		{
 			// ignore
 			// m_pModel->nFrame = nFrame;
@@ -162,7 +164,7 @@ void Model::LoadMaterialsFromMilkshapeAscii( const RString &_sPath )
 
 		// materials
 		int nNumMaterials = 0;
-		if( sscanf(sLine, "Materials: %d", &nNumMaterials) == 1 )
+		if( sscanf(sLine.c_str(), "Materials: %d", &nNumMaterials) == 1 )
 		{
 			m_Materials.resize( nNumMaterials );
 
@@ -175,7 +177,7 @@ void Model::LoadMaterialsFromMilkshapeAscii( const RString &_sPath )
 				// name
 				if( f.GetLine( sLine ) <= 0 )
 					THROW;
-				if( sscanf(sLine, "\"%255[^\"]\"", szName) != 1 )
+				if( sscanf(sLine.c_str(), "\"%255[^\"]\"", szName) != 1 )
 					THROW;
 				Material.sName = szName;
 
@@ -183,7 +185,7 @@ void Model::LoadMaterialsFromMilkshapeAscii( const RString &_sPath )
 				if( f.GetLine( sLine ) <= 0 )
 					THROW;
 				RageVector4 Ambient;
-				if( sscanf(sLine, "%f %f %f %f", &Ambient[0], &Ambient[1], &Ambient[2], &Ambient[3]) != 4 )
+				if( sscanf(sLine.c_str(), "%f %f %f %f", &Ambient[0], &Ambient[1], &Ambient[2], &Ambient[3]) != 4 )
 					THROW;
 				memcpy( &Material.Ambient, &Ambient, sizeof(Material.Ambient) );
 
@@ -191,7 +193,7 @@ void Model::LoadMaterialsFromMilkshapeAscii( const RString &_sPath )
 				if( f.GetLine( sLine ) <= 0 )
 					THROW;
 				RageVector4 Diffuse;
-				if( sscanf(sLine, "%f %f %f %f", &Diffuse[0], &Diffuse[1], &Diffuse[2], &Diffuse[3]) != 4 )
+				if( sscanf(sLine.c_str(), "%f %f %f %f", &Diffuse[0], &Diffuse[1], &Diffuse[2], &Diffuse[3]) != 4 )
 					THROW;
 				memcpy( &Material.Diffuse, &Diffuse, sizeof(Material.Diffuse) );
 
@@ -199,7 +201,7 @@ void Model::LoadMaterialsFromMilkshapeAscii( const RString &_sPath )
 				if( f.GetLine( sLine ) <= 0 )
 					THROW;
 				RageVector4 Specular;
-				if( sscanf(sLine, "%f %f %f %f", &Specular[0], &Specular[1], &Specular[2], &Specular[3]) != 4 )
+				if( sscanf(sLine.c_str(), "%f %f %f %f", &Specular[0], &Specular[1], &Specular[2], &Specular[3]) != 4 )
 					THROW;
 				memcpy( &Material.Specular, &Specular, sizeof(Material.Specular) );
 
@@ -207,7 +209,7 @@ void Model::LoadMaterialsFromMilkshapeAscii( const RString &_sPath )
 				if( f.GetLine( sLine ) <= 0 )
 					THROW;
 				RageVector4 Emissive;
-				if( sscanf (sLine, "%f %f %f %f", &Emissive[0], &Emissive[1], &Emissive[2], &Emissive[3]) != 4 )
+				if( sscanf (sLine.c_str(), "%f %f %f %f", &Emissive[0], &Emissive[1], &Emissive[2], &Emissive[3]) != 4 )
 					THROW;
 				memcpy( &Material.Emissive, &Emissive, sizeof(Material.Emissive) );
 
@@ -231,7 +233,7 @@ void Model::LoadMaterialsFromMilkshapeAscii( const RString &_sPath )
 				if( f.GetLine( sLine ) <= 0 )
 					THROW;
 				strcpy( szName, "" );
-				sscanf( sLine, "\"%255[^\"]\"", szName );
+				sscanf( sLine.c_str(), "\"%255[^\"]\"", szName );
 				RString sDiffuseTexture = szName;
 
 				if( sDiffuseTexture == "" )
@@ -253,7 +255,7 @@ void Model::LoadMaterialsFromMilkshapeAscii( const RString &_sPath )
 				if( f.GetLine( sLine ) <= 0 )
 					THROW;
 				strcpy( szName, "" );
-				sscanf( sLine, "\"%255[^\"]\"", szName );
+				sscanf( sLine.c_str(), "\"%255[^\"]\"", szName );
 				RString sAlphaTexture = szName;
 
 				if( sAlphaTexture == "" )

--- a/src/Model.cpp
+++ b/src/Model.cpp
@@ -785,7 +785,7 @@ public:
 	static int position( T* p, lua_State *L )	{ p->SetPosition( FArg(1) ); COMMON_RETURN_SELF; }
 	static int playanimation( T* p, lua_State *L )	{ p->PlayAnimation(SArg(1),FArg(2)); COMMON_RETURN_SELF; }
 	static int SetDefaultAnimation( T* p, lua_State *L )	{ p->SetDefaultAnimation(SArg(1),FArg(2)); COMMON_RETURN_SELF; }
-	static int GetDefaultAnimation( T* p, lua_State *L )	{ lua_pushstring( L, p->GetDefaultAnimation() ); return 1; }
+	static int GetDefaultAnimation( T* p, lua_State *L )	{ lua_pushstring( L, p->GetDefaultAnimation().c_str() ); return 1; }
 	static int loop( T* p, lua_State *L )		{ p->SetLoop(BArg(1)); COMMON_RETURN_SELF; }
 	static int rate( T* p, lua_State *L )		{ p->SetRate(FArg(1)); COMMON_RETURN_SELF; }
 	static int GetNumStates( T* p, lua_State *L )		{ lua_pushnumber( L, p->GetNumStates() ); return 1; }

--- a/src/ModelTypes.cpp
+++ b/src/ModelTypes.cpp
@@ -44,11 +44,16 @@ void AnimatedTexture::Load( const RString &sTexOrIniPath )
 
 	m_bSphereMapped = sTexOrIniPath.find("sphere") != RString::npos;
 	if( sTexOrIniPath.find("add") != std::string::npos )
+	{
 		m_BlendMode = BLEND_ADD;
+	}
 	else
+	{
 		m_BlendMode = BLEND_NORMAL;
+	}
 
-	if( GetExtension(sTexOrIniPath).CompareNoCase("ini")==0 )
+	ci_string ini("ini");
+	if (ini == GetExtension(sTexOrIniPath).c_str())
 	{
 		IniFile ini;
 		if( !ini.ReadFile( sTexOrIniPath ) )

--- a/src/ModelTypes.cpp
+++ b/src/ModelTypes.cpp
@@ -242,12 +242,12 @@ bool msAnimation::LoadMilkshapeAsciiBones( RString sAniName, RString sPath )
 	{
 		iLineNum++;
 
-		if (!strncmp (sLine, "//", 2))
+		if (!strncmp (sLine.c_str(), "//", 2))
 			continue;
 
 		// bones
 		int nNumBones = 0;
-		if( sscanf (sLine, "Bones: %d", &nNumBones) != 1 )
+		if( sscanf (sLine.c_str(), "Bones: %d", &nNumBones) != 1 )
 			continue;
 
 		char szName[MS_MAX_NAME];
@@ -261,7 +261,7 @@ bool msAnimation::LoadMilkshapeAsciiBones( RString sAniName, RString sPath )
 			// name
 			if( f.GetLine( sLine ) <= 0 )
 				THROW;
-			if (sscanf(sLine, "\"%31[^\"]\"", szName) != 1)
+			if (sscanf(sLine.c_str(), "\"%31[^\"]\"", szName) != 1)
 				THROW;
 			Bone.sName = szName;
 
@@ -269,7 +269,7 @@ bool msAnimation::LoadMilkshapeAsciiBones( RString sAniName, RString sPath )
 			if( f.GetLine( sLine ) <= 0 )
 				THROW;
 			strcpy(szName, "");
-			sscanf(sLine, "\"%31[^\"]\"", szName);
+			sscanf(sLine.c_str(), "\"%31[^\"]\"", szName);
 
 			Bone.sParentName = szName;
 
@@ -279,7 +279,7 @@ bool msAnimation::LoadMilkshapeAsciiBones( RString sAniName, RString sPath )
 				THROW;
 
 			int nFlags;
-			if (sscanf (sLine, "%d %f %f %f %f %f %f",
+			if (sscanf (sLine.c_str(), "%d %f %f %f %f %f %f",
 				&nFlags,
 				&Position[0], &Position[1], &Position[2],
 				&Rotation[0], &Rotation[1], &Rotation[2]) != 7)
@@ -296,7 +296,7 @@ bool msAnimation::LoadMilkshapeAsciiBones( RString sAniName, RString sPath )
 			if( f.GetLine( sLine ) <= 0 )
 				THROW;
 			int nNumPositionKeys = 0;
-			if (sscanf (sLine, "%d", &nNumPositionKeys) != 1)
+			if (sscanf (sLine.c_str(), "%d", &nNumPositionKeys) != 1)
 				THROW;
 
 			Bone.PositionKeys.resize( nNumPositionKeys );
@@ -307,7 +307,7 @@ bool msAnimation::LoadMilkshapeAsciiBones( RString sAniName, RString sPath )
 					THROW;
 
 				float fTime;
-				if (sscanf (sLine, "%f %f %f %f", &fTime, &Position[0], &Position[1], &Position[2]) != 4)
+				if (sscanf (sLine.c_str(), "%f %f %f %f", &fTime, &Position[0], &Position[1], &Position[2]) != 4)
 					THROW;
 
 				msPositionKey key;
@@ -320,7 +320,7 @@ bool msAnimation::LoadMilkshapeAsciiBones( RString sAniName, RString sPath )
 			if( f.GetLine( sLine ) <= 0 )
 				THROW;
 			int nNumRotationKeys = 0;
-			if (sscanf (sLine, "%d", &nNumRotationKeys) != 1)
+			if (sscanf (sLine.c_str(), "%d", &nNumRotationKeys) != 1)
 				THROW;
 
 			Bone.RotationKeys.resize( nNumRotationKeys );
@@ -331,7 +331,7 @@ bool msAnimation::LoadMilkshapeAsciiBones( RString sAniName, RString sPath )
 					THROW;
 
 				float fTime;
-				if (sscanf (sLine, "%f %f %f %f", &fTime, &Rotation[0], &Rotation[1], &Rotation[2]) != 4)
+				if (sscanf (sLine.c_str(), "%f %f %f %f", &fTime, &Rotation[0], &Rotation[1], &Rotation[2]) != 4)
 					THROW;
 				Rotation = RadianToDegree(Rotation);
 

--- a/src/NetworkSyncManager.cpp
+++ b/src/NetworkSyncManager.cpp
@@ -932,16 +932,16 @@ unsigned long NetworkSyncManager::GetCurrentSMBuild( LoadingWindow* ld )
 						RString::size_type sFieldPos = svResponse[h].find(": ");
 						if( sFieldPos != RString::npos )
 						{
-							RString sFieldName = svResponse[h].Left(sFieldPos),
-								sFieldValue = svResponse[h].substr(sFieldPos+2);
+							RString sFieldName = head(svResponse[h] ,sFieldPos);
+							RString sFieldValue = svResponse[h].substr(sFieldPos+2);
 
 							Trim( sFieldName );
 							Trim( sFieldValue );
 
-							if( 0 == stricmp(sFieldName,"X-SM-Build") )
+							if( 0 == stricmp(sFieldName.c_str(),"X-SM-Build") )
 							{
 								bSuccess = true;
-								uCurrentSMBuild = strtoul( sFieldValue, NULL, 10 );
+								uCurrentSMBuild = strtoul( sFieldValue.c_str(), NULL, 10 );
 								break;
 							}
 						}

--- a/src/NetworkSyncManager.cpp
+++ b/src/NetworkSyncManager.cpp
@@ -845,9 +845,7 @@ void PacketFunctions::ClearPacket()
 
 RString NetworkSyncManager::MD5Hex( const RString &sInput )
 {
-	auto hex = BinaryToHex( CryptManager::GetMD5ForString(sInput));
-	std::transform(hex.begin(), hex.end(), hex.begin(), GetAsciiUpper);
-	return hex;
+	return MakeUpper(BinaryToHex( CryptManager::GetMD5ForString(sInput)));
 }
 
 void NetworkSyncManager::GetListOfLANServers( vector<NetServerInfo>& AllServers )

--- a/src/NetworkSyncManager.cpp
+++ b/src/NetworkSyncManager.cpp
@@ -450,7 +450,7 @@ void NetworkSyncManager::DisplayStartupStatus()
 		//Networking wasn't attepmpted
 		return;
 	case 1:
-		sMessage = ssprintf( CONNECTION_SUCCESSFUL.GetValue(), m_ServerName.c_str() );
+		sMessage = fmt::sprintf( CONNECTION_SUCCESSFUL.GetValue(), m_ServerName.c_str() );
 		break;
 	case 2:
 		sMessage = CONNECTION_FAILED.GetValue();

--- a/src/NetworkSyncManager.cpp
+++ b/src/NetworkSyncManager.cpp
@@ -845,7 +845,9 @@ void PacketFunctions::ClearPacket()
 
 RString NetworkSyncManager::MD5Hex( const RString &sInput )
 {
-	return BinaryToHex( CryptManager::GetMD5ForString(sInput) ).MakeUpper();
+	auto hex = BinaryToHex( CryptManager::GetMD5ForString(sInput));
+	std::transform(hex.begin(), hex.end(), hex.begin(), GetAsciiUpper);
+	return hex;
 }
 
 void NetworkSyncManager::GetListOfLANServers( vector<NetServerInfo>& AllServers )
@@ -985,7 +987,7 @@ static bool ConnectToServer( const RString &t )
 
 extern Preference<RString> g_sLastServer;
 
-LuaFunction( ConnectToServer, 		ConnectToServer( ( RString(SArg(1)).length()==0 ) ? RString(g_sLastServer) : RString(SArg(1) ) ) )
+LuaFunction( ConnectToServer, ConnectToServer( ( RString(SArg(1)).length()==0 ) ? g_sLastServer.Get() : RString(SArg(1) ) ) )
 
 #endif
 

--- a/src/NetworkSyncManager.cpp
+++ b/src/NetworkSyncManager.cpp
@@ -608,7 +608,7 @@ void NetworkSyncManager::ProcessInput()
 			{
 				m_sChatText += m_packet.ReadNT() + " \n ";
 				//10000 chars backlog should be more than enough
-				m_sChatText = m_sChatText.Right(10000);
+				m_sChatText = tail(m_sChatText, 10000);
 				SCREENMAN->SendMessageToTopScreen( SM_AddToChat );
 			}
 			break;

--- a/src/NoteDisplay.cpp
+++ b/src/NoteDisplay.cpp
@@ -135,7 +135,7 @@ struct NoteSkinAndPath
 	GameController gc;
 	bool operator<( const NoteSkinAndPath &other ) const
 	{
-		int cmp = strcmp(sNoteSkin, other.sNoteSkin);
+		int cmp = std::strcmp(sNoteSkin.c_str(), other.sNoteSkin.c_str());
 
 		if( cmp < 0 )
 		{

--- a/src/NoteField.cpp
+++ b/src/NoteField.cpp
@@ -94,8 +94,7 @@ void NoteField::Unload()
 
 void NoteField::CacheNoteSkin( const RString &sNoteSkin_ )
 {
-	RString sNoteSkinLower = sNoteSkin_;
-	sNoteSkinLower.MakeLower();
+	RString sNoteSkinLower = MakeLower(sNoteSkin_);
 
 	if( m_NoteDisplays.find(sNoteSkinLower) != m_NoteDisplays.end() )
 		return;
@@ -115,8 +114,7 @@ void NoteField::CacheNoteSkin( const RString &sNoteSkin_ )
 
 void NoteField::UncacheNoteSkin( const RString &sNoteSkin_ )
 {
-	RString sNoteSkinLower = sNoteSkin_;
-	sNoteSkinLower.MakeLower();
+	RString sNoteSkinLower = MakeLower(sNoteSkin_);
 
 	LOG->Trace("NoteField::CacheNoteSkin: release %s", sNoteSkinLower.c_str() );
 	ASSERT_M( m_NoteDisplays.find(sNoteSkinLower) != m_NoteDisplays.end(), sNoteSkinLower );
@@ -141,7 +139,7 @@ void NoteField::CacheAllUsedNoteSkins()
 	for (auto &s: asSkinsLower)
 	{
 		NOTESKIN->ValidateNoteSkinName(s);
-		s.MakeLower();
+		s = MakeLower(s);
 	}
 
 	for( unsigned i=0; i < asSkinsLower.size(); ++i )
@@ -163,7 +161,7 @@ void NoteField::CacheAllUsedNoteSkins()
 
 	RString sCurrentNoteSkinLower = m_pPlayerState->m_PlayerOptions.GetCurrent().m_sNoteSkin;
 	NOTESKIN->ValidateNoteSkinName(sCurrentNoteSkinLower);
-	sCurrentNoteSkinLower.MakeLower();
+	sCurrentNoteSkinLower = MakeLower(sCurrentNoteSkinLower);
 
 	auto it = m_NoteDisplays.find( sCurrentNoteSkinLower );
 	ASSERT_M( it != m_NoteDisplays.end(), sCurrentNoteSkinLower );
@@ -174,7 +172,7 @@ void NoteField::CacheAllUsedNoteSkins()
 	{
 		RString sNoteSkinLower = GAMESTATE->m_pPlayerState[pn]->m_PlayerOptions.GetCurrent().m_sNoteSkin;
 		NOTESKIN->ValidateNoteSkinName(sNoteSkinLower);
-		sNoteSkinLower.MakeLower();
+		sNoteSkinLower = MakeLower(sNoteSkinLower);
 		it = m_NoteDisplays.find( sNoteSkinLower );
 		ASSERT_M( it != m_NoteDisplays.end(), sNoteSkinLower );
 		m_pDisplays[pn] = it->second;
@@ -243,7 +241,7 @@ void NoteField::Load(
 		m_NoteDisplays.insert(std::pair<RString, NoteDisplayCols *> (sNoteSkinLower, badIdea));
 	}
 
-	sNoteSkinLower.MakeLower();
+	sNoteSkinLower = MakeLower(sNoteSkinLower);
 	auto it = m_NoteDisplays.find( sNoteSkinLower );
 	ASSERT_M( it != m_NoteDisplays.end(), ssprintf("iterator != m_NoteDisplays.end() [sNoteSkinLower = %s]",sNoteSkinLower.c_str()) );
 	memset( m_pDisplays, 0, sizeof(m_pDisplays) );
@@ -263,7 +261,7 @@ void NoteField::Load(
 			m_NoteDisplays.insert(std::pair<RString, NoteDisplayCols *> (sNoteSkinLower, badIdea));
 		}
 
-		sNoteSkinLower.MakeLower();
+		sNoteSkinLower = MakeLower(sNoteSkinLower);
 		it = m_NoteDisplays.find( sNoteSkinLower );
 		ASSERT_M( it != m_NoteDisplays.end(), sNoteSkinLower );
 		m_pDisplays[pn] = it->second;

--- a/src/NoteSkinManager.cpp
+++ b/src/NoteSkinManager.cpp
@@ -211,14 +211,10 @@ void NoteSkinManager::GetNoteSkinNames( const Game* pGame, vector<RString> &AddT
 
 bool NoteSkinManager::NoteSkinNameInList(const RString name, vector<RString> name_list)
 {
-	for(size_t i= 0; i < name_list.size(); ++i)
-	{
-		if(0 == stricmp(name, name_list[i]))
-		{
-			return true;
-		}
-	}
-	return false;
+	ci_string ciName(name.c_str());
+	return std::any_of(name_list.begin(), name_list.end(), [&ciName](RString const &item) {
+		return ciName == item.c_str();
+	});
 }
 
 bool NoteSkinManager::DoesNoteSkinExist( const RString &sSkinName )

--- a/src/NoteSkinManager.cpp
+++ b/src/NoteSkinManager.cpp
@@ -140,11 +140,16 @@ void NoteSkinManager::LoadNoteSkinDataRecursive( const RString &sNoteSkinName_, 
 		// read global fallback the current NoteSkin (if any)
 		IniFile ini;
 		ini.ReadFile( sDir+"metrics.ini" );
+		ci_string ciName(sNoteSkinName.c_str());
 
-		if( !sNoteSkinName.CompareNoCase(GAME_BASE_NOTESKIN_NAME) )
+		if ( ciName == GAME_BASE_NOTESKIN_NAME.c_str())
+		{
 			bLoadedBase = true;
-		if( !sNoteSkinName.CompareNoCase(GAME_COMMON_NOTESKIN_NAME) )
+		}
+		else if ( ciName == GAME_COMMON_NOTESKIN_NAME.c_str())
+		{
 			bLoadedCommon = true;
+		}
 
 		RString sFallback;
 		if( !ini.GetValue("Global","FallbackNoteSkin", sFallback) )

--- a/src/NoteSkinManager.cpp
+++ b/src/NoteSkinManager.cpp
@@ -90,8 +90,7 @@ void NoteSkinManager::RefreshNoteSkinData( const Game* pGame )
 	g_mapNameToData.clear();
 	for( unsigned j=0; j<asNoteSkinNames.size(); j++ )
 	{
-		RString sName = asNoteSkinNames[j];
-		sName.MakeLower();
+		RString sName = MakeLower(asNoteSkinNames[j]);
 		LoadNoteSkinData( sName, g_mapNameToData[sName] );
 	}
 }
@@ -286,8 +285,7 @@ RString NoteSkinManager::GetMetric( const RString &sButtonName, const RString &s
 		LuaHelpers::ReportScriptError("NOTESKIN:GetMetric: No noteskin currently set.", "NOTESKIN_ERROR");
 		return "";
 	}
-	RString sNoteSkinName = m_sCurrentNoteSkin;
-	sNoteSkinName.MakeLower();
+	RString sNoteSkinName = MakeLower(m_sCurrentNoteSkin);
 	auto it = g_mapNameToData.find(sNoteSkinName);
 	ASSERT_M( it != g_mapNameToData.end(), sNoteSkinName );	// this NoteSkin doesn't exist!
 	const NoteSkinData& data = it->second;
@@ -338,8 +336,7 @@ RString NoteSkinManager::GetPath( const RString &sButtonName, const RString &sEl
 		LuaHelpers::ReportScriptError("NOTESKIN:GetPath: No noteskin currently set.", "NOTESKIN_ERROR");
 		return "";
 	}
-	RString sNoteSkinName = m_sCurrentNoteSkin;
-	sNoteSkinName.MakeLower();
+	RString sNoteSkinName = MakeLower(m_sCurrentNoteSkin);
 	auto iter = g_mapNameToData.find( sNoteSkinName );
 	ASSERT( iter != g_mapNameToData.end() );
 	const NoteSkinData &data = iter->second;

--- a/src/NotesLoader.cpp
+++ b/src/NotesLoader.cpp
@@ -28,7 +28,7 @@ void NotesLoader::GetMainAndSubTitlesFromFullTitle( const RString &sFullTitle, R
 		size_t iBeginIndex = sFullTitle.find( sep );
 		if( iBeginIndex == string::npos )
 			continue;
-		sMainTitleOut = sFullTitle.Left( (int) iBeginIndex );
+		sMainTitleOut = head(sFullTitle, iBeginIndex);
 		sSubTitleOut = sFullTitle.substr( iBeginIndex+1, sFullTitle.size()-iBeginIndex+1 );
 		return;
 	}

--- a/src/NotesLoaderBMS.cpp
+++ b/src/NotesLoaderBMS.cpp
@@ -1248,7 +1248,7 @@ bool BMSChartReader::ReadNoteData()
 		if( channel == 3 ) // bpm change
 		{
 			int bpm;
-			if( sscanf(obj.value, "%x", &bpm) == 1 )
+			if( sscanf(obj.value.c_str(), "%x", &bpm) == 1 )
 			{
 				if (bpm > 0)
 				{

--- a/src/NotesLoaderBMS.cpp
+++ b/src/NotesLoaderBMS.cpp
@@ -73,7 +73,7 @@ static RString FindLargestInitialSubstring( const RString &string1, const RStrin
 
 static void SearchForDifficulty( RString sTag, Steps *pOut )
 {
-	sTag.MakeLower();
+	sTag = MakeLower(sTag);
 
 	// Only match "Light" in parentheses.
 	if( sTag.find( "(light" ) != sTag.npos )
@@ -416,12 +416,11 @@ struct bmsCommandTree
 		statement = statement.substr(hash);
 
 		size_t space = statement.find(' ');
-		RString name = statement.substr(0, space);
+		RString name = MakeLower(statement.substr(0, space));
 		RString value = "";
 
 		if (space != statement.npos)
 			value = statement.substr(space + 1);
-		name.MakeLower();
 
 		if (name == "#if")
 		{
@@ -570,7 +569,7 @@ bool BMSChart::Load( const RString &chartPath )
 				RString value = data.substr(2 * i, 2);
 				if (value != "00")
 				{
-					value.MakeLower();
+					value = MakeLower(value);
 					BMSObject o = { channel, measure, (float)i / count, flag, value };
 					objects.push_back(o);
 				}
@@ -884,8 +883,7 @@ void BMSChartReader::ReadHeaders()
 		}
 		else if( it->first == "#lnobj" )
 		{
-			lnobj = it->second;
-			lnobj.MakeLower();
+			lnobj = MakeLower(it->second);
 		}
 		else if( it->first == "#playlevel" )
 		{
@@ -1505,8 +1503,7 @@ void BMSSongLoader::AddToSong()
 
 			if( title != "" && title.size() != commonSubstring.size() )
 			{
-				RString tag = title.substr( commonSubstring.size(), title.size() - commonSubstring.size() );
-				tag.MakeLower();
+				RString tag = MakeLower(title.substr( commonSubstring.size(), title.size() - commonSubstring.size() ));
 
 				// XXX: We should do this with filenames too, I have plenty of examples.
 				// however, filenames will be trickier, as stuff at the beginning AND

--- a/src/NotesLoaderDWI.cpp
+++ b/src/NotesLoaderDWI.cpp
@@ -238,10 +238,10 @@ static NoteData ParseNoteData(RString &step1, RString &step2,
 				DEFAULT_FAIL( pad );
 		}
 
-		sStepData.Replace("\n", "");
-		sStepData.Replace("\r", "");
-		sStepData.Replace("\t", "");
-		sStepData.Replace(" ", "");
+		ReplaceAll(sStepData, "\n", "");
+		ReplaceAll(sStepData, "\r", "");
+		ReplaceAll(sStepData, "\t", "");
+		ReplaceAll(sStepData, " ", "");
 
 		double fCurrentBeat = 0;
 		double fCurrentIncrementer = 1.0/8 * BEATS_PER_MEASURE;

--- a/src/NotesLoaderDWI.cpp
+++ b/src/NotesLoaderDWI.cpp
@@ -500,11 +500,10 @@ bool DWILoader::LoadNoteDataFromSimfile( const RString &path, Steps &out )
 		int iNumParams = msd.GetNumParams(i);
 		const MsdFile::value_t &params = msd.GetValue(i);
 		RString valueName = params[0];
+		ci_string ciValueName(valueName.c_str());
 
-		if(valueName.EqualsNoCase("SINGLE")  ||
-		   valueName.EqualsNoCase("DOUBLE")  ||
-		   valueName.EqualsNoCase("COUPLE")  ||
-		   valueName.EqualsNoCase("SOLO") )
+		if(ciValueName == "SINGLE" || ciValueName == "DOUBLE" ||
+		   ciValueName == "COUPLE" || ciValueName == "SOLO")
 		{
 			if (out.m_StepsType != GetTypeFromMode(valueName))
 				continue;
@@ -560,10 +559,12 @@ bool DWILoader::LoadFromDir( const RString &sPath_, Song &out, std::set<RString>
 		}
 
 		// handle the data
-		if( sValueName.EqualsNoCase("FILE") )
+		ci_string ciValueName(sValueName.c_str());
+		if( ciValueName == "FILE" )
+		{
 			out.m_sMusicFile = sParams[1];
-
-		else if( sValueName.EqualsNoCase("TITLE") )
+		}
+		else if( ciValueName == "TITLE" )
 		{
 			NotesLoader::GetMainAndSubTitlesFromFullTitle( sParams[1], out.m_sMainTitle, out.m_sSubTitle );
 
@@ -573,22 +574,23 @@ bool DWILoader::LoadFromDir( const RString &sPath_, Song &out, std::set<RString>
 			ConvertString( out.m_sSubTitle, "utf-8,english" );
 		}
 
-		else if( sValueName.EqualsNoCase("ARTIST") )
+		else if( ciValueName == "ARTIST" )
 		{
 			out.m_sArtist = sParams[1];
 			ConvertString( out.m_sArtist, "utf-8,english" );
 		}
 
-		else if( sValueName.EqualsNoCase("GENRE") )
+		else if( ciValueName == "GENRE" )
 		{
 			out.m_sGenre = sParams[1];
 			ConvertString( out.m_sGenre, "utf-8,english" );
 		}
 
-		else if( sValueName.EqualsNoCase("CDTITLE") )
+		else if( ciValueName == "CDTITLE" )
+		{
 			out.m_sCDTitleFile = sParams[1];
-
-		else if( sValueName.EqualsNoCase("BPM") )
+		}
+		else if( ciValueName == "BPM" )
 		{
 			const float fBPM = StringToFloat( sParams[1] );
 
@@ -602,20 +604,20 @@ bool DWILoader::LoadFromDir( const RString &sPath_, Song &out, std::set<RString>
 				out.m_SongTiming.AddSegment( BPMSegment(0, fBPM) );
 			}
 		}
-		else if( sValueName.EqualsNoCase("DISPLAYBPM") )
+		else if( ciValueName == "DISPLAYBPM" )
 		{
 			// #DISPLAYBPM:[xxx..xxx]|[xxx]|[*];
 		    int iMin, iMax;
 			/* We can't parse this as a float with sscanf, since '.' is a valid
 			 * character in a float.  (We could do it with a regex, but it's not
 			 * worth bothering with since we don't display fractional BPM anyway.) */
-		    if( sscanf( sParams[1], "%i..%i", &iMin, &iMax ) == 2 )
+		    if( sscanf( sParams[1].c_str(), "%i..%i", &iMin, &iMax ) == 2 )
 			{
 				out.m_DisplayBPMType = DISPLAY_BPM_SPECIFIED;
 				out.m_fSpecifiedBPMMin = (float) iMin;
 				out.m_fSpecifiedBPMMax = (float) iMax;
 			}
-			else if( sscanf( sParams[1], "%i", &iMin ) == 1 )
+			else if( sscanf( sParams[1].c_str(), "%i", &iMin ) == 1 )
 			{
 				out.m_DisplayBPMType = DISPLAY_BPM_SPECIFIED;
 				out.m_fSpecifiedBPMMin = out.m_fSpecifiedBPMMax = (float) iMin;
@@ -626,14 +628,14 @@ bool DWILoader::LoadFromDir( const RString &sPath_, Song &out, std::set<RString>
 			}
 		}
 
-		else if( sValueName.EqualsNoCase("GAP") )
+		else if( ciValueName == "GAP" )
 			// the units of GAP is 1/1000 second
 			out.m_SongTiming.m_fBeat0OffsetInSeconds = -StringToInt(sParams[1]) / 1000.0f;
 
-		else if( sValueName.EqualsNoCase("SAMPLESTART") )
+		else if( ciValueName == "SAMPLESTART" )
 			out.m_fMusicSampleStartSeconds = ParseBrokenDWITimestamp(sParams[1], sParams[2], sParams[3]);
 
-		else if( sValueName.EqualsNoCase("SAMPLELENGTH") )
+		else if( ciValueName == "SAMPLELENGTH" )
 		{
 			float sampleLength = ParseBrokenDWITimestamp(sParams[1], sParams[2], sParams[3]);
 			if (sampleLength > 0 && sampleLength < 1) {
@@ -644,7 +646,7 @@ bool DWILoader::LoadFromDir( const RString &sPath_, Song &out, std::set<RString>
 
 		}
 
-		else if( sValueName.EqualsNoCase("FREEZE") )
+		else if( ciValueName == "FREEZE" )
 		{
 			vector<RString> arrayFreezeExpressions;
 			split( sParams[1], ",", arrayFreezeExpressions );
@@ -666,7 +668,7 @@ bool DWILoader::LoadFromDir( const RString &sPath_, Song &out, std::set<RString>
 			}
 		}
 
-		else if( sValueName.EqualsNoCase("CHANGEBPM")  || sValueName.EqualsNoCase("BPMCHANGE") )
+		else if( ciValueName == "CHANGEBPM" || ciValueName == "BPMCHANGE" )
 		{
 			vector<RString> arrayBPMChangeExpressions;
 			split( sParams[1], ",", arrayBPMChangeExpressions );
@@ -691,10 +693,8 @@ bool DWILoader::LoadFromDir( const RString &sPath_, Song &out, std::set<RString>
 			}
 		}
 
-		else if( sValueName.EqualsNoCase("SINGLE")  ||
-			 sValueName.EqualsNoCase("DOUBLE")  ||
-			 sValueName.EqualsNoCase("COUPLE")  ||
-			 sValueName.EqualsNoCase("SOLO") )
+		else if( ciValueName == "SINGLE" || ciValueName == "DOUBLE" ||
+				ciValueName == "COUPLE" || ciValueName == "SOLO")
 		{
 			Steps* pNewNotes = out.CreateSteps();
 			LoadFromDWITokens(
@@ -714,8 +714,7 @@ bool DWILoader::LoadFromDir( const RString &sPath_, Song &out, std::set<RString>
 			else
 				delete pNewNotes;
 		}
-		else if( sValueName.EqualsNoCase("DISPLAYTITLE") ||
-			sValueName.EqualsNoCase("DISPLAYARTIST") )
+		else if( ciValueName == "DISPLAYTITLE" || ciValueName == "DISPLAYARTIST" )
 		{
 			/* We don't want to support these tags.  However, we don't want
 			 * to pick up images used here as song images (eg. banners). */

--- a/src/NotesLoaderDWI.cpp
+++ b/src/NotesLoaderDWI.cpp
@@ -149,8 +149,7 @@ const int BEATS_PER_MEASURE = 4;
  * normalized when written to SMs, etc.) */
 Difficulty DwiCompatibleStringToDifficulty( const RString& sDC )
 {
-	RString s2 = sDC;
-	s2.MakeLower();
+	RString s2 = MakeLower(sDC);
 	if( s2 == "beginner" )			return Difficulty_Beginner;
 	else if( s2 == "easy" )		return Difficulty_Easy;
 	else if( s2 == "basic" )		return Difficulty_Easy;
@@ -731,11 +730,10 @@ bool DWILoader::LoadFromDir( const RString &sPath_, Song &out, std::set<RString>
 				if( endpos == RString::npos )
 					break;
 
-				RString sub = param.substr( startpos+1, endpos-startpos-1 );
+				RString sub = MakeLower(param.substr( startpos+1, endpos-startpos-1 ));
 
 				pos = endpos + 1;
 
-				sub.MakeLower();
 				BlacklistedImages.insert( sub );
 			}
 		}

--- a/src/NotesLoaderJson.cpp
+++ b/src/NotesLoaderJson.cpp
@@ -175,12 +175,16 @@ static void Deserialize( Song &out, const Json::Value &root )
 	out.m_SongTiming.m_fBeat0OffsetInSeconds = (float)root["Offset"].asDouble();
 	out.m_fMusicSampleStartSeconds = (float)root["SampleStart"].asDouble();
 	out.m_fMusicSampleLengthSeconds = (float)root["SampleLength"].asDouble();
-	RString sSelectable = root["Selectable"].asString();
-	if( sSelectable.EqualsNoCase("YES") )
+	ci_string sSelectable = root["Selectable"].asString().c_str();
+	
+	if( sSelectable == "YES" )
+	{
 		out.m_SelectionDisplay = out.SHOW_ALWAYS;
-	else if( sSelectable.EqualsNoCase("NO") )
+	}
+	else if( sSelectable == "NO" )
+	{
 		out.m_SelectionDisplay = out.SHOW_NEVER;
-
+	}
 	out.m_sSongFileName = root["SongFileName"].asString();
 	out.m_bHasMusic = root["HasMusic"].asBool();
 	out.m_bHasBanner = root["HasBanner"].asBool();

--- a/src/NotesLoaderKSF.cpp
+++ b/src/NotesLoaderKSF.cpp
@@ -50,8 +50,7 @@ static bool LoadFromKSFFile( const RString &sPath, Steps &out, Song &song, bool 
 	for( unsigned i=0; i<msd.GetNumValues(); i++ )
 	{
 		const MsdFile::value_t &sParams = msd.GetValue( i );
-		RString sValueName = sParams[0];
-		sValueName.MakeUpper();
+		RString sValueName = MakeUpper(sParams[0]);
 
 		/* handle the data...well, not this data: not related to steps.
 		 * Skips INTRO, MUSICINTRO, TITLEFILE, DISCFILE, SONGFILE. */
@@ -150,8 +149,7 @@ static bool LoadFromKSFFile( const RString &sPath, Steps &out, Song &song, bool 
 		// new cases from Aldo_MX's fork:
 		else if( sValueName=="PLAYER" )
 		{
-			RString sPlayer = sParams[1];
-			sPlayer.MakeLower();
+			RString sPlayer = MakeLower(sParams[1]);
 			if( sPlayer.find( "double" ) != string::npos )
 				bDoublesChart = true;
 		}
@@ -189,7 +187,7 @@ static bool LoadFromKSFFile( const RString &sPath, Steps &out, Song &song, bool 
 	{
 		RString sDir, sFName, sExt;
 		splitpath( sPath, sDir, sFName, sExt );
-		sFName.MakeLower();
+		sFName = MakeLower(sFName);
 
 		out.SetDescription(sFName);
 		// Check another before anything else... is this okay? -DaisuMaster
@@ -555,8 +553,7 @@ static bool LoadGlobalData( const RString &sPath, Song &out, bool &bKIUCompliant
 	for( unsigned i=0; i < msd.GetNumValues(); i++ )
 	{
 		const MsdFile::value_t &sParams = msd.GetValue(i);
-		RString sValueName = sParams[0];
-		sValueName.MakeUpper();
+		RString sValueName = MakeUpper(sParams[0]);
 
 		// handle the data
 		if( sValueName=="TITLE" )

--- a/src/NotesLoaderKSF.cpp
+++ b/src/NotesLoaderKSF.cpp
@@ -479,16 +479,14 @@ static void LoadTags( const RString &str, Song &out )
 	vector<RString> asBits;
 	split( str, " - ", asBits, false );
 	// Ignore the difficulty, since we get that elsewhere.
-	if( asBits.size() == 3 && (
-		asBits[2].EqualsNoCase("double") ||
-		asBits[2].EqualsNoCase("easy") ||
-		asBits[2].EqualsNoCase("normal") ||
-		asBits[2].EqualsNoCase("hard") ||
-		asBits[2].EqualsNoCase("crazy") ||
-		asBits[2].EqualsNoCase("nightmare"))
-		)
+	if (asBits.size() == 3)
 	{
-		asBits.erase( asBits.begin()+2, asBits.begin()+3 );
+		ci_string csBit(asBits[2].c_str());
+		if (csBit == "double" || csBit == "easy" || csBit == "normal" ||
+			csBit == "hard" || csBit == "crazy" || csBit == "nightmare")
+		{
+			asBits.erase( asBits.begin()+2, asBits.begin()+3 );
+		}
 	}
 
 	RString title, artist;

--- a/src/NotesLoaderSM.cpp
+++ b/src/NotesLoaderSM.cpp
@@ -986,8 +986,7 @@ bool SMLoader::LoadFromBGChangesString( BackgroundChange &change, const RString 
 		// fall through
 	case 8:
 	{
-		RString tmp = aBGChangeValues[7];
-		tmp.MakeLower();
+		RString tmp = MakeLower(aBGChangeValues[7]);
 		if( ( tmp.find(".ini") != string::npos || tmp.find(".xml") != string::npos )
 		   && !PREFSMAN->m_bQuirksMode )
 		{
@@ -1030,8 +1029,7 @@ bool SMLoader::LoadFromBGChangesString( BackgroundChange &change, const RString 
 		// fall through
 	case 2:
 	{
-		RString tmp = aBGChangeValues[1];
-		tmp.MakeLower();
+		RString tmp = MakeLower(aBGChangeValues[1]);
 		if( ( tmp.find(".ini") != string::npos || tmp.find(".xml") != string::npos )
 		   && !PREFSMAN->m_bQuirksMode )
 		{
@@ -1063,8 +1061,7 @@ bool SMLoader::LoadNoteDataFromSimfile( const RString &path, Steps &out )
 	{
 		int iNumParams = msd.GetNumParams(i);
 		const MsdFile::value_t &sParams = msd.GetValue(i);
-		RString sValueName = sParams[0];
-		sValueName.MakeUpper();
+		RString sValueName = MakeUpper(sParams[0]);
 
 		// The only tag we care about is the #NOTES tag.
 		if( sValueName=="NOTES" || sValueName=="NOTES2" )
@@ -1151,8 +1148,7 @@ bool SMLoader::LoadFromSimfile( const RString &sPath, Song &out, bool bFromCache
 	{
 		int iNumParams = msd.GetNumParams(i);
 		const MsdFile::value_t &sParams = msd.GetValue(i);
-		RString sValueName = sParams[0];
-		sValueName.MakeUpper();
+		RString sValueName = MakeUpper(sParams[0]);
 
 		reused_song_info.params= &sParams;
 		song_handler_map_t::iterator handler=
@@ -1237,8 +1233,7 @@ bool SMLoader::LoadEditFromMsd( const MsdFile &msd, const RString &sEditFilePath
 	{
 		int iNumParams = msd.GetNumParams(i);
 		const MsdFile::value_t &sParams = msd.GetValue(i);
-		RString sValueName = sParams[0];
-		sValueName.MakeUpper();
+		RString sValueName = MakeUpper(sParams[0]);
 
 		// handle the data
 		if( sValueName=="SONG" )

--- a/src/NotesLoaderSM.cpp
+++ b/src/NotesLoaderSM.cpp
@@ -1062,8 +1062,10 @@ bool SMLoader::LoadNoteDataFromSimfile( const RString &path, Steps &out )
 			RString difficulty = sParams[3];
 
 			// HACK?: If this is a .edit fudge the edit difficulty
-			if(path.Right(5).CompareNoCase(".edit") == 0) difficulty = "edit";
-
+			if(tail(path, 5).CompareNoCase(".edit") == 0)
+			{
+				difficulty = "edit";
+			}
 			Trim(stepsType);
 			Trim(description);
 			Trim(difficulty);

--- a/src/NotesLoaderSM.cpp
+++ b/src/NotesLoaderSM.cpp
@@ -363,7 +363,7 @@ void SMLoader::LoadFromTokens(
 void SMLoader::ProcessBGChanges( Song &out, const RString &sValueName, const RString &sPath, const RString &sParam )
 {
 	BackgroundLayer iLayer = BACKGROUND_LAYER_1;
-	if( sscanf(sValueName, "BGCHANGES%d", &*ConvertValue<int>(&iLayer)) == 1 )
+	if( sscanf(sValueName.c_str(), "BGCHANGES%d", &*ConvertValue<int>(&iLayer)) == 1 )
 		enum_add(iLayer, -1);	// #BGCHANGES2 = BACKGROUND_LAYER_2
 
 	bool bValid = iLayer>=0 && iLayer<NUM_BackgroundLayer;
@@ -862,7 +862,7 @@ void SMLoader::ProcessTickcounts( TimingData &out, const RString line, const int
 		}
 
 		const float fTickcountBeat = RowToBeat( arrayTickcountValues[0], rowsPerBeat );
-		int iTicks = clamp(atoi( arrayTickcountValues[1] ), 0, ROWS_PER_BEAT);
+		int iTicks = clamp(atoi( arrayTickcountValues[1].c_str() ), 0, ROWS_PER_BEAT);
 
 		out.AddSegment( TickcountSegment(BeatToNoteRow(fTickcountBeat), iTicks) );
 	}

--- a/src/NotesLoaderSM.cpp
+++ b/src/NotesLoaderSM.cpp
@@ -1136,7 +1136,7 @@ bool SMLoader::LoadFromSimfile( const RString &sPath, Song &out, bool bFromCache
 		 * splitting other formats that *don't* natively support #SUBTITLE. */
 			handler->second(reused_song_info);
 		}
-		else if(sValueName.Left(strlen("BGCHANGES")) == "BGCHANGES")
+		else if(BeginsWith(sValueName, "BGCHANGES"))
 		{
 			SMSetBGChanges(reused_song_info);
 		}

--- a/src/NotesLoaderSM.cpp
+++ b/src/NotesLoaderSM.cpp
@@ -878,7 +878,7 @@ void SMLoader::ProcessSpeeds( TimingData &out, const RString line, const int row
 		vector<RString> vs2;
 		split( *s1, "=", vs2 );
 
-		if( vs2[0] == 0 && vs2.size() == 2 ) // First one always seems to have 2.
+		if( vs2[0][0] == '0' && vs2.size() == 2 ) // First one always seems to have 2.
 		{
 			vs2.push_back("0");
 		}
@@ -973,12 +973,12 @@ bool SMLoader::LoadFromBGChangesString( BackgroundChange &change, const RString 
 	{
 	case 11:
 		change.m_def.m_sColor2 = aBGChangeValues[10];
-		change.m_def.m_sColor2.Replace( '^', ',' );
+		ReplaceAll(change.m_def.m_sColor2, "^", ",");
 		change.m_def.m_sColor2 = RageColor::NormalizeColorString( change.m_def.m_sColor2 );
 		// fall through
 	case 10:
 		change.m_def.m_sColor1 = aBGChangeValues[9];
-		change.m_def.m_sColor1.Replace( '^', ',' );
+		ReplaceAll(change.m_def.m_sColor1, "^", ",");
 		change.m_def.m_sColor1 = RageColor::NormalizeColorString( change.m_def.m_sColor1 );
 		// fall through
 	case 9:
@@ -1248,7 +1248,7 @@ bool SMLoader::LoadEditFromMsd( const MsdFile &msd, const RString &sEditFilePath
 
 			RString sSongFullTitle = sParams[1];
 			this->SetSongTitle(sParams[1]);
-			sSongFullTitle.Replace( '\\', '/' );
+			ReplaceAll(sSongFullTitle, "\\", "/");
 
 			pSong = SONGMAN->FindSong( sSongFullTitle );
 			if( pSong == NULL )

--- a/src/NotesLoaderSM.cpp
+++ b/src/NotesLoaderSM.cpp
@@ -145,23 +145,36 @@ void SMSetDisplayBPM(SMSongTagInfo& info)
 }
 void SMSetSelectable(SMSongTagInfo& info)
 {
-	if((*info.params)[1].EqualsNoCase("YES"))
-	{ info.song->m_SelectionDisplay = info.song->SHOW_ALWAYS; }
-	else if((*info.params)[1].EqualsNoCase("NO"))
-	{ info.song->m_SelectionDisplay = info.song->SHOW_NEVER; }
+	ci_string ciParam( (*info.params)[1].c_str());
+	if(ciParam == "YES")
+	{
+		info.song->m_SelectionDisplay = info.song->SHOW_ALWAYS;
+	}
+	else if(ciParam == "NO")
+	{
+		info.song->m_SelectionDisplay = info.song->SHOW_NEVER;
+	}
 	// ROULETTE from 3.9. It was removed since UnlockManager can serve
 	// the same purpose somehow. This, of course, assumes you're using
 	// unlocks. -aj
-	else if((*info.params)[1].EqualsNoCase("ROULETTE"))
-	{ info.song->m_SelectionDisplay = info.song->SHOW_ALWAYS; }
+	else if(ciParam == "ROULETTE")
+	{
+		info.song->m_SelectionDisplay = info.song->SHOW_ALWAYS;
+	}
 	/* The following two cases are just fixes to make sure simfiles that
 	 * used 3.9+ features are not excluded here */
-	else if((*info.params)[1].EqualsNoCase("ES") || (*info.params)[1].EqualsNoCase("OMES"))
-	{ info.song->m_SelectionDisplay = info.song->SHOW_ALWAYS; }
+	else if(ciParam == "ES" || ciParam == "OMES")
+	{
+		info.song->m_SelectionDisplay = info.song->SHOW_ALWAYS;
+	}
 	else if(StringToInt((*info.params)[1]) > 0)
-	{ info.song->m_SelectionDisplay = info.song->SHOW_ALWAYS; }
+	{
+		info.song->m_SelectionDisplay = info.song->SHOW_ALWAYS;
+	}
 	else
-	{ LOG->UserLog("Song file", info.path, "has an unknown #SELECTABLE value, \"%s\"; ignored.", (*info.params)[1].c_str()); }
+	{
+		LOG->UserLog("Song file", info.path, "has an unknown #SELECTABLE value, \"%s\"; ignored.", (*info.params)[1].c_str());
+	}
 }
 void SMSetBGChanges(SMSongTagInfo& info)
 {

--- a/src/NotesLoaderSM.cpp
+++ b/src/NotesLoaderSM.cpp
@@ -337,12 +337,13 @@ void SMLoader::LoadFromTokens(
 	// Difficulty_Challenge. (At least v1.64, possibly v3.0 final...)
 	if( out.GetDifficulty() == Difficulty_Hard )
 	{
+		ci_string ciDesc(sDescription.c_str());
 		// HACK: SMANIAC used to be Difficulty_Hard with a special description.
-		if( sDescription.CompareNoCase("smaniac") == 0 )
+		if( ciDesc == "smaniac" )
 			out.SetDifficulty( Difficulty_Challenge );
 
 		// HACK: CHALLENGE used to be Difficulty_Hard with a special description.
-		if( sDescription.CompareNoCase("challenge") == 0 )
+		else if( ciDesc == "challenge" )
 			out.SetDifficulty( Difficulty_Challenge );
 	}
 
@@ -410,14 +411,21 @@ void SMLoader::ProcessAttacks( AttackArray &attacks, MsdFile::value_t params )
 			continue;
 
 		Trim( sBits[0] );
-
-		if( !sBits[0].CompareNoCase("TIME") )
-			attack.fStartSecond = strtof( sBits[1], NULL );
-		else if( !sBits[0].CompareNoCase("LEN") )
-			attack.fSecsRemaining = strtof( sBits[1], NULL );
-		else if( !sBits[0].CompareNoCase("END") )
-			end = strtof( sBits[1], NULL );
-		else if( !sBits[0].CompareNoCase("MODS") )
+		ci_string ciBit(sBits[0].c_str());
+		
+		if (ciBit == "TIME")
+		{
+			attack.fStartSecond = std::strtof( sBits[1].c_str(), NULL );
+		}
+		else if(ciBit == "LEN")
+		{
+			attack.fSecsRemaining = std::strtof( sBits[1].c_str(), NULL );
+		}
+		else if(ciBit == "END")
+		{
+			end = std::strtof( sBits[1].c_str(), NULL );
+		}
+		else if(ciBit == "MODS")
 		{
 			Trim(sBits[1]);
 			attack.sModifiers = sBits[1];
@@ -1075,30 +1083,34 @@ bool SMLoader::LoadNoteDataFromSimfile( const RString &path, Steps &out )
 			RString difficulty = sParams[3];
 
 			// HACK?: If this is a .edit fudge the edit difficulty
-			if(tail(path, 5).CompareNoCase(".edit") == 0)
+			ci_string ciPath(tail(path, 5).c_str());
+			if(ciPath == ".edit")
 			{
 				difficulty = "edit";
 			}
 			Trim(stepsType);
 			Trim(description);
 			Trim(difficulty);
+			ci_string ciDiff(difficulty.c_str());
 			// Remember our old versions.
-			if (difficulty.CompareNoCase("smaniac") == 0)
+			if (ciDiff == "smaniac")
 			{
 				difficulty = "Challenge";
 			}
 
 			/* Handle hacks that originated back when StepMania didn't have
 			 * Difficulty_Challenge. TODO: Remove the need for said hacks. */
-			if( difficulty.CompareNoCase("hard") == 0 )
+			if( ciDiff == "hard" )
 			{
 				/* HACK: Both SMANIAC and CHALLENGE used to be Difficulty_Hard.
 				 * They were differentiated via aspecial description.
 				 * Account for the rogue charts that do this. */
 				// HACK: SMANIAC used to be Difficulty_Hard with a special description.
-				if (description.CompareNoCase("smaniac") == 0 ||
-					description.CompareNoCase("challenge") == 0)
+				ci_string ciDesc(description.c_str());
+				if ( ciDesc == "smaniac" || ciDesc == "challenge")
+				{
 					difficulty = "Challenge";
+				}
 			}
 
 			if(!(out.m_StepsType == GAMEMAN->StringToStepsType( stepsType ) &&
@@ -1334,9 +1346,10 @@ void SMLoader::TidyUpData( Song &song, bool bFromCache )
 		 * with a very high beat, search the whole list. */
 		bool bHasNoSongBgTag = false;
 
+		ci_string ciNoSong(NO_SONG_BG_FILE.c_str());
 		for( unsigned i = 0; !bHasNoSongBgTag && i < bg.size(); ++i )
 		{
-			if( !bg[i].m_def.m_sFile1.CompareNoCase(NO_SONG_BG_FILE) )
+			if (ciNoSong == bg[i].m_def.m_sFile1.c_str())
 			{
 				bg.erase( bg.begin()+i );
 				bHasNoSongBgTag = true;
@@ -1358,12 +1371,15 @@ void SMLoader::TidyUpData( Song &song, bool bFromCache )
 				break;
 
 			// If the last BGA is already the song BGA, don't add a duplicate.
-			if( !bg.empty() && !bg.back().m_def.m_sFile1.CompareNoCase(song.m_sBackgroundFile) )
+			ci_string ciSongBack(song.m_sBackgroundFile.c_str());
+			if( !bg.empty() && ciSongBack == bg.back().m_def.m_sFile1.c_str())
+			{
 				break;
-
+			}
 			if( !IsAFile( song.GetBackgroundPath() ) )
+			{
 				break;
-
+			}
 			bg.push_back( BackgroundChange(lastBeat,song.m_sBackgroundFile) );
 		} while(0);
 	}

--- a/src/NotesLoaderSMA.cpp
+++ b/src/NotesLoaderSMA.cpp
@@ -339,7 +339,7 @@ bool SMALoader::LoadFromSimfile( const RString &sPath, Song &out, bool bFromCach
 					     sParams[1].c_str() );
 		}
 
-		else if( sValueName.Left(strlen("BGCHANGES"))=="BGCHANGES" || sValueName=="ANIMATIONS" )
+		else if( BeginsWith(sValueName, "BGCHANGES") || sValueName=="ANIMATIONS" )
 		{
 			SMLoader::ProcessBGChanges( out, sValueName, sPath, sParams[1]);
 		}

--- a/src/NotesLoaderSMA.cpp
+++ b/src/NotesLoaderSMA.cpp
@@ -171,10 +171,7 @@ bool SMALoader::LoadFromSimfile( const RString &sPath, Song &out, bool bFromCach
 	{
 		int iNumParams = msd.GetNumParams(i);
 		const MsdFile::value_t &sParams = msd.GetValue(i);
-		RString sValueName = sParams[0];
-		ci_string ciValueName( sValueName.c_str());
-		
-		sValueName.MakeUpper();
+		RString sValueName = MakeUpper(sParams[0]);
 
 		// handle the data
 		/* Don't use GetMainAndSubTitlesFromFullTitle; that's only for heuristically

--- a/src/NotesLoaderSMA.cpp
+++ b/src/NotesLoaderSMA.cpp
@@ -172,6 +172,8 @@ bool SMALoader::LoadFromSimfile( const RString &sPath, Song &out, bool bFromCach
 		int iNumParams = msd.GetNumParams(i);
 		const MsdFile::value_t &sParams = msd.GetValue(i);
 		RString sValueName = sParams[0];
+		ci_string ciValueName( sValueName.c_str());
+		
 		sValueName.MakeUpper();
 
 		// handle the data
@@ -317,26 +319,36 @@ bool SMALoader::LoadFromSimfile( const RString &sPath, Song &out, bool bFromCach
 
 		else if( sValueName=="SELECTABLE" )
 		{
-			if(sParams[1].EqualsNoCase("YES"))
+			ci_string ciParam(sParams[1].c_str());
+			if(ciParam == "YES")
+			{
 				out.m_SelectionDisplay = out.SHOW_ALWAYS;
-			else if(sParams[1].EqualsNoCase("NO"))
+			}
+			else if(ciParam == "NO")
+			{
 				out.m_SelectionDisplay = out.SHOW_NEVER;
+			}
 			// ROULETTE from 3.9. It was removed since UnlockManager can serve
 			// the same purpose somehow. This, of course, assumes you're using
 			// unlocks. -aj
-			else if(sParams[1].EqualsNoCase("ROULETTE"))
+			else if(ciParam == "ROULETTE")
+			{
 				out.m_SelectionDisplay = out.SHOW_ALWAYS;
+			}
 			/* The following two cases are just fixes to make sure simfiles that
 			 * used 3.9+ features are not excluded here */
-			else if(sParams[1].EqualsNoCase("ES") || sParams[1].EqualsNoCase("OMES"))
+			else if(ciParam == "ES" || ciParam == "OMES")
+			{
 				out.m_SelectionDisplay = out.SHOW_ALWAYS;
+			}
 			else if( StringToInt(sParams[1]) > 0 )
+			{
 				out.m_SelectionDisplay = out.SHOW_ALWAYS;
+			}
 			else
-				LOG->UserLog("Song file",
-					     sPath,
-					     "has an unknown #SELECTABLE value, \"%s\"; ignored.",
-					     sParams[1].c_str() );
+			{
+				LOG->UserLog("Song file", sPath, "has an unknown #SELECTABLE value, \"%s\"; ignored.", sParams[1].c_str() );
+			}
 		}
 
 		else if( BeginsWith(sValueName, "BGCHANGES") || sValueName=="ANIMATIONS" )

--- a/src/NotesLoaderSSC.cpp
+++ b/src/NotesLoaderSSC.cpp
@@ -869,8 +869,7 @@ bool SSCLoader::LoadNoteDataFromSimfile( const RString & cachePath, Steps &out )
 	for (unsigned i = 0; i < values; i++)
 	{
 		const MsdFile::value_t &params = msd.GetValue(i);
-		RString valueName = params[0];
-		valueName.MakeUpper();
+		RString valueName = MakeUpper(params[0]);
 		RString matcher = params[1]; // mainly for debugging.
 		Trim(matcher);
 
@@ -911,7 +910,7 @@ bool SSCLoader::LoadNoteDataFromSimfile( const RString & cachePath, Steps &out )
 						// tag. -Kyz
 						if(out.GetDifficulty() != StringToDifficulty(matcher) &&
 							!(out.GetDifficulty() == Difficulty_Edit &&
-								GetExtension(cachePath).MakeLower() == "edit"))
+								MakeLower(GetExtension(cachePath)) == "edit"))
 						{ tryingSteps = false; }
 						break;
 					case LNDID_meter:
@@ -982,8 +981,7 @@ bool SSCLoader::LoadFromSimfile( const RString &sPath, Song &out, bool bFromCach
 	for( unsigned i = 0; i < values; i++ )
 	{
 		const MsdFile::value_t &sParams = msd.GetValue(i);
-		RString sValueName = sParams[0];
-		sValueName.MakeUpper();
+		RString sValueName = MakeUpper(sParams[0]);
 
 		switch (state)
 		{
@@ -1101,8 +1099,7 @@ bool SSCLoader::LoadEditFromMsd(const MsdFile &msd,
 	{
 		int iNumParams = msd.GetNumParams(i);
 		const MsdFile::value_t &sParams = msd.GetValue(i);
-		RString sValueName = sParams[0];
-		sValueName.MakeUpper();
+		RString sValueName = MakeUpper(sParams[0]);
 
 		if(pSong != NULL)
 		{

--- a/src/NotesLoaderSSC.cpp
+++ b/src/NotesLoaderSSC.cpp
@@ -983,7 +983,7 @@ bool SSCLoader::LoadFromSimfile( const RString &sPath, Song &out, bool bFromCach
 				{
 					handler->second(reused_song_info);
 				}
-				else if(sValueName.Left(strlen("BGCHANGES"))=="BGCHANGES")
+				else if(BeginsWith(sValueName, "BGCHANGES"))
 				{
 					SetBGChanges(reused_song_info);
 				}

--- a/src/NotesLoaderSSC.cpp
+++ b/src/NotesLoaderSSC.cpp
@@ -1202,7 +1202,7 @@ bool SSCLoader::LoadEditFromMsd(const MsdFile &msd,
 
 				RString sSongFullTitle = sParams[1];
 				this->SetSongTitle(sParams[1]);
-				sSongFullTitle.Replace('\\', '/');
+				ReplaceAll(sSongFullTitle, "\\", "/");
 				pSong = SONGMAN->FindSong(sSongFullTitle);
 				reused_steps_info.song= pSong;
 				if(pSong == NULL)

--- a/src/NotesLoaderSSC.cpp
+++ b/src/NotesLoaderSSC.cpp
@@ -189,21 +189,34 @@ void SetDisplayBPM(SongTagInfo& info)
 }
 void SetSelectable(SongTagInfo& info)
 {
-	if((*info.params)[1].EqualsNoCase("YES"))
-	{ info.song->m_SelectionDisplay = info.song->SHOW_ALWAYS; }
-	else if((*info.params)[1].EqualsNoCase("NO"))
-	{ info.song->m_SelectionDisplay = info.song->SHOW_NEVER; }
+	ci_string ciParam = (*info.params)[1].c_str();
+	if(ciParam == "YES")
+	{
+		info.song->m_SelectionDisplay = info.song->SHOW_ALWAYS;
+	}
+	else if(ciParam == "NO")
+	{
+		info.song->m_SelectionDisplay = info.song->SHOW_NEVER;
+	}
 	// ROULETTE from 3.9 is no longer in use.
-	else if((*info.params)[1].EqualsNoCase("ROULETTE"))
-	{ info.song->m_SelectionDisplay = info.song->SHOW_ALWAYS; }
+	else if(ciParam == "ROULETTE")
+	{
+		info.song->m_SelectionDisplay = info.song->SHOW_ALWAYS;
+	}
 	/* The following two cases are just fixes to make sure simfiles that
 	 * used 3.9+ features are not excluded here */
-	else if((*info.params)[1].EqualsNoCase("ES") || (*info.params)[1].EqualsNoCase("OMES"))
-	{ info.song->m_SelectionDisplay = info.song->SHOW_ALWAYS; }
+	else if(ciParam == "ES" || ciParam == "OMES")
+	{
+		info.song->m_SelectionDisplay = info.song->SHOW_ALWAYS;
+	}
 	else if(StringToInt((*info.params)[1]) > 0)
-	{ info.song->m_SelectionDisplay = info.song->SHOW_ALWAYS; }
+	{
+		info.song->m_SelectionDisplay = info.song->SHOW_ALWAYS;
+	}
 	else
-	{ LOG->UserLog("Song file", info.path, "has an unknown #SELECTABLE value, \"%s\"; ignored.", (*info.params)[1].c_str()); }
+	{
+		LOG->UserLog("Song file", info.path, "has an unknown #SELECTABLE value, \"%s\"; ignored.", (*info.params)[1].c_str());
+	}
 }
 void SetBGChanges(SongTagInfo& info)
 {

--- a/src/NotesWriterSM.cpp
+++ b/src/NotesWriterSM.cpp
@@ -314,14 +314,14 @@ bool NotesWriterSM::WriteEditFileToMachine( const Song *pSong, Steps *pSteps, RS
 		pSteps->GetFilename() != sPath;
 	if( bFileNameChanging  &&  DoesFileExist(sPath) )
 	{
-		sErrorOut = ssprintf( DESTINATION_ALREADY_EXISTS.GetValue(), sPath.c_str() );
+		sErrorOut = fmt::sprintf( DESTINATION_ALREADY_EXISTS.GetValue(), sPath.c_str() );
 		return false;
 	}
 
 	RageFile f;
 	if( !f.Open(sPath, RageFile::WRITE | RageFile::SLOW_FLUSH) )
 	{
-		sErrorOut = ssprintf( ERROR_WRITING_FILE.GetValue(), sPath.c_str() );
+		sErrorOut = fmt::sprintf( ERROR_WRITING_FILE.GetValue(), sPath.c_str() );
 		return false;
 	}
 
@@ -329,7 +329,7 @@ bool NotesWriterSM::WriteEditFileToMachine( const Song *pSong, Steps *pSteps, RS
 	GetEditFileContents( pSong, pSteps, sTag );
 	if( f.PutLine(sTag) == -1 || f.Flush() == -1 )
 	{
-		sErrorOut = ssprintf( ERROR_WRITING_FILE.GetValue(), sPath.c_str() );
+		sErrorOut = fmt::sprintf( ERROR_WRITING_FILE.GetValue(), sPath.c_str() );
 		return false;
 	}
 

--- a/src/NotesWriterSSC.cpp
+++ b/src/NotesWriterSSC.cpp
@@ -43,18 +43,32 @@ struct TimingTagWriter {
 
 	TimingTagWriter( vector<RString> *pvsLines ): m_pvsLines (pvsLines) { }
 
-	void Write( const int row, const char *value )
+	void Write( const int row, std::string const &value )
 	{
-		m_pvsLines->push_back( m_sNext + ssprintf( "%.6f=%s", NoteRowToBeat(row), value ) );
+		m_pvsLines->push_back( m_sNext + fmt::sprintf( "%.6f=%s", NoteRowToBeat(row), value ) );
 		m_sNext = ",";
 	}
 
-	void Write( const int row, const float value )        { Write( row, ssprintf( "%.6f",  value ) ); }
-	void Write( const int row, const int value )          { Write( row, ssprintf( "%d",    value ) ); }
-	void Write( const int row, const int a, const int b ) { Write( row, ssprintf( "%d=%d", a, b ) );  }
-	void Write( const int row, const float a, const float b ) { Write( row, ssprintf( "%.6f=%.6f", a, b) ); }
+	void Write( const int row, const float value )
+	{
+		Write( row, fmt::sprintf( "%.6f", value ) );
+	}
+	void Write( const int row, const int value )
+	{
+		Write( row, fmt::sprintf( "%d", value ) );
+	}
+	void Write( const int row, const int a, const int b )
+	{
+		Write( row, fmt::sprintf( "%d=%d", a, b ) );
+	}
+	void Write( const int row, const float a, const float b )
+	{
+		Write( row, fmt::sprintf( "%.6f=%.6f", a, b) );
+	}
 	void Write( const int row, const float a, const float b, const unsigned short c )
-		{ Write( row, ssprintf( "%.6f=%.6f=%hd", a, b, c) ); }
+	{
+		Write( row, fmt::sprintf( "%.6f=%.6f=%hd", a, b, c) );
+	}
 
 	void Init( const RString sTag ) { m_sNext = "#" + sTag + ":"; }
 	void Finish( ) { m_pvsLines->push_back( ( m_sNext != "," ? m_sNext : "" ) + ";" ); }

--- a/src/NotesWriterSSC.cpp
+++ b/src/NotesWriterSSC.cpp
@@ -525,14 +525,14 @@ bool NotesWriterSSC::WriteEditFileToMachine( const Song *pSong, Steps *pSteps, R
 		pSteps->GetFilename() != sPath;
 	if( bFileNameChanging  &&  DoesFileExist(sPath) )
 	{
-		sErrorOut = ssprintf( DESTINATION_ALREADY_EXISTS.GetValue(), sPath.c_str() );
+		sErrorOut = fmt::sprintf( DESTINATION_ALREADY_EXISTS.GetValue(), sPath.c_str() );
 		return false;
 	}
 
 	RageFile f;
 	if( !f.Open(sPath, RageFile::WRITE | RageFile::SLOW_FLUSH) )
 	{
-		sErrorOut = ssprintf( ERROR_WRITING_FILE.GetValue(), sPath.c_str() );
+		sErrorOut = fmt::sprintf( ERROR_WRITING_FILE.GetValue(), sPath.c_str() );
 		return false;
 	}
 
@@ -540,7 +540,7 @@ bool NotesWriterSSC::WriteEditFileToMachine( const Song *pSong, Steps *pSteps, R
 	GetEditFileContents( pSong, pSteps, sTag );
 	if( f.PutLine(sTag) == -1 || f.Flush() == -1 )
 	{
-		sErrorOut = ssprintf( ERROR_WRITING_FILE.GetValue(), sPath.c_str() );
+		sErrorOut = fmt::sprintf( ERROR_WRITING_FILE.GetValue(), sPath.c_str() );
 		return false;
 	}
 

--- a/src/OptionRow.cpp
+++ b/src/OptionRow.cpp
@@ -1004,7 +1004,7 @@ public:
 	DEFINE_METHOD( FirstItemGoesDown, GetFirstItemGoesDown() )
 	static int GetChoiceInRowWithFocus( T* p, lua_State *L ) { lua_pushnumber( L, p->GetChoiceInRowWithFocus(Enum::Check<PlayerNumber>(L, 1)) ); return 1; }
 	DEFINE_METHOD( GetLayoutType, GetHandler()->m_Def.m_layoutType )
-	static int GetName( T* p, lua_State *L ) { lua_pushstring( L, p->GetHandler()->m_Def.m_sName ); return 1; }
+	static int GetName( T* p, lua_State *L ) { lua_pushstring( L, p->GetHandler()->m_Def.m_sName.c_str() ); return 1; }
 	static int GetNumChoices( T* p, lua_State *L ) { lua_pushnumber( L, p->GetHandler()->m_Def.m_vsChoices.size() ); return 1; }
 	DEFINE_METHOD( GetSelectType, GetHandler()->m_Def.m_selectType )
 	DEFINE_METHOD( GetRowTitle, GetRowTitle() )

--- a/src/OptionRow.cpp
+++ b/src/OptionRow.cpp
@@ -212,7 +212,8 @@ RString OptionRow::GetRowTitle() const
 	RString sTitle = m_pHand->OptionTitle();
 
 	// HACK: tack the BPM onto the name of the speed line
-	if( m_pHand->m_Def.m_sName.CompareNoCase("speed")==0 )
+	ci_string ciName(m_pHand->m_Def.m_sName.c_str());
+	if (ciName == "speed")
 	{
 		bool bShowBpmInSpeedTitle = m_pParentType->SHOW_BPM_IN_SPEED_TITLE;
 

--- a/src/OptionRowHandler.cpp
+++ b/src/OptionRowHandler.cpp
@@ -355,9 +355,11 @@ public:
 	virtual ReloadChanged Reload()
 	{
 		// HACK: always reload "speed", to update the BPM text in the name of the speed line
-		if( !m_Def.m_sName.CompareNoCase("speed") )
+		ci_string ciName(m_Def.m_sName.c_str());
+		if( ciName == "speed" )
+		{
 			return RELOAD_CHANGED_ALL;
-
+		}
 		return OptionRowHandler::Reload();
 	}
 };
@@ -1508,19 +1510,44 @@ OptionRowHandler* OptionRowHandlerUtil::Make( const Commands &cmds )
 		ROW_INVALID_IF(command.m_vsArgs.size() != 2 || !sParam.size(),
 			"list row command must be 'list,name' or 'list,type'.", NULL);
 
-		if(	 sParam.CompareNoCase("NoteSkins")==0 )		MAKE( OptionRowHandlerListNoteSkins )
-		else if( sParam.CompareNoCase("Steps")==0 )		MAKE( OptionRowHandlerListSteps )
-		else if( sParam.CompareNoCase("StepsLocked")==0 )
+		ci_string ciParam(sParam.c_str());
+		if(	ciParam == "NoteSkins" )
+		{
+			MAKE( OptionRowHandlerListNoteSkins )
+		}
+		else if( ciParam == "Steps" )
+		{
+			MAKE( OptionRowHandlerListSteps )
+		}
+		else if( ciParam == "StepsLocked" )
 		{
 			MAKE( OptionRowHandlerListSteps );
 			pHand->m_Def.m_bOneChoiceForAllPlayers = true;
 		}
-		else if( sParam.CompareNoCase("Characters")==0 )	MAKE( OptionRowHandlerListCharacters )
-		else if( sParam.CompareNoCase("Styles")==0 )		MAKE( OptionRowHandlerListStyles )
-		else if( sParam.CompareNoCase("Groups")==0 )		MAKE( OptionRowHandlerListGroups )
-		else if( sParam.CompareNoCase("Difficulties")==0 )	MAKE( OptionRowHandlerListDifficulties )
-		else if( sParam.CompareNoCase("SongsInCurrentSongGroup")==0 )	MAKE( OptionRowHandlerListSongsInCurrentSongGroup )
-		else MAKE( OptionRowHandlerList )
+		else if( ciParam == "Characters" )
+		{
+			MAKE( OptionRowHandlerListCharacters )
+		}
+		else if( ciParam == "Styles" )
+		{
+			MAKE( OptionRowHandlerListStyles )
+		}
+		else if( ciParam == "Groups" )
+		{
+			MAKE( OptionRowHandlerListGroups )
+		}
+		else if( ciParam == "Difficulties" )
+		{
+			MAKE( OptionRowHandlerListDifficulties )
+		}
+		else if( ciParam == "SongsInCurrentSongGroup" )
+		{
+			MAKE( OptionRowHandlerListSongsInCurrentSongGroup )
+		}
+		else
+		{
+			MAKE( OptionRowHandlerList )
+		}
 	}
 	else if( name == "lua" )		MAKE( OptionRowHandlerLua )
 	else if( name == "conf" )		MAKE( OptionRowHandlerConfig )

--- a/src/OptionRowHandler.cpp
+++ b/src/OptionRowHandler.cpp
@@ -707,8 +707,7 @@ class OptionRowHandlerListCharacters: public OptionRowHandlerList
 		for( unsigned i=0; i<vpCharacters.size(); i++ )
 		{
 			Character* pCharacter = vpCharacters[i];
-			RString s = pCharacter->GetDisplayName();
-			s.MakeUpper();
+			RString s = MakeUpper(pCharacter->GetDisplayName());
 
 			m_Def.m_vsChoices.push_back( s );
 			GameCommand mc;

--- a/src/PaneDisplay.cpp
+++ b/src/PaneDisplay.cpp
@@ -223,7 +223,7 @@ void PaneDisplay::GetPaneTextAndLevel( PaneCategory c, RString & sTextOut, float
 			case PaneCategory_ProfileHighScore:
 			case PaneCategory_MachineHighName: // set fLevelOut for color
 			case PaneCategory_MachineHighScore:
-				CHECKPOINT;
+				CHECKPOINT_M("High score being placed.");
 				fLevelOut = pHSL->GetTopScore().GetPercentDP();
 				break;
 			default: break;

--- a/src/PaneDisplay.cpp
+++ b/src/PaneDisplay.cpp
@@ -261,7 +261,7 @@ void PaneDisplay::GetPaneTextAndLevel( PaneCategory c, RString & sTextOut, float
 				case PaneCategory_Hands:
 				case PaneCategory_Lifts:
 				case PaneCategory_Fakes:
-					sTextOut = ssprintf( COUNT_FORMAT.GetValue(), fLevelOut );
+					sTextOut = fmt::sprintf( COUNT_FORMAT.GetValue(), fLevelOut );
 					break;
 				default: break;
 			}

--- a/src/PercentageDisplay.cpp
+++ b/src/PercentageDisplay.cpp
@@ -168,8 +168,8 @@ void PercentageDisplay::Refresh()
 		{
 			int iPercentWhole = int(fPercentDancePoints*100);
 			int iPercentRemainder = int( (fPercentDancePoints*100 - int(fPercentDancePoints*100)) * 10 );
-			sNumToDisplay = ssprintf( m_sPercentFormat, iPercentWhole );
-			m_textPercentRemainder.SetText( ssprintf(m_sRemainderFormat, iPercentRemainder) );
+			sNumToDisplay = fmt::sprintf( m_sPercentFormat, iPercentWhole );
+			m_textPercentRemainder.SetText( fmt::sprintf(m_sRemainderFormat, iPercentRemainder) );
 		}
 		else
 		{

--- a/src/PercentageDisplay.cpp
+++ b/src/PercentageDisplay.cpp
@@ -185,7 +185,7 @@ void PercentageDisplay::Refresh()
 			}
 
 			// HACK: Use the last frame in the numbers texture as '-'
-			sNumToDisplay.Replace('-','x');
+			std::replace(sNumToDisplay.begin(), sNumToDisplay.end(), '-', 'x');
 		}
 	}
 

--- a/src/PlayerOptions.cpp
+++ b/src/PlayerOptions.cpp
@@ -384,7 +384,7 @@ bool PlayerOptions::FromOneModString( const RString &sOneMod, RString &sErrorOut
 		}
 		else if( s[0]=='*' )
 		{
-			sscanf( s, "*%f", &speed );
+			sscanf( s.c_str(), "*%f", &speed );
 			if( !std::isfinite(speed) )
 				speed = 1.0f;
 		}
@@ -405,7 +405,7 @@ bool PlayerOptions::FromOneModString( const RString &sOneMod, RString &sErrorOut
 		m_fTimeSpacing = 0;
 		m_fMaxScrollBPM = 0;
 	}
-	else if( sscanf( sBit, "c%f", &level ) == 1 )
+	else if( sscanf( sBit.c_str(), "c%f", &level ) == 1 )
 	{
 		if( !std::isfinite(level) || level <= 0.0f )
 			level = CMOD_DEFAULT;
@@ -415,7 +415,7 @@ bool PlayerOptions::FromOneModString( const RString &sOneMod, RString &sErrorOut
 		m_fMaxScrollBPM = 0;
 	}
 	// oITG's m-mods
-	else if( sscanf( sBit, "m%f", &level ) == 1 )
+	else if( sscanf( sBit.c_str(), "m%f", &level ) == 1 )
 	{
 		// OpenITG doesn't have this block:
 		/*

--- a/src/PlayerOptions.cpp
+++ b/src/PlayerOptions.cpp
@@ -1153,11 +1153,11 @@ public:
 		int original_top= lua_gettop(L);
 		if( p->m_sNoteSkin.empty()  )
 		{
-			lua_pushstring( L, CommonMetrics::DEFAULT_NOTESKIN_NAME.GetValue() );
+			lua_pushstring( L, CommonMetrics::DEFAULT_NOTESKIN_NAME.GetValue().c_str() );
 		}
 		else
 		{
-			lua_pushstring( L, p->m_sNoteSkin );
+			lua_pushstring( L, p->m_sNoteSkin.c_str() );
 		}
 		if(original_top >= 1 && lua_isstring(L, 1))
 		{

--- a/src/PlayerOptions.cpp
+++ b/src/PlayerOptions.cpp
@@ -346,8 +346,7 @@ bool PlayerOptions::FromOneModString( const RString &sOneMod, RString &sErrorOut
 {
 	ASSERT_M( NOTESKIN != NULL, "The Noteskin Manager must be loaded in order to process mods." );
 
-	RString sBit = sOneMod;
-	sBit.MakeLower();
+	RString sBit = MakeLower(sOneMod);
 	Trim( sBit );
 
 	/* "drunk"

--- a/src/PlayerOptions.cpp
+++ b/src/PlayerOptions.cpp
@@ -370,7 +370,7 @@ bool PlayerOptions::FromOneModString( const RString &sOneMod, RString &sErrorOut
 		{
 			/* If the last character is a *, they probably said "123*" when
 			 * they meant "*123". */
-			if( s.Right(1) == "*" )
+			if( EndsWith(s, "*") )
 			{
 				// XXX: We know what they want, is there any reason not to handle it?
 				// Yes. We should be strict in handling the format. -Chris

--- a/src/Preference.cpp
+++ b/src/Preference.cpp
@@ -22,9 +22,10 @@ IPreference::~IPreference()
 
 IPreference *IPreference::GetPreferenceByName( const RString &sName )
 {
+	ci_string ciName(sName.c_str());
 	for (auto *p: *m_Subscribers.m_pSubscribers)
 	{
-		if( !p->GetName().CompareNoCase( sName ) )
+		if (ciName == p->GetName().c_str())
 		{
 			return p;
 		}

--- a/src/PrefsManager.cpp
+++ b/src/PrefsManager.cpp
@@ -373,9 +373,9 @@ void PrefsManager::StoreGamePrefs()
 
 	// save off old values
 	GamePrefs &gp = m_mapGameNameToGamePrefs[m_sCurrentGame.ToString()];
-	gp.m_sAnnouncer = m_sAnnouncer;
-	gp.m_sTheme = m_sTheme;
-	gp.m_sDefaultModifiers = m_sDefaultModifiers;
+	gp.m_sAnnouncer = m_sAnnouncer.Get();
+	gp.m_sTheme = m_sTheme.Get();
+	gp.m_sDefaultModifiers = m_sDefaultModifiers.Get();
 }
 
 void PrefsManager::RestoreGamePrefs()

--- a/src/PrefsManager.cpp
+++ b/src/PrefsManager.cpp
@@ -472,7 +472,7 @@ void PrefsManager::ReadGamePrefsFromIni( const RString &sIni )
 		if( !BeginsWith(section_name, GAME_SECTION_PREFIX) )
 			continue;
 
-		RString sGame = section_name.Right( section_name.length() - GAME_SECTION_PREFIX.length() );
+		RString sGame = tail(section_name, section_name.length() - GAME_SECTION_PREFIX.length() );
 		GamePrefs &gp = m_mapGameNameToGamePrefs[ sGame ];
 
 		// todo: read more prefs here? -aj

--- a/src/Profile.cpp
+++ b/src/Profile.cpp
@@ -1079,7 +1079,7 @@ ProfileLoadResult Profile::LoadAllFromDir( RString sDir, bool bRequireSignature 
 
 	LOG->Trace( "Profile::LoadAllFromDir( %s )", sDir.c_str() );
 
-	ASSERT( sDir.Right(1) == "/" );
+	ASSERT( EndsWith(sDir, "/") );
 
 	InitAll();
 
@@ -1998,7 +1998,7 @@ void Profile::LoadCourseScoresFromNode( const XNode* pCourseScores )
 
 				for (auto *c: vpAllCourses)
 				{
-					RString sOther = c->m_sPath.Right(sFullFileName.size());
+					RString sOther = tail(c->m_sPath, sFullFileName.size());
 
 					if( sFullFileName.CompareNoCase(sOther) == 0 )
 					{

--- a/src/Profile.cpp
+++ b/src/Profile.cpp
@@ -224,9 +224,10 @@ Character *Profile::GetCharacter() const
 {
 	vector<Character*> vpCharacters;
 	CHARMAN->GetCharacters( vpCharacters );
+	ci_string ciChar(m_sCharacterID.c_str());
 	for (auto *c: vpCharacters)
 	{
-		if( c->m_sCharacterID.CompareNoCase(m_sCharacterID)==0 )
+		if (ciChar == c->m_sCharacterID.c_str())
 		{
 			return c;
 		}
@@ -1995,12 +1996,13 @@ void Profile::LoadCourseScoresFromNode( const XNode* pCourseScores )
 				RString sDir, sFName, sExt;
 				splitpath( courseID.GetPath(), sDir, sFName, sExt );
 				RString sFullFileName = sFName + sExt;
+				ci_string ciFull(sFullFileName.c_str());
 
 				for (auto *c: vpAllCourses)
 				{
 					RString sOther = tail(c->m_sPath, sFullFileName.size());
 
-					if( sFullFileName.CompareNoCase(sOther) == 0 )
+					if (ciFull == sOther.c_str())
 					{
 						pC = c;
 						courseID.FromCourse( pC );

--- a/src/Profile.cpp
+++ b/src/Profile.cpp
@@ -2417,13 +2417,13 @@ public:
 	DEFINE_METHOD(GetType, m_Type);
 	DEFINE_METHOD(GetPriority, m_ListPriority);
 
-	static int GetDisplayName( T* p, lua_State *L )			{ lua_pushstring(L, p->m_sDisplayName ); return 1; }
+	static int GetDisplayName( T* p, lua_State *L )			{ lua_pushstring(L, p->m_sDisplayName.c_str() ); return 1; }
 	static int SetDisplayName( T* p, lua_State *L )
 	{
 		p->m_sDisplayName= SArg(1);
 		COMMON_RETURN_SELF;
 	}
-	static int GetLastUsedHighScoreName( T* p, lua_State *L )	{ lua_pushstring(L, p->m_sLastUsedHighScoreName ); return 1; }
+	static int GetLastUsedHighScoreName( T* p, lua_State *L )	{ lua_pushstring(L, p->m_sLastUsedHighScoreName.c_str() ); return 1; }
 	static int SetLastUsedHighScoreName( T* p, lua_State *L )
 	{
 		p->m_sLastUsedHighScoreName= SArg(1);
@@ -2572,7 +2572,7 @@ public:
 	static int GetTotalGameplaySeconds( T* p, lua_State *L )		{ lua_pushnumber(L, p->m_iTotalGameplaySeconds ); return 1; }
 	static int GetSongsAndCoursesPercentCompleteAllDifficulties( T* p, lua_State *L )		{ lua_pushnumber(L, p->GetSongsAndCoursesPercentCompleteAllDifficulties(Enum::Check<StepsType>(L, 1)) ); return 1; }
 	static int GetTotalCaloriesBurned( T* p, lua_State *L )		{ lua_pushnumber(L, p->m_fTotalCaloriesBurned ); return 1; }
-	static int GetDisplayTotalCaloriesBurned( T* p, lua_State *L )	{ lua_pushstring(L, p->GetDisplayTotalCaloriesBurned() ); return 1; }
+	static int GetDisplayTotalCaloriesBurned( T* p, lua_State *L )	{ lua_pushstring(L, p->GetDisplayTotalCaloriesBurned().c_str() ); return 1; }
 	static int GetMostPopularSong( T* p, lua_State *L )
 	{
 		Song *p2 = p->GetMostPopularSong();

--- a/src/Profile.cpp
+++ b/src/Profile.cpp
@@ -419,14 +419,14 @@ float Profile::GetSongsActual( StepsType st, Difficulty dc ) const
 			CHECKPOINT_M( ssprintf("Profile::GetSongsActual: n %s = %p", sid.ToString().c_str(), pSteps) );
 			if( pSteps->GetDifficulty() != dc )
 				continue;	// skip
-			CHECKPOINT;
+			CHECKPOINT_M("Proper difficulty gotten.");
 
 			const HighScoresForASteps& h = j.second;
 			const HighScoreList& hsl = h.hsl;
 
 			fTotalPercents += hsl.GetTopScore().GetPercentDP();
 		}
-		CHECKPOINT;
+		CHECKPOINT_M("All scores covered.");
 	}
 
 	return fTotalPercents;
@@ -1076,7 +1076,7 @@ void Profile::LoadCustomFunction( RString sDir )
 
 ProfileLoadResult Profile::LoadAllFromDir( RString sDir, bool bRequireSignature )
 {
-	CHECKPOINT;
+	CHECKPOINT_M("About to load all from the directory.");
 
 	LOG->Trace( "Profile::LoadAllFromDir( %s )", sDir.c_str() );
 
@@ -1841,7 +1841,7 @@ float Profile::CalculateCaloriesFromHeartRate(float HeartRate, float Duration)
 
 XNode* Profile::SaveSongScoresCreateNode() const
 {
-	CHECKPOINT;
+	CHECKPOINT_M("About to save song scores.");
 
 	const Profile* pProfile = this;
 	ASSERT( pProfile != NULL );
@@ -1885,7 +1885,7 @@ XNode* Profile::SaveSongScoresCreateNode() const
 
 void Profile::LoadSongScoresFromNode( const XNode* pSongScores )
 {
-	CHECKPOINT;
+	CHECKPOINT_M("About to load song scores.");
 
 	ASSERT( pSongScores->GetName() == "SongScores" );
 
@@ -1924,7 +1924,7 @@ void Profile::LoadSongScoresFromNode( const XNode* pSongScores )
 
 XNode* Profile::SaveCourseScoresCreateNode() const
 {
-	CHECKPOINT;
+	CHECKPOINT_M("About to save course scores.");
 
 	const Profile* pProfile = this;
 	ASSERT( pProfile != NULL );
@@ -1964,7 +1964,7 @@ XNode* Profile::SaveCourseScoresCreateNode() const
 
 void Profile::LoadCourseScoresFromNode( const XNode* pCourseScores )
 {
-	CHECKPOINT;
+	CHECKPOINT_M("About to load course scores.");
 
 	ASSERT( pCourseScores->GetName() == "CourseScores" );
 
@@ -2035,7 +2035,7 @@ void Profile::LoadCourseScoresFromNode( const XNode* pCourseScores )
 
 XNode* Profile::SaveCategoryScoresCreateNode() const
 {
-	CHECKPOINT;
+	CHECKPOINT_M("About to save category scores.");
 
 	const Profile* pProfile = this;
 	ASSERT( pProfile != NULL );
@@ -2071,7 +2071,7 @@ XNode* Profile::SaveCategoryScoresCreateNode() const
 
 void Profile::LoadCategoryScoresFromNode( const XNode* pCategoryScores )
 {
-	CHECKPOINT;
+	CHECKPOINT_M("About to load category scores.");
 
 	ASSERT( pCategoryScores->GetName() == "CategoryScores" );
 
@@ -2126,7 +2126,7 @@ void Profile::AddScreenshot( const Screenshot &screenshot )
 
 void Profile::LoadScreenshotDataFromNode( const XNode* pScreenshotData )
 {
-	CHECKPOINT;
+	CHECKPOINT_M("About to load screenshot data.");
 
 	ASSERT( pScreenshotData->GetName() == "ScreenshotData" );
 	FOREACH_CONST_Child( pScreenshotData, pScreenshot )
@@ -2143,7 +2143,7 @@ void Profile::LoadScreenshotDataFromNode( const XNode* pScreenshotData )
 
 XNode* Profile::SaveScreenshotDataCreateNode() const
 {
-	CHECKPOINT;
+	CHECKPOINT_M("About to save screenshot data.");
 
 	const Profile* pProfile = this;
 	ASSERT( pProfile != NULL );
@@ -2160,7 +2160,7 @@ XNode* Profile::SaveScreenshotDataCreateNode() const
 
 void Profile::LoadCalorieDataFromNode( const XNode* pCalorieData )
 {
-	CHECKPOINT;
+	CHECKPOINT_M("About to load calorie data.");
 
 	ASSERT( pCalorieData->GetName() == "CalorieData" );
 	FOREACH_CONST_Child( pCalorieData, pCaloriesBurned )
@@ -2185,7 +2185,7 @@ void Profile::LoadCalorieDataFromNode( const XNode* pCalorieData )
 
 XNode* Profile::SaveCalorieDataCreateNode() const
 {
-	CHECKPOINT;
+	CHECKPOINT_M("About to save calorie data.");
 
 	const Profile* pProfile = this;
 	ASSERT( pProfile != NULL );
@@ -2306,7 +2306,7 @@ bool Profile::IsMachine() const
 
 XNode* Profile::SaveCoinDataCreateNode() const
 {
-	CHECKPOINT;
+	CHECKPOINT_M("About to save coin data.");
 
 	const Profile* pProfile = this;
 	ASSERT( pProfile != NULL );

--- a/src/ProfileManager.cpp
+++ b/src/ProfileManager.cpp
@@ -273,7 +273,7 @@ bool ProfileManager::LoadProfileFromMemoryCard( PlayerNumber pn, bool bLoadEdits
 	/* If we imported a profile fallback directory, change the memory card
 	 * directory back to the preferred directory: never write over imported
 	 * scores. */
-	m_sProfileDir[pn] = MEM_CARD_MOUNT_POINT[pn] + (RString)PREFSMAN->m_sMemoryCardProfileSubdir + "/";
+	m_sProfileDir[pn] = MEM_CARD_MOUNT_POINT[pn] + PREFSMAN->m_sMemoryCardProfileSubdir.Get() + "/";
 
 	/* Load edits from all fallback directories, newest first. */
 	if( bLoadEdits )
@@ -648,7 +648,7 @@ void ProfileManager::SaveMachineProfile() const
 	// If the machine name has changed, make sure we use the new name.
 	// It's important that this name be applied before the Player profiles
 	// are saved, so that the Player's profiles show the right machine name.
-	const_cast<ProfileManager *> (this)->m_pMachineProfile->m_sDisplayName = PREFSMAN->m_sMachineName;
+	const_cast<ProfileManager *> (this)->m_pMachineProfile->m_sDisplayName = PREFSMAN->m_sMachineName.Get();
 
 	m_pMachineProfile->SaveAllToDir( MACHINE_PROFILE_DIR, false ); /* don't sign machine profiles */
 }
@@ -663,7 +663,7 @@ void ProfileManager::LoadMachineProfile()
 	}
 
 	// If the machine name has changed, make sure we use the new name
-	m_pMachineProfile->m_sDisplayName = PREFSMAN->m_sMachineName;
+	m_pMachineProfile->m_sDisplayName = PREFSMAN->m_sMachineName.Get();
 
 	LoadMachineProfileEdits();
 }

--- a/src/ProfileManager.cpp
+++ b/src/ProfileManager.cpp
@@ -151,7 +151,7 @@ ProfileLoadResult ProfileManager::LoadProfile( PlayerNumber pn, RString sProfile
 	LOG->Trace( "LoadingProfile P%d, %s, %d", pn+1, sProfileDir.c_str(), bIsMemCard );
 
 	ASSERT( !sProfileDir.empty() );
-	ASSERT( sProfileDir.Right(1) == "/" );
+	ASSERT( EndsWith(sProfileDir, "/"));
 
 
 	m_sProfileDir[pn] = sProfileDir;

--- a/src/ProfileManager.cpp
+++ b/src/ProfileManager.cpp
@@ -1056,21 +1056,21 @@ public:
 		{
 			luaL_error(L, "Profile index %d out of range.", index);
 		}
-		lua_pushstring(L, p->GetLocalProfileIDFromIndex(index) );
+		lua_pushstring(L, p->GetLocalProfileIDFromIndex(index).c_str() );
 		return 1;
 	}
 	static int GetLocalProfileIndexFromID( T* p, lua_State *L )	{ lua_pushnumber(L, p->GetLocalProfileIndexFromID(SArg(1)) ); return 1; }
 	static int GetNumLocalProfiles( T* p, lua_State *L )	{ lua_pushnumber(L, p->GetNumLocalProfiles() ); return 1; }
-	static int GetProfileDir( T* p, lua_State *L ) { lua_pushstring(L, p->GetProfileDir(Enum::Check<ProfileSlot>(L, 1)) ); return 1; }
+	static int GetProfileDir( T* p, lua_State *L ) { lua_pushstring(L, p->GetProfileDir(Enum::Check<ProfileSlot>(L, 1)).c_str() ); return 1; }
 	static int IsSongNew( T* p, lua_State *L )	{ lua_pushboolean(L, p->IsSongNew(Luna<Song>::check(L,1)) ); return 1; }
 	static int ProfileWasLoadedFromMemoryCard( T* p, lua_State *L )	{ lua_pushboolean(L, p->ProfileWasLoadedFromMemoryCard(Enum::Check<PlayerNumber>(L, 1)) ); return 1; }
 	static int LastLoadWasTamperedOrCorrupt( T* p, lua_State *L ) { lua_pushboolean(L, p->LastLoadWasTamperedOrCorrupt(Enum::Check<PlayerNumber>(L, 1)) ); return 1; }
-	static int GetPlayerName( T* p, lua_State *L )				{ PlayerNumber pn = Enum::Check<PlayerNumber>(L, 1); lua_pushstring(L, p->GetPlayerName(pn)); return 1; }
+	static int GetPlayerName( T* p, lua_State *L )				{ PlayerNumber pn = Enum::Check<PlayerNumber>(L, 1); lua_pushstring(L, p->GetPlayerName(pn).c_str()); return 1; }
 
 	static int LocalProfileIDToDir( T* , lua_State *L )
 	{
 		RString dir = USER_PROFILES_DIR + SArg(1) + "/";
-		lua_pushstring( L, dir );
+		lua_pushstring( L, dir.c_str() );
 		return 1;
 	}
 	static int SaveProfile( T* p, lua_State *L ) { lua_pushboolean( L, p->SaveProfile(Enum::Check<PlayerNumber>(L, 1)) ); return 1; }

--- a/src/RageBitmapTexture.cpp
+++ b/src/RageBitmapTexture.cpp
@@ -112,8 +112,7 @@ void RageBitmapTexture::Create()
 	}
 
 	// look in the file name for a format hints
-	RString sHintString = GetID().filename + actualID.AdditionalTextureHints;
-	sHintString.MakeLower();
+	RString sHintString = MakeLower(GetID().filename + actualID.AdditionalTextureHints);
 
 	if( sHintString.find("32bpp") != string::npos )			actualID.iColorDepth = 32;
 	else if( sHintString.find("16bpp") != string::npos )		actualID.iColorDepth = 16;

--- a/src/RageDisplay.cpp
+++ b/src/RageDisplay.cpp
@@ -127,7 +127,7 @@ void RageDisplay::ProcessStatsOnFlip()
 		if( LOG_FPS )
 		{
 			RString sStats = GetStats();
-			sStats.Replace( "\n", ", " );
+			ReplaceAll(sStats, "\n", ", ");
 			LOG->Trace( "%s", sStats.c_str() );
 		}
 	}

--- a/src/RageException.cpp
+++ b/src/RageException.cpp
@@ -44,7 +44,7 @@ void RageException::Throw( const char *sFmt, ... )
 	}
 	else
 	{
-		puts( msg );
+		puts( msg.c_str() );
 		fflush( stdout );
 	}
 

--- a/src/RageFile.cpp
+++ b/src/RageFile.cpp
@@ -354,7 +354,7 @@ public:
 	{
 		RString string;
 		p->Read(string);
-		lua_pushstring( L, string );
+		lua_pushstring( L, string.c_str() );
 		return 1;
 	}
 	
@@ -362,7 +362,7 @@ public:
 	{
 		RString string;
 		p->Read( string, IArg(1) );
-		lua_pushstring( L, string );
+		lua_pushstring( L, string.c_str() );
 		return 1;
 	}
 
@@ -382,7 +382,7 @@ public:
 	{
 		RString string;
 		p->GetLine(string);
-		lua_pushstring( L, string );
+		lua_pushstring( L, string.c_str() );
 		return 1;
 	}
 
@@ -394,9 +394,8 @@ public:
 	
 	static int GetError( T* p, lua_State *L )
 	{
-		RString error;
-		error = p->GetError();
-		lua_pushstring( L, error );
+		RString error = p->GetError();
+		lua_pushstring( L, error.c_str() );
 		return 1;
 	}
 	

--- a/src/RageFileDriver.cpp
+++ b/src/RageFileDriver.cpp
@@ -86,9 +86,14 @@ FileDriverEntry::~FileDriverEntry()
 
 RageFileDriver *MakeFileDriver( const RString &sType, const RString &sRoot )
 {
+	ci_string ciType(sType.c_str());
 	for( const FileDriverEntry *p = g_pFileDriverList; p; p = p->m_pLink )
-		if( !p->m_sType.CompareNoCase(sType) )
+	{
+		if( ciType == p->m_sType.c_str() )
+		{
 			return p->Create( sRoot );
+		}
+	}
 	return NULL;
 }
 

--- a/src/RageFileDriverDirect.cpp
+++ b/src/RageFileDriverDirect.cpp
@@ -55,7 +55,7 @@ static RageFileObjDirect *MakeFileObjDirect( RString sPath, int iMode, int &iErr
 	int iFD;
 	if( iMode & RageFile::READ )
 	{
-		iFD = DoOpen( sPath, O_BINARY|O_RDONLY, 0666 );
+		iFD = DoOpen( sPath.c_str(), O_BINARY|O_RDONLY, 0666 );
 
 		/* XXX: Windows returns EACCES if we try to open a file on a CDROM that isn't
 		 * ready, instead of something like ENODEV.  We want to return that case as
@@ -70,7 +70,7 @@ static RageFileObjDirect *MakeFileObjDirect( RString sPath, int iMode, int &iErr
 			sOut = MakeTempFilename(sPath);
 
 		/* Open a temporary file for writing. */
-		iFD = DoOpen( sOut, O_BINARY|O_WRONLY|O_CREAT|O_TRUNC, 0666 );
+		iFD = DoOpen( sOut.c_str(), O_BINARY|O_WRONLY|O_CREAT|O_TRUNC, 0666 );
 	}
 
 	if( iFD == -1 )
@@ -129,7 +129,7 @@ bool RageFileDriverDirect::Move( const RString &sOldPath_, const RString &sNewPa
 	int size = FDB->GetFileSize( sOldPath );
 	int hash = FDB->GetFileHash( sOldPath );
 	TRACE( ssprintf("rename \"%s\" -> \"%s\"", (m_sRoot + sOldPath).c_str(), (m_sRoot + sNewPath).c_str()) );
-	if( DoRename(m_sRoot + sOldPath, m_sRoot + sNewPath) == -1 )
+	if( DoRename((m_sRoot + sOldPath).c_str(), (m_sRoot + sNewPath).c_str()) == -1 )
 	{
 		WARN( ssprintf("rename(%s,%s) failed: %s", (m_sRoot + sOldPath).c_str(), (m_sRoot + sNewPath).c_str(), strerror(errno)) );
 		return false;
@@ -149,7 +149,7 @@ bool RageFileDriverDirect::Remove( const RString &sPath_ )
 	{
 	case RageFileManager::TYPE_FILE:
 		TRACE( ssprintf("remove '%s'", (m_sRoot + sPath).c_str()) );
-		if( DoRemove(m_sRoot + sPath) == -1 )
+		if( DoRemove((m_sRoot + sPath).c_str()) == -1 )
 		{
 			WARN( ssprintf("remove(%s) failed: %s", (m_sRoot + sPath).c_str(), strerror(errno)) );
 			return false;
@@ -159,7 +159,7 @@ bool RageFileDriverDirect::Remove( const RString &sPath_ )
 
 	case RageFileManager::TYPE_DIR:
 		TRACE( ssprintf("rmdir '%s'", (m_sRoot + sPath).c_str()) );
-		if( DoRmdir(m_sRoot + sPath) == -1 )
+		if( DoRmdir((m_sRoot + sPath).c_str()) == -1 )
 		{
 			WARN( ssprintf("rmdir(%s) failed: %s", (m_sRoot + sPath).c_str(), strerror(errno)) );
 			return false;
@@ -234,7 +234,7 @@ namespace
 	bool FlushDir( RString sPath, RString &sError )
 	{
 		/* Wait for the directory to be flushed. */
-		int dirfd = open( sPath, O_RDONLY );
+		int dirfd = open( sPath.c_str(), O_RDONLY );
 		if( dirfd == -1 )
 		{
 			sError = strerror(errno);
@@ -337,7 +337,7 @@ RageFileObjDirect::~RageFileObjDirect()
 		SetError( error );
 		break;
 #else
-		if( rename( sOldPath, sNewPath ) == -1 )
+		if( rename( sOldPath.c_str(), sNewPath.c_str() ) == -1 )
 		{
 			WARN( ssprintf("Error renaming \"%s\" to \"%s\": %s", 
 					sOldPath.c_str(), sNewPath.c_str(), strerror(errno)) );
@@ -362,7 +362,7 @@ RageFileObjDirect::~RageFileObjDirect()
 	} while(0);
 
 	// The write or the rename failed. Delete the incomplete temporary file.
-	DoRemove( MakeTempFilename(m_sPath) );
+	DoRemove( MakeTempFilename(m_sPath).c_str() );
 }
 
 int RageFileObjDirect::ReadInternal( void *pBuf, size_t iBytes )

--- a/src/RageFileDriverDirectHelpers.cpp
+++ b/src/RageFileDriverDirectHelpers.cpp
@@ -147,7 +147,7 @@ void DirectFilenameDB::SetRoot( RString root_ )
 	root = root_;
 
 	// "\abcd\" -> "/abcd/":
-	root.Replace( "\\", "/" );
+	std::transform(root.begin(), root.end(), '\\', '/');
 
 	// "/abcd/" -> "/abcd":
 	if( EndsWith(root, "/") )

--- a/src/RageFileDriverDirectHelpers.cpp
+++ b/src/RageFileDriverDirectHelpers.cpp
@@ -80,7 +80,7 @@ bool CreateDirectories( RString Path )
 	RString curpath;
 
 	// If Path is absolute, add the initial slash ("ignore empty" will remove it).
-	if( Path.Left(1) == "/" )
+	if( BeginsWith(Path, "/"))
 		curpath = "/";
 
 	// Ignore empty, so eg. "/foo/bar//baz" doesn't try to create "/foo/bar" twice.

--- a/src/RageFileDriverDirectHelpers.cpp
+++ b/src/RageFileDriverDirectHelpers.cpp
@@ -147,7 +147,7 @@ void DirectFilenameDB::SetRoot( RString root_ )
 	root = root_;
 
 	// "\abcd\" -> "/abcd/":
-	std::transform(root.begin(), root.end(), '\\', '/');
+	ReplaceAll(root, "\\", "/");
 
 	// "/abcd/" -> "/abcd":
 	if( EndsWith(root, "/") )

--- a/src/RageFileDriverDirectHelpers.cpp
+++ b/src/RageFileDriverDirectHelpers.cpp
@@ -150,7 +150,7 @@ void DirectFilenameDB::SetRoot( RString root_ )
 	root.Replace( "\\", "/" );
 
 	// "/abcd/" -> "/abcd":
-	if( root.Right(1) == "/" )
+	if( EndsWith(root, "/") )
 		root.erase( root.size()-1, 1 );
 }
 
@@ -221,7 +221,7 @@ void DirectFilenameDB::PopulateFileSet( FileSet &fs, const RString &path )
 #if defined(WIN32)
 	WIN32_FIND_DATA fd;
 
-	if ( sPath.size() > 0  && sPath.Right(1) == "/" )
+	if ( sPath.size() > 0  && EndsWith(sPath, "/") )
 		sPath.erase( sPath.size() - 1 );
 
 	HANDLE hFind = DoFindFirstFile( root+sPath+"/*", &fd );
@@ -306,7 +306,7 @@ void DirectFilenameDB::PopulateFileSet( FileSet &fs, const RString &path )
 	{
 		if( !BeginsWith( iter->lname, IGNORE_MARKER_BEGINNING ) )
 			break;
-		RString sFileLNameToIgnore = iter->lname.Right( iter->lname.length() - IGNORE_MARKER_BEGINNING.length() );
+		RString sFileLNameToIgnore = tail(iter->lname, iter->lname.length() - IGNORE_MARKER_BEGINNING.length() );
 		vsFilesToRemove.push_back( iter->name );
 		vsFilesToRemove.push_back( sFileLNameToIgnore );
 	}

--- a/src/RageFileDriverDirectHelpers.cpp
+++ b/src/RageFileDriverDirectHelpers.cpp
@@ -100,7 +100,7 @@ bool CreateDirectories( RString Path )
 		}
 #endif
 
-		if( DoMkdir(curpath, 0777) == 0 )
+		if( DoMkdir(curpath.c_str(), 0777) == 0 )
 			continue;
 
 #if defined(WIN32)
@@ -119,7 +119,7 @@ bool CreateDirectories( RString Path )
 		{
 			/* Make sure it's a directory. */
 			struct stat st;
-			if( DoStat(curpath, &st) != -1 && !(st.st_mode & S_IFDIR) )
+			if( DoStat(curpath.c_str(), &st) != -1 && !(st.st_mode & S_IFDIR) )
 			{
 				WARN( ssprintf("Couldn't create %s: path exists and is not a directory", curpath.c_str()) );
 				return false;
@@ -188,7 +188,7 @@ void DirectFilenameDB::CacheFile( const RString &sPath )
 	File f( Basename(sPath) );
 
 	struct stat st;
-	if( DoStat(root+sPath, &st) == -1 )
+	if( DoStat((root+sPath).c_str(), &st) == -1 )
 	{
 		int iError = errno;
 		// If it's a broken symlink, ignore it.  Otherwise, warn.
@@ -251,7 +251,7 @@ void DirectFilenameDB::PopulateFileSet( FileSet &fs, const RString &path )
 	 * for each file.  This isn't a major issue, since most large directory
 	 * scans are I/O-bound. */
 
-	DIR *pDir = opendir(root+sPath);
+	DIR *pDir = opendir((root+sPath).c_str());
 	if( pDir == NULL )
 		return;
 
@@ -265,11 +265,11 @@ void DirectFilenameDB::PopulateFileSet( FileSet &fs, const RString &path )
 		File f( pEnt->d_name );
 
 		struct stat st;
-		if( DoStat(root+sPath + "/" + pEnt->d_name, &st) == -1 )
+		if( DoStat((root + sPath + "/" + pEnt->d_name).c_str(), &st) == -1 )
 		{
 			int iError = errno;
 			/* If it's a broken symlink, ignore it.  Otherwise, warn. */
-			if( lstat(root+sPath + "/" + pEnt->d_name, &st) == 0 )
+			if( lstat((root + sPath + "/" + pEnt->d_name).c_str(), &st) == 0 )
 				continue;
 
 			/* Huh? */

--- a/src/RageFileManager.cpp
+++ b/src/RageFileManager.cpp
@@ -73,7 +73,7 @@ static void UnreferenceAllDrivers( vector<LoadedDriver *> &apDriverList )
 RageFileDriver *RageFileManager::GetFileDriver( RString sMountpoint )
 {
 	FixSlashesInPlace( sMountpoint );
-	if( sMountpoint.size() && sMountpoint.Right(1) != "/" )
+	if( sMountpoint.size() && !EndsWith(sMountpoint, "/") )
 		sMountpoint += '/';
 
 	g_Mutex->Lock();
@@ -335,7 +335,7 @@ RString LoadedDriver::GetPath( const RString &sPath ) const
 		return RString(); /* no match */
 
 	/* Add one, so we don't cut off the leading slash. */
-	RString sRet = sPath.Right( sPath.size() - m_sMountPoint.size() + 1 );
+	RString sRet = tail(sPath, sPath.size() - m_sMountPoint.size() + 1 );
 	return sRet;
 }
 
@@ -497,7 +497,7 @@ static void AdjustMountpoint( RString &sMountPoint )
 
 	ASSERT_M( BeginsWith(sMountPoint, "/"), "Mountpoints must be absolute: " + sMountPoint );
 
-	if( sMountPoint.size() && sMountPoint.Right(1) != "/" )
+	if( sMountPoint.size() && !EndsWith(sMountPoint, "/") )
 		sMountPoint += '/';
 
 	if( !BeginsWith(sMountPoint, "/") )
@@ -581,7 +581,7 @@ void RageFileManager::Unmount( const RString &sType, const RString &sRoot_, cons
 	FixSlashesInPlace( sRoot );
 	FixSlashesInPlace( sMountPoint );
 
-	if( sMountPoint.size() && sMountPoint.Right(1) != "/" )
+	if( sMountPoint.size() && !EndsWith(sMountPoint, "/") )
 		sMountPoint += '/';
 
 	/* Find all drivers we want to delete.  Remove them from g_pDrivers, and move them
@@ -1005,7 +1005,7 @@ void GetDirListing( const RString &sPath, vector<RString> &AddTo, bool bOnlyDirs
 
 void GetDirListingRecursive( const RString &sDir, const RString &sMatch, vector<RString> &AddTo )
 {
-	ASSERT( sDir.Right(1) == "/" );
+	ASSERT( EndsWith(sDir, "/") );
 	vector<RString> vsFiles;
 	GetDirListing( sDir+sMatch, vsFiles, false, true );
 	vector<RString> vsDirs;
@@ -1026,7 +1026,7 @@ void GetDirListingRecursive( const RString &sDir, const RString &sMatch, vector<
 
 void GetDirListingRecursive( RageFileDriver *prfd, const RString &sDir, const RString &sMatch, vector<RString> &AddTo )
 {
-	ASSERT( sDir.Right(1) == "/" );
+	ASSERT( EndsWith(sDir, "/") );
 	vector<RString> vsFiles;
 	prfd->GetDirListing( sDir+sMatch, vsFiles, false, true );
 	vector<RString> vsDirs;
@@ -1047,7 +1047,7 @@ void GetDirListingRecursive( RageFileDriver *prfd, const RString &sDir, const RS
 
 bool DeleteRecursive( RageFileDriver *prfd, const RString &sDir )
 {
-	ASSERT( sDir.Right(1) == "/" );
+	ASSERT( EndsWith(sDir, "/") );
 
 	vector<RString> vsFiles;
 	prfd->GetDirListing( sDir+"*", vsFiles, false, true );
@@ -1064,7 +1064,7 @@ bool DeleteRecursive( RageFileDriver *prfd, const RString &sDir )
 
 bool DeleteRecursive( const RString &sDir )
 {
-	ASSERT( sDir.Right(1) == "/" );
+	ASSERT( EndsWith(sDir, "/") );
 
 	vector<RString> vsFiles;
 	GetDirListing( sDir+"*", vsFiles, false, true );

--- a/src/RageFileManager.cpp
+++ b/src/RageFileManager.cpp
@@ -78,13 +78,17 @@ RageFileDriver *RageFileManager::GetFileDriver( RString sMountpoint )
 
 	g_Mutex->Lock();
 	RageFileDriver *pRet = NULL;
+	ci_string ciMount(sMountpoint.c_str());
 	for( unsigned i = 0; i < g_pDrivers.size(); ++i )
 	{
 		if( g_pDrivers[i]->m_sType == "mountpoints" )
+		{
 			continue;
-		if( g_pDrivers[i]->m_sMountPoint.CompareNoCase( sMountpoint ) )
+		}
+		if( ciMount == g_pDrivers[i]->m_sMountPoint.c_str() )
+		{
 			continue;
-
+		}
 		pRet = g_pDrivers[i]->m_pDriver;
 		++g_pDrivers[i]->m_iRefs;
 		break;
@@ -331,9 +335,11 @@ RString LoadedDriver::GetPath( const RString &sPath ) const
 			return RString();
 	}
 
-	if( head(sPath, m_sMountPoint.size()).CompareNoCase(m_sMountPoint) )
+	ci_string ciPath(head(sPath, m_sMountPoint.size()).c_str());
+	if( ciPath != m_sMountPoint.c_str() )
+	{
 		return RString(); /* no match */
-
+	}
 	/* Add one, so we don't cut off the leading slash. */
 	RString sRet = tail(sPath, sPath.size() - m_sMountPoint.size() + 1 );
 	return sRet;
@@ -353,8 +359,16 @@ static void NormalizePath( RString &sPath )
 	}
 }
 
-bool ilt( const RString &a, const RString &b ) { return a.CompareNoCase(b) < 0; }
-bool ieq( const RString &a, const RString &b ) { return a.CompareNoCase(b) == 0; }
+bool ilt( const RString &a, const RString &b )
+{
+	ci_string x(a.c_str());
+	return x < b.c_str();
+}
+bool ieq( const RString &a, const RString &b )
+{
+	ci_string x(a.c_str());
+	return x == b.c_str();
+}
 void RageFileManager::GetDirListing( const RString &sPath_, vector<RString> &AddTo, bool bOnlyDirs, bool bReturnPathToo )
 {
 	RString sPath = sPath_;
@@ -588,15 +602,23 @@ void RageFileManager::Unmount( const RString &sType, const RString &sRoot_, cons
 	 * into aDriverListToUnmount. */
 	vector<LoadedDriver *> apDriverListToUnmount;
 	g_Mutex->Lock();
+	ci_string ciType(sType.c_str());
+	ci_string ciRoot(sRoot.c_str());
+	ci_string ciMount(sMountPoint.c_str());
 	for( unsigned i = 0; i < g_pDrivers.size(); ++i )
 	{
-		if( !sType.empty() && g_pDrivers[i]->m_sType.CompareNoCase( sType ) )
+		if( !sType.empty() && ciType != g_pDrivers[i]->m_sType.c_str() )
+		{
 			continue;
-		if( !sRoot.empty() && g_pDrivers[i]->m_sRoot.CompareNoCase( sRoot ) )
+		}
+		if( !sRoot.empty() && ciRoot != g_pDrivers[i]->m_sRoot.c_str() )
+		{
 			continue;
-		if( !sMountPoint.empty() && g_pDrivers[i]->m_sMountPoint.CompareNoCase( sMountPoint ) )
+		}
+		if( !sMountPoint.empty() && ciMount != g_pDrivers[i]->m_sMountPoint.c_str() )
+		{
 			continue;
-
+		}
 		++g_pDrivers[i]->m_iRefs;
 		apDriverListToUnmount.push_back( g_pDrivers[i] );
 		g_pDrivers.erase( g_pDrivers.begin()+i );
@@ -645,12 +667,10 @@ void RageFileManager::Remount( RString sMountpoint, RString sPath )
 bool RageFileManager::IsMounted( RString MountPoint )
 {
 	LockMut( *g_Mutex );
-
-	for( unsigned i = 0; i < g_pDrivers.size(); ++i )
-		if( !g_pDrivers[i]->m_sMountPoint.CompareNoCase( MountPoint ) )
-			return true;
-
-	return false;
+	ci_string ciMount(MountPoint.c_str());
+	return std::any_of(g_pDrivers.begin(), g_pDrivers.end(), [&ciMount](LoadedDriver const *driver) {
+		return ciMount == driver->m_sMountPoint.c_str();
+	});
 }
 
 void RageFileManager::GetLoadedDrivers( vector<DriverLocation> &asMounts )

--- a/src/RageFileManager.cpp
+++ b/src/RageFileManager.cpp
@@ -193,7 +193,7 @@ static RString GetDirOfExecutable( RString argv0 )
 	sPath = argv0;
 #endif
 
-	std::transform(sPath.begin(), sPath.end(), '\\', '/');
+	ReplaceAll(sPath, "\\", "/");
 
 	bool bIsAbsolutePath = false;
 	if( sPath.size() == 0 || sPath[0] == '/' )

--- a/src/RageFileManager.cpp
+++ b/src/RageFileManager.cpp
@@ -331,7 +331,7 @@ RString LoadedDriver::GetPath( const RString &sPath ) const
 			return RString();
 	}
 
-	if( sPath.Left(m_sMountPoint.size()).CompareNoCase(m_sMountPoint) )
+	if( head(sPath, m_sMountPoint.size()).CompareNoCase(m_sMountPoint) )
 		return RString(); /* no match */
 
 	/* Add one, so we don't cut off the leading slash. */
@@ -495,12 +495,12 @@ static void AdjustMountpoint( RString &sMountPoint )
 {
 	FixSlashesInPlace( sMountPoint );
 
-	ASSERT_M( sMountPoint.Left(1) == "/", "Mountpoints must be absolute: " + sMountPoint );
+	ASSERT_M( BeginsWith(sMountPoint, "/"), "Mountpoints must be absolute: " + sMountPoint );
 
 	if( sMountPoint.size() && sMountPoint.Right(1) != "/" )
 		sMountPoint += '/';
 
-	if( sMountPoint.Left(1) != "/" )
+	if( !BeginsWith(sMountPoint, "/") )
 		sMountPoint = "/" + sMountPoint;
 
 }

--- a/src/RageFileManager.cpp
+++ b/src/RageFileManager.cpp
@@ -546,11 +546,11 @@ bool RageFileManager::Mount( const RString &sType, const RString &sRoot_, const 
 	// Unmount anything that was previously mounted here.
 	Unmount( sType, sRoot, sMountPoint );
 
-	CHECKPOINT;
+	CHECKPOINT_M("About to make a file driver.");
 	RageFileDriver *pDriver = MakeFileDriver( sType, sRoot );
 	if( pDriver == NULL )
 	{
-		CHECKPOINT;
+		CHECKPOINT_M("Could not find a file driver to make.");
 
 		if( LOG )
 			LOG->Warn("Can't mount unknown VFS type \"%s\", root \"%s\"", sType.c_str(), sRoot.c_str() );
@@ -559,7 +559,7 @@ bool RageFileManager::Mount( const RString &sType, const RString &sRoot_, const 
 		return false;
 	}
 
-	CHECKPOINT;
+	CHECKPOINT_M("We have a file driver.");
 
 	LoadedDriver *pLoadedDriver = new LoadedDriver;
 	pLoadedDriver->m_pDriver = pDriver;

--- a/src/RageFileManager.cpp
+++ b/src/RageFileManager.cpp
@@ -225,7 +225,7 @@ static RString GetDirOfExecutable( RString argv0 )
 			split( path, ":", vPath );
 			for (auto &i: vPath)
 			{
-				if( access(i + "/" + argv0, X_OK|R_OK) )
+				if( access((i + "/" + argv0).c_str(), X_OK|R_OK) )
 					continue;
 				sPath = i;
 				break;
@@ -263,7 +263,7 @@ static void ChangeToDirOfExecutable( const RString &argv0 )
 	 * through a symlink. Assume this is the case and change to the dir of the symlink. */
 	if( Basename(RageFileManagerUtil::sDirOfExecutable) == "MacOS" )
 		CollapsePath( RageFileManagerUtil::sDirOfExecutable += "/../../../" );
-	chdir( RageFileManagerUtil::sDirOfExecutable );
+	chdir( RageFileManagerUtil::sDirOfExecutable.c_str() );
 #endif
 }
 
@@ -540,7 +540,7 @@ bool RageFileManager::Mount( const RString &sType, const RString &sRoot_, const 
 	const RString &sPaths = ssprintf( "\"%s\", \"%s\", \"%s\"", sType.c_str(), sRoot.c_str(), sMountPoint.c_str() );
 	CHECKPOINT_M( sPaths );
 #if defined(DEBUG)
-	puts( sPaths );
+	puts( sPaths.c_str() );
 #endif
 
 	// Unmount anything that was previously mounted here.
@@ -845,7 +845,7 @@ static bool PathUsesSlowFlush( const RString &sPath )
 	};
 
 	auto doesPathMatch = [&sPath](RString const &curPath) {
-		return !strncmp(sPath, curPath, strlen(curPath));
+		return !strncmp(sPath.c_str(), curPath.c_str(), strlen(curPath.c_str()));
 	};
 
 	return std::any_of(FlushPaths.begin(), FlushPaths.end(), doesPathMatch);

--- a/src/RageFileManager.cpp
+++ b/src/RageFileManager.cpp
@@ -193,7 +193,7 @@ static RString GetDirOfExecutable( RString argv0 )
 	sPath = argv0;
 #endif
 
-	sPath.Replace( "\\", "/" );
+	std::transform(sPath.begin(), sPath.end(), '\\', '/');
 
 	bool bIsAbsolutePath = false;
 	if( sPath.size() == 0 || sPath[0] == '/' )

--- a/src/RageInputDevice.cpp
+++ b/src/RageInputDevice.cpp
@@ -177,16 +177,16 @@ DeviceButton StringToDeviceButton( const RString& s )
 		return (DeviceButton) s[0];
 
 	int i;
-	if( sscanf(s, "unk %i", &i) == 1 )
+	if( sscanf(s.c_str(), "unk %i", &i) == 1 )
 		return enum_add2( KEY_OTHER_0, i );
 
-	if( sscanf(s, "B%i", &i) == 1 )
+	if( sscanf(s.c_str(), "B%i", &i) == 1 )
 		return enum_add2( JOY_BUTTON_1, i-1 );
 
-	if( sscanf(s, "Midi %i", &i) == 1 )
+	if( sscanf(s.c_str(), "Midi %i", &i) == 1 )
 		return enum_add2( MIDI_FIRST, i );
 
-	if( sscanf(s, "Mouse %i", &i) == 1 )
+	if( sscanf(s.c_str(), "Mouse %i", &i) == 1 )
 		return enum_add2( MOUSE_LEFT, i );
 
 	auto it = g_mapStringToNames.find( s );
@@ -256,7 +256,7 @@ bool DeviceInput::FromString( const RString &s )
 	char szDevice[32] = "";
 	char szButton[32] = "";
 
-	if( 2 != sscanf( s, "%31[^_]_%31[^_]", szDevice, szButton ) )
+	if( 2 != sscanf( s.c_str(), "%31[^_]_%31[^_]", szDevice, szButton ) )
 	{
 		device = InputDevice_Invalid;
 		return false;

--- a/src/RageLog.cpp
+++ b/src/RageLog.cpp
@@ -434,7 +434,7 @@ void RageLog::UnmapLog( const RString &key )
 	UpdateMappedLog();
 }
 
-void ShowWarningOrTrace( const char *file, int line, const char *message, bool bWarning )
+void ShowWarningOrTrace( const char *file, int line, std::string const &message, bool bWarning )
 {
 	/* Ignore everything up to and including the first "src/". */
 	const char *temp = strstr( file, "src/" );
@@ -446,7 +446,7 @@ void ShowWarningOrTrace( const char *file, int line, const char *message, bool b
 	if( LOG )
 		(LOG->*method)( "%s:%i: %s", file, line, message );
 	else
-		fprintf( stderr, "%s:%i: %s\n", file, line, message );
+		fprintf( stderr, "%s:%i: %s\n", file, line, message.c_str() );
 }
 
 

--- a/src/RageLog.cpp
+++ b/src/RageLog.cpp
@@ -281,7 +281,7 @@ void RageLog::Write( int where, const RString &sLine )
 			sStr = sWarning + sStr;
 		}
 		if( m_bShowLogOutput || (where&WRITE_TO_INFO) )
-			puts(sStr); //fputws( (const wchar_t *)sStr.c_str(), stdout );
+			puts(sStr.c_str()); //fputws( (const wchar_t *)sStr.c_str(), stdout );
 		if( where & WRITE_TO_INFO )
 			AddToInfo( sStr );
 		if( m_bLogToDisk && (where&WRITE_TO_INFO) && g_fileInfo->IsOpen() )
@@ -365,7 +365,7 @@ void RageLog::AddToRecentLogs( const RString &str )
 	if( len > sizeof(backlog[backlog_start])-1 )
 		len = sizeof(backlog[backlog_start])-1;
 
-	strncpy( backlog[backlog_start], str, len );
+	strncpy( backlog[backlog_start], str.c_str(), len );
 	backlog[backlog_start] [ len ] = 0;
 
 	backlog_start++;

--- a/src/RageLog.cpp
+++ b/src/RageLog.cpp
@@ -444,7 +444,7 @@ void ShowWarningOrTrace( const char *file, int line, std::string const &message,
 	void (RageLog::*method)(const char *fmt, ...) = bWarning ? &RageLog::Warn : &RageLog::Trace;
 
 	if( LOG )
-		(LOG->*method)( "%s:%i: %s", file, line, message );
+		(LOG->*method)( "%s:%i: %s", file, line, message.c_str() );
 	else
 		fprintf( stderr, "%s:%i: %s\n", file, line, message.c_str() );
 }

--- a/src/RageModelGeometry.cpp
+++ b/src/RageModelGeometry.cpp
@@ -113,23 +113,23 @@ void RageModelGeometry::LoadMilkshapeAscii( const RString& _sPath, bool bNeedsNo
 	{
 		iLineNum++;
 
-		if( !strncmp(sLine, "//", 2) )
+		if( !strncmp(sLine.c_str(), "//", 2) )
 			continue;
 
 		int nFrame;
-		if( sscanf(sLine, "Frames: %d", &nFrame) == 1 )
+		if( sscanf(sLine.c_str(), "Frames: %d", &nFrame) == 1 )
 		{
 			// ignore
 			// m_pRageModelGeometry->nTotalFrames = nFrame;
 		}
-		if( sscanf(sLine, "Frame: %d", &nFrame) == 1 )
+		if( sscanf(sLine.c_str(), "Frame: %d", &nFrame) == 1 )
 		{
 			// ignore
 			// m_pRageModelGeometry->nFrame = nFrame;
 		}
 
 		int nNumMeshes = 0;
-		if( sscanf(sLine, "Meshes: %d", &nNumMeshes) == 1 )
+		if( sscanf(sLine.c_str(), "Meshes: %d", &nNumMeshes) == 1 )
 		{
 			ASSERT( m_Meshes.empty() );
 			m_Meshes.resize( nNumMeshes );
@@ -144,7 +144,7 @@ void RageModelGeometry::LoadMilkshapeAscii( const RString& _sPath, bool bNeedsNo
 					THROW;
 
 				// mesh: name, flags, material index
-				if( sscanf (sLine, "\"%31[^\"]\" %d %d",szName, &nFlags, &nIndex) != 3 )
+				if( sscanf (sLine.c_str(), "\"%31[^\"]\" %d %d",szName, &nFlags, &nIndex) != 3 )
 					THROW;
 
 				mesh.sName = szName;
@@ -160,7 +160,7 @@ void RageModelGeometry::LoadMilkshapeAscii( const RString& _sPath, bool bNeedsNo
 					THROW;
 
 				int nNumVertices = 0;
-				if( sscanf (sLine, "%d", &nNumVertices) != 1 )
+				if( sscanf (sLine.c_str(), "%d", &nNumVertices) != 1 )
 					THROW;
 
 				Vertices.resize( nNumVertices );
@@ -172,7 +172,7 @@ void RageModelGeometry::LoadMilkshapeAscii( const RString& _sPath, bool bNeedsNo
 					if( f.GetLine( sLine ) <= 0 )
 						THROW;
 
-					if( sscanf(sLine, "%d %f %f %f %f %f %d",
+					if( sscanf(sLine.c_str(), "%d %f %f %f %f %f %d",
 								&nFlags,
 								&v.p[0], &v.p[1], &v.p[2],
 								&v.t[0], &v.t[1],
@@ -204,7 +204,7 @@ void RageModelGeometry::LoadMilkshapeAscii( const RString& _sPath, bool bNeedsNo
 					THROW;
 
 				int nNumNormals = 0;
-				if( sscanf(sLine, "%d", &nNumNormals) != 1 )
+				if( sscanf(sLine.c_str(), "%d", &nNumNormals) != 1 )
 					THROW;
 
 				vector<RageVector3> Normals;
@@ -215,7 +215,7 @@ void RageModelGeometry::LoadMilkshapeAscii( const RString& _sPath, bool bNeedsNo
 						THROW;
 
 					RageVector3 Normal;
-					if( sscanf(sLine, "%f %f %f", &Normal[0], &Normal[1], &Normal[2]) != 3 )
+					if( sscanf(sLine.c_str(), "%f %f %f", &Normal[0], &Normal[1], &Normal[2]) != 3 )
 						THROW;
 
 					RageVec3Normalize( (RageVector3*)&Normal, (RageVector3*)&Normal );
@@ -229,7 +229,7 @@ void RageModelGeometry::LoadMilkshapeAscii( const RString& _sPath, bool bNeedsNo
 					THROW;
 
 				int nNumTriangles = 0;
-				if( sscanf (sLine, "%d", &nNumTriangles) != 1 )
+				if( sscanf (sLine.c_str(), "%d", &nNumTriangles) != 1 )
 					THROW;
 
 				Triangles.resize( nNumTriangles );
@@ -241,7 +241,7 @@ void RageModelGeometry::LoadMilkshapeAscii( const RString& _sPath, bool bNeedsNo
 
 					uint16_t nIndices[3];
 					uint16_t nNormalIndices[3];
-					if( sscanf (sLine, "%d %hd %hd %hd %hd %hd %hd %d",
+					if( sscanf (sLine.c_str(), "%d %hd %hd %hd %hd %hd %hd %d",
 								&nFlags,
 								&nIndices[0], &nIndices[1], &nIndices[2],
 								&nNormalIndices[0], &nNormalIndices[1], &nNormalIndices[2],

--- a/src/RageSoundManager.cpp
+++ b/src/RageSoundManager.cpp
@@ -145,8 +145,7 @@ RageSoundReader *RageSoundManager::GetLoadedSound( const RString &sPath_ )
 {
 	LockMut(g_SoundManMutex); /* lock for access to m_mapPreloadedSounds */
 
-	RString sPath(sPath_);
-	sPath.MakeLower();
+    RString sPath = MakeLower(sPath_);
 	auto it = m_mapPreloadedSounds.find( sPath );
 	if( it == m_mapPreloadedSounds.end() )
 		return NULL;
@@ -163,8 +162,7 @@ void RageSoundManager::AddLoadedSound( const RString &sPath_, RageSoundReader_Pr
 
 	/* Don't AddLoadedSound a sound that's already registered.  It should have been
 	 * used in GetLoadedSound. */
-	RString sPath(sPath_);
-	sPath.MakeLower();
+    RString sPath = MakeLower(sPath_);
 	auto it = m_mapPreloadedSounds.find( sPath );
 	ASSERT_M( it == m_mapPreloadedSounds.end(), sPath );
 

--- a/src/RageSoundReader_Chain.cpp
+++ b/src/RageSoundReader_Chain.cpp
@@ -64,7 +64,7 @@ void RageSoundReader_Chain::AddSound( int iIndex, float fOffsetSecs, float fPan 
 
 int RageSoundReader_Chain::LoadSound( RString sPath )
 {
-	sPath.MakeLower();
+	sPath = MakeLower(sPath);
 
 	auto it = m_apNamedSounds.find( sPath );
 	if( it != m_apNamedSounds.end() )

--- a/src/RageSoundReader_FileReader.cpp
+++ b/src/RageSoundReader_FileReader.cpp
@@ -139,8 +139,7 @@ RageSoundReader_FileReader *RageSoundReader_FileReader::OpenFile( RString filena
 		FileTypes.insert(*curr);
 	}
 
-	RString format = GetExtension( filename );
-	format.MakeLower();
+	RString format = MakeLower(GetExtension( filename ));
 
 	error = "";
 

--- a/src/RageSoundReader_FileReader.cpp
+++ b/src/RageSoundReader_FileReader.cpp
@@ -22,19 +22,26 @@ using std::vector;
 RageSoundReader_FileReader *RageSoundReader_FileReader::TryOpenFile( RageFileBasic *pFile, RString &error, RString format, bool &bKeepTrying )
 {
 	RageSoundReader_FileReader *Sample = NULL;
+	ci_string ciFormat(format.c_str());
 
 #ifndef NO_WAV_SUPPORT
-	if( !format.CompareNoCase("wav") )
+	if( ciFormat == "wav" )
+	{
 		Sample = new RageSoundReader_WAV;
+}
 #endif
 #ifndef NO_MP3_SUPPORT
-	if( !format.CompareNoCase("mp3") )
+	if( format == "mp3" )
+	{
 		Sample = new RageSoundReader_MP3;
+}
 #endif
 
 #ifndef NO_VORBIS_SUPPORT
-	if( !format.CompareNoCase("oga") || !format.CompareNoCase("ogg") )
+	if( format == "oga" || format == "ogg" )
+	{
 		Sample = new RageSoundReader_Vorbisfile;
+	}
 #endif
 
 	if( !Sample )

--- a/src/RageSoundReader_WAV.cpp
+++ b/src/RageSoundReader_WAV.cpp
@@ -457,11 +457,9 @@ RString ReadString( RageFileBasic &f, int iSize, RString &sError )
 	if( sError.size() != 0 )
 		return RString();
 
-	RString sBuf;
-	char *pBuf = sBuf.GetBuffer( iSize );
+	char pBuf[iSize];
 	FileReading::ReadBytes( f, pBuf, iSize, sError );
-	sBuf.ReleaseBuffer( iSize );
-	return sBuf;
+	return std::string(pBuf);
 }
 
 #define FATAL_ERROR(s) \

--- a/src/RageSurface_Load.cpp
+++ b/src/RageSurface_Load.cpp
@@ -103,8 +103,7 @@ RageSurface *RageSurfaceUtils::LoadFile( const RString &sPath, RString &error, b
 		FileTypes.insert(*curr);
 	}
 
-	RString format = GetExtension(sPath);
-	format.MakeLower();
+	RString format = MakeLower(GetExtension(sPath));
 
 	bool bKeepTrying = true;
 

--- a/src/RageSurface_Load.cpp
+++ b/src/RageSurface_Load.cpp
@@ -16,14 +16,23 @@ static RageSurface *TryOpenFile( RString sPath, bool bHeaderOnly, RString &error
 {
 	RageSurface *ret = NULL;
 	RageSurfaceUtils::OpenResult result;
-	if( !format.CompareNoCase("png") )
+	ci_string ciFormat(format.c_str());
+	if( ciFormat == "png" )
+	{
 		result = RageSurface_Load_PNG( sPath, ret, bHeaderOnly, error );
-	else if( !format.CompareNoCase("gif") )
+	}
+	else if( ciFormat == "gif" )
+	{
 		result = RageSurface_Load_GIF( sPath, ret, bHeaderOnly, error );
-	else if( !format.CompareNoCase("jpg") || !format.CompareNoCase("jpeg") )
+	}
+	else if( ciFormat == "jpg" || ciFormat == "jpeg" )
+	{
 		result = RageSurface_Load_JPEG( sPath, ret, bHeaderOnly, error );
-	else if( !format.CompareNoCase("bmp") )
+	}
+	else if( ciFormat == "bmp" )
+	{
 		result = RageSurface_Load_BMP( sPath, ret, bHeaderOnly, error );
+	}
 	else
 	{
 		error = "Unsupported format";

--- a/src/RageSurface_Load_JPEG.cpp
+++ b/src/RageSurface_Load_JPEG.cpp
@@ -214,7 +214,7 @@ RageSurfaceUtils::OpenResult RageSurface_Load_JPEG( const RString &sPath, RageSu
 	}
 
 	char errorbuf[1024];
-	ret = RageSurface_Load_JPEG( &f, sPath, errorbuf );
+	ret = RageSurface_Load_JPEG( &f, sPath.c_str(), errorbuf );
 	if( ret == NULL )
 	{
 		error = errorbuf;

--- a/src/RageSurface_Load_PNG.cpp
+++ b/src/RageSurface_Load_PNG.cpp
@@ -263,7 +263,7 @@ RageSurfaceUtils::OpenResult RageSurface_Load_PNG( const RString &sPath, RageSur
 	}
 
 	char errorbuf[1024];
-	ret = RageSurface_Load_PNG( &f, sPath, errorbuf, bHeaderOnly );
+	ret = RageSurface_Load_PNG( &f, sPath.c_str(), errorbuf, bHeaderOnly );
 	if( ret == NULL )
 	{
 		error = errorbuf;

--- a/src/RageSurface_Load_PNG.cpp
+++ b/src/RageSurface_Load_PNG.cpp
@@ -29,7 +29,7 @@ void RageFile_png_read( png_struct *png, png_byte *p, png_size_t size )
 		 * GetError().c_str() to it, a temporary may be created; since control
 		 * never returns here, it may never be destructed and we could leak. */
 		static char error[256];
-		strncpy( error, f->GetError(), sizeof(error) );
+		strncpy( error, f->GetError().c_str(), sizeof(error) );
 		error[sizeof(error)-1] = 0;
 		png_error( png, error );
 	}

--- a/src/RageSurface_Load_XPM.cpp
+++ b/src/RageSurface_Load_XPM.cpp
@@ -56,7 +56,7 @@ RageSurface *RageSurface_Load_XPM( char * const *xpm, RString &error )
 
 		RString clr = color.substr( color_length+4 );
 		int r, g, b;
-		if( sscanf( clr, "%2x%2x%2x", &r, &g, &b ) != 3 )
+		if( sscanf( clr.c_str(), "%2x%2x%2x", &r, &g, &b ) != 3 )
 			continue;
 		RageSurfaceColor colorval;
 		colorval.r = (uint8_t) r;

--- a/src/RageSurface_Save_PNG.cpp
+++ b/src/RageSurface_Save_PNG.cpp
@@ -22,7 +22,7 @@ static void SafePngError( png_struct *pPng, const RString &sStr )
 	 * GetError().c_str() to it, a temporary may be created; since control
 	 * never returns, it may never be destructed and leak. */
 	static char error[256];
-	strncpy( error, sStr, sizeof(error) );
+	strncpy( error, sStr.c_str(), sizeof(error) );
 	error[sizeof(error)-1] = 0;
 	png_error( pPng, error );
 }

--- a/src/RageThreads.cpp
+++ b/src/RageThreads.cpp
@@ -262,7 +262,7 @@ RageThreadRegister::RageThreadRegister( const RString &sName )
 
 	m_pSlot = &g_ThreadSlots[iSlot];
 
-	strcpy( m_pSlot->m_szName, sName );
+	strcpy( m_pSlot->m_szName, sName.c_str() );
 	sprintf( m_pSlot->m_szThreadFormattedOutput, "Thread: %s", sName.c_str() );
 
 	m_pSlot->m_iID = GetThisThreadId();

--- a/src/RageThreads.cpp
+++ b/src/RageThreads.cpp
@@ -378,7 +378,7 @@ void Checkpoints::LogCheckpoints( bool on )
 	g_LogCheckpoints = on;
 }
 
-void Checkpoints::SetCheckpoint( const char *file, int line, const char *message )
+void Checkpoints::SetCheckpoint( const char *file, int line, std::string const &message )
 {
 	using std::max;
 	ThreadSlot *slot = GetCurThreadSlot();
@@ -392,7 +392,7 @@ void Checkpoints::SetCheckpoint( const char *file, int line, const char *message
 	const char *temp = strstr( file, "src/" );
 	if( temp )
 		file = temp + 4;
-	slot->m_Checkpoints[slot->m_iCurCheckpoint].Set( file, line, message );
+	slot->m_Checkpoints[slot->m_iCurCheckpoint].Set( file, line, message.c_str() );
 
 	if( g_LogCheckpoints )
 		LOG->Trace( "%s", slot->m_Checkpoints[slot->m_iCurCheckpoint].m_szFormattedBuf );

--- a/src/RageThreads.h
+++ b/src/RageThreads.h
@@ -75,7 +75,7 @@ private:
 namespace Checkpoints
 {
 	void LogCheckpoints( bool yes=true );
-	void SetCheckpoint( const char *file, int line, const char *message );
+	void SetCheckpoint( const char *file, int line, std::string const &message );
 	void GetLogs( char *pBuf, int iSize, const char *delim );
 };
 

--- a/src/RageTypes.h
+++ b/src/RageTypes.h
@@ -218,7 +218,8 @@ public:
 	
 	bool FromString( const RString &str )
 	{
-		int result = sscanf( str, "%f,%f,%f,%f", &r, &g, &b, &a );
+		auto const *cstr = str.c_str();
+		int result = sscanf( cstr, "%f,%f,%f,%f", &r, &g, &b, &a );
 		if( result == 3 )
 		{
 			a = 1;
@@ -228,7 +229,7 @@ public:
 			return true;
 		
 		int ir=255, ib=255, ig=255, ia=255;
-		result = sscanf( str, "#%2x%2x%2x%2x", &ir, &ig, &ib, &ia );
+		result = sscanf( cstr, "#%2x%2x%2x%2x", &ir, &ig, &ib, &ia );
 		if( result >= 3 )
 		{
 			r = ir / 255.0f; g = ig / 255.0f; b = ib / 255.0f;

--- a/src/RageUtil.cpp
+++ b/src/RageUtil.cpp
@@ -697,9 +697,10 @@ void GetLanguageInfos( vector<const LanguageInfo*> &vAddTo )
 
 const LanguageInfo *GetLanguageInfo( const RString &sIsoCode )
 {
+	ci_string ciIsoCode(sIsoCode.c_str());
 	for (auto const &lang: g_langs)
 	{
-		if ( sIsoCode.EqualsNoCase(lang.szIsoCode))
+		if ( ciIsoCode == lang.szIsoCode )
 		{
 			return &lang;
 		}
@@ -1345,9 +1346,10 @@ RString URLEncode( const RString &sStr )
 // remove various version control-related files
 static bool CVSOrSVN( const RString& s )
 {
-	return tail(s, 3).EqualsNoCase("CVS") ||
-			tail(s, 4) == ".svn" ||
-			tail(s, 3).EqualsNoCase(".hg");
+	ci_string version3(s.c_str());
+	ci_string version4(s.c_str());
+	return version3 == "CVS" || version4 == ".svn" ||
+		version3 == ".hg" || version4 == ".git";
 }
 
 void StripCvsAndSvn( vector<RString> &vs )

--- a/src/RageUtil.cpp
+++ b/src/RageUtil.cpp
@@ -250,7 +250,7 @@ bool HexToBinary( const RString &s, unsigned char *stringOut )
 		RString sByte = s.substr( i*2, 2 );
 
 		uint8_t val = 0;
-		if( sscanf( sByte, "%hhx", &val ) != 1 )
+		if( sscanf( sByte.c_str(), "%hhx", &val ) != 1 )
 			return false;
 		stringOut[i] = val;
 	}
@@ -497,47 +497,6 @@ RString vssprintf( const char *szFormat, va_list argList )
 #endif
 	return sStr;
 }
-
-/* Windows uses %I64i to format a 64-bit int, instead of %lli. Convert "a b %lli %-3llu c d"
- * to "a b %I64 %-3I64u c d". This assumes a well-formed format string; invalid format strings
- * should not crash, but the results are undefined. */
-#if defined(WIN32)
-RString ConvertI64FormatString( const RString &sStr )
-{
-	RString sRet;
-	sRet.reserve( sStr.size() + 16 );
-
-	size_t iOffset = 0;
-	while( iOffset < sStr.size() )
-	{
-		size_t iPercent = sStr.find( '%', iOffset );
-		if( iPercent != sStr.npos )
-		{
-			sRet.append( sStr, iOffset, iPercent - iOffset );
-			iOffset = iPercent;
-		}
-
-		size_t iEnd = sStr.find_first_of( "diouxXeEfFgGaAcsCSpnm%", iOffset + 1 );
-		if( iEnd != sStr.npos && iEnd - iPercent >= 3 && iPercent > 2 && sStr[iEnd-2] == 'l' && sStr[iEnd-1] == 'l' )
-		{
-			sRet.append( sStr, iPercent, iEnd - iPercent - 2 ); // %
-			sRet.append( "I64" ); // %I64
-			sRet.append( sStr, iEnd, 1 ); // %I64i
-			iOffset = iEnd + 1;
-		}
-		else
-		{
-			if( iEnd == sStr.npos )
-				iEnd = sStr.size() - 1;
-			sRet.append( sStr, iOffset, iEnd - iOffset + 1 );
-			iOffset = iEnd + 1;
-		}
-	}
-	return sRet;
-}
-#else
-RString ConvertI64FormatString( const RString &sStr ) { return sStr; }
-#endif
 
 /* ISO-639-1 codes: http://www.loc.gov/standards/iso639-2/php/code_list.php
  * native forms: http://people.w3.org/rishida/names/languages.html
@@ -1921,7 +1880,7 @@ RString IntToString( const int &iNum )
 
 float StringToFloat( const RString &sString )
 {
-	float ret = strtof( sString, NULL );
+	float ret = strtof( sString.c_str(), NULL );
 
 	if( !isfinite(ret) )
 		ret = 0.0f;
@@ -1932,7 +1891,7 @@ bool StringToFloat( const RString &sString, float &fOut )
 {
 	char *endPtr;
 
-	fOut = strtof( sString, &endPtr );
+	fOut = strtof( sString.c_str(), &endPtr );
 	return sString.size() && *endPtr == '\0' && isfinite( fOut );
 }
 
@@ -2358,7 +2317,7 @@ namespace StringConversion
 	template<> bool FromString<float>( const RString &sValue, float &out )
 	{
 		const char *endptr = sValue.data() + sValue.size();
-		out = strtof( sValue, (char **) &endptr );
+		out = strtof( sValue.c_str(), (char **) &endptr );
 		if( endptr != sValue.data() && isfinite( out ) )
 			return true;
 		out = 0;

--- a/src/RageUtil.cpp
+++ b/src/RageUtil.cpp
@@ -1102,7 +1102,7 @@ void GetCommandLineArguments( int &argc, char **&argv )
  * If argument is non-NULL, accept an argument. */
 bool GetCommandlineArgument( const RString &option, RString *argument, int iIndex )
 {
-	const RString optstr = "--" + option;
+	ci_string optstr = ("--" + option).c_str();
 
 	for( int arg = 1; arg < g_argc; ++arg )
 	{
@@ -1110,9 +1110,10 @@ bool GetCommandlineArgument( const RString &option, RString *argument, int iInde
 
 		const size_t i = CurArgument.find( "=" );
 		RString CurOption = CurArgument.substr(0,i);
-		if( CurOption.CompareNoCase(optstr) )
+		if (optstr != CurOption.c_str())
+		{
 			continue; // no match
-
+		}
 		// Found it.
 		if( iIndex )
 		{
@@ -1201,12 +1202,14 @@ bool DirectoryIsEmpty( const RString &sDir )
 
 bool CompareRStringsAsc( const RString &sStr1, const RString &sStr2 )
 {
-	return sStr1.CompareNoCase( sStr2 ) < 0;
+	ci_string x(sStr1.c_str());
+	return x < sStr2.c_str();
 }
 
 bool CompareRStringsDesc( const RString &sStr1, const RString &sStr2 )
 {
-	return sStr1.CompareNoCase( sStr2 ) > 0;
+	ci_string x(sStr1.c_str());
+	return x > sStr2.c_str();
 }
 
 void SortRStringArray( vector<RString> &arrayRStrings, const bool bSortAscending )
@@ -2384,7 +2387,8 @@ namespace StringConversion
 
 bool FileCopy( const RString &sSrcFile, const RString &sDstFile )
 {
-	if( !sSrcFile.CompareNoCase(sDstFile) )
+	ci_string x(sSrcFile.c_str());
+	if( x == sDstFile.c_str() )
 	{
 		LOG->Warn( "Tried to copy \"%s\" over itself", sSrcFile.c_str() );
 		return false;

--- a/src/RageUtil.cpp
+++ b/src/RageUtil.cpp
@@ -1345,9 +1345,9 @@ RString URLEncode( const RString &sStr )
 // remove various version control-related files
 static bool CVSOrSVN( const RString& s )
 {
-	return s.Right(3).EqualsNoCase("CVS") ||
-			s.Right(4) == ".svn" ||
-			s.Right(3).EqualsNoCase(".hg");
+	return tail(s, 3).EqualsNoCase("CVS") ||
+			tail(s, 4) == ".svn" ||
+			tail(s, 3).EqualsNoCase(".hg");
 }
 
 void StripCvsAndSvn( vector<RString> &vs )

--- a/src/RageUtil.cpp
+++ b/src/RageUtil.cpp
@@ -1357,7 +1357,7 @@ void StripCvsAndSvn( vector<RString> &vs )
 
 static bool MacResourceFork( const RString& s )
 {
-	return s.Left(2).EqualsNoCase("._");
+	return BeginsWith(s, "._");
 }
 
 void StripMacResourceForks( vector<RString> &vs )

--- a/src/RageUtil.cpp
+++ b/src/RageUtil.cpp
@@ -1004,8 +1004,7 @@ bool FindFirstFilenameContaining(const vector<RString>& filenames,
 {
 	for(size_t i= 0; i < filenames.size(); ++i)
 	{
-		RString lower= GetFileNameWithoutExtension(filenames[i]);
-		lower.MakeLower();
+		RString lower= MakeLower(GetFileNameWithoutExtension(filenames[i]));
 		for(size_t s= 0; s < starts_with.size(); ++s)
 		{
 			if(!lower.compare(0, starts_with[s].size(), starts_with[s]))
@@ -1828,6 +1827,20 @@ void MakeLower( wchar_t *p, size_t iLen )
 	UnicodeUpperLower( p, iLen, g_LowerCase );
 }
 
+std::string MakeUpper( std::string const &str)
+{
+	auto *cstr = const_cast<char *>(str.c_str());
+	MakeUpper(cstr, str.size());
+	return std::string(cstr);
+}
+
+std::string MakeLower( std::string const &str)
+{
+	auto *cstr = const_cast<char *>(str.c_str());
+	MakeLower(cstr, str.size());
+	return std::string(cstr);
+}
+
 char GetAsciiUpper(char const &ch)
 {
 	return (ch >= 'a' && ch <= 'z')? char(ch + 'A' - 'a'): ch;
@@ -1979,8 +1992,7 @@ void ReplaceEntityText( RString &sText, const std::map<RString,RString> &m )
 			continue;
 		}
 
-		RString sElement = sText.substr( iStart+1, iEnd-iStart-1 );
-		sElement.MakeLower();
+		RString sElement = MakeLower(sText.substr( iStart+1, iEnd-iStart-1 ));
 
 		auto it = m.find( sElement );
 		if( it == m.end() )
@@ -2425,10 +2437,10 @@ LuaFunction( SecondsToMSS, SecondsToMSS( FArg(1) ) )
 LuaFunction( SecondsToMMSS, SecondsToMMSS( FArg(1) ) )
 LuaFunction( FormatNumberAndSuffix, FormatNumberAndSuffix( IArg(1) ) )
 LuaFunction( Basename, Basename( SArg(1) ) )
-static RString MakeLower( RString s ) { s.MakeLower(); return s; }
-LuaFunction( Lowercase, MakeLower( SArg(1) ) )
-static RString MakeUpper( RString s ) { s.MakeUpper(); return s; }
-LuaFunction( Uppercase, MakeUpper( SArg(1) ) )
+static RString MakeLowercase( RString s ) { return MakeLower(s); }
+LuaFunction( Lowercase, MakeLowercase( SArg(1) ) )
+static RString MakeUppercase( RString s ) { return MakeUpper(s); }
+LuaFunction( Uppercase, MakeUppercase( SArg(1) ) )
 LuaFunction( mbstrlen, (int)RStringToWstring(SArg(1)).length() )
 LuaFunction( URLEncode, URLEncode( SArg(1) ) );
 LuaFunction( PrettyPercent, PrettyPercent( FArg(1), FArg(2) ) );

--- a/src/RageUtil.cpp
+++ b/src/RageUtil.cpp
@@ -474,31 +474,28 @@ RString vssprintf_unx( char const *szFormat, va_list argList )
 		int iNeeded = vsnprintf( &ignore, 0, szFormat, tmp );
 		va_end(tmp);
 
-		char *buf = sStr.GetBuffer( iNeeded+1 );
-		vsnprintf( buf, iNeeded+1, szFormat, argList );
-		sStr.ReleaseBuffer( iNeeded );
-		return sStr;
+		char buffer[8192];
+		vsnprintf( buffer, iNeeded+1, szFormat, argList );
+		return string(buffer);
 	}
 
 	int iChars = FMT_BLOCK_SIZE;
 	int iTry = 1;
-	while( 1 )
+	for(;;)
 	{
 		// Grow more than linearly (e.g. 512, 1536, 3072, etc)
-		char *buf = sStr.GetBuffer(iChars);
-		int iUsed = vsnprintf(buf, iChars-1, szFormat, argList);
+		char buffer[iChars];
+		int iUsed = vsnprintf(buffer, iChars-1, szFormat, argList);
 
 		if( iUsed == -1 )
 		{
 			iChars += ((iTry+1) * FMT_BLOCK_SIZE);
-			sStr.ReleaseBuffer();
 			++iTry;
 			continue;
 		}
 
 		/* OK */
-		sStr.ReleaseBuffer(iUsed);
-		break;
+		return string(buffer);
 	}
 #endif
 	return sStr;

--- a/src/RageUtil.cpp
+++ b/src/RageUtil.cpp
@@ -424,12 +424,9 @@ RString ssprintf( const char *fmt, ...)
 	return vssprintf(fmt, va);
 }
 
-#define FMT_BLOCK_SIZE		2048 // # of bytes to increment per try
-
-RString vssprintf( const char *szFormat, va_list argList )
+RString vssprintf_win( char const *szFormat, va_list argList )
 {
 	RString sStr;
-
 #if defined(WIN32)
 	char *pBuf = NULL;
 	int iChars = 1;
@@ -447,7 +444,16 @@ RString vssprintf( const char *szFormat, va_list argList )
 
 	// assign whatever we managed to format
 	sStr.assign( pBuf, iUsed );
-#else
+#endif
+	return sStr;
+}
+
+#define FMT_BLOCK_SIZE		2048 // # of bytes to increment per try
+
+RString vssprintf_unx( char const *szFormat, va_list argList )
+{
+	RString sStr;
+#if !defined(WIN32)
 	static bool bExactSizeSupported;
 	static bool bInitialized = false;
 	if( !bInitialized )
@@ -496,6 +502,15 @@ RString vssprintf( const char *szFormat, va_list argList )
 	}
 #endif
 	return sStr;
+}
+
+RString vssprintf( const char *szFormat, va_list argList )
+{
+#if defined(WIN32)
+	return vssprintf_win(szFormat, argList);
+#else
+	return vssprintf_unx(szFormat, argList);
+#endif
 }
 
 /* ISO-639-1 codes: http://www.loc.gov/standards/iso639-2/php/code_list.php

--- a/src/RageUtil.cpp
+++ b/src/RageUtil.cpp
@@ -1522,7 +1522,7 @@ bool Regex::Replace( const RString &sReplacement, const RString &sSubject, RStri
 	{
 		RString sFrom = ssprintf( "\\${%d}", i );
 		RString sTo = asMatches[i];
-		sOut.Replace(sFrom, sTo);
+		ReplaceAll(sOut, sFrom, sTo);
 	}
 
 	return true;
@@ -1839,6 +1839,14 @@ std::string MakeLower( std::string const &str)
 	auto *cstr = const_cast<char *>(str.c_str());
 	MakeLower(cstr, str.size());
 	return std::string(cstr);
+}
+
+void ReplaceAll(std::string &str, std::string const & from, std::string const & to) {
+	size_t start_pos = 0;
+	while((start_pos = str.find(from, start_pos)) != std::string::npos) {
+		str.replace(start_pos, from.length(), to);
+		start_pos += to.length(); // Handles case where 'to' is a substring of 'from'
+	}
 }
 
 char GetAsciiUpper(char const &ch)

--- a/src/RageUtil.cpp
+++ b/src/RageUtil.cpp
@@ -2179,11 +2179,11 @@ RString Capitalize( const RString &s )
 		return RString();
 
 	RString s2 = s;
-	char *pBuf = s2.GetBuffer();
-	UnicodeDoUpper( pBuf, s2.size(), g_UpperCase );
-	s2.ReleaseBuffer();
-
-	return s2;
+	auto *t = const_cast<char *>(s2.c_str());
+	UnicodeDoUpper( t, s2.size(), g_UpperCase );
+	RString ret(t);
+	delete t;
+	return ret;
 }
 
 unsigned char g_UpperCase[256] =

--- a/src/RageUtil.cpp
+++ b/src/RageUtil.cpp
@@ -1864,6 +1864,32 @@ void MakeLower( wchar_t *p, size_t iLen )
 	UnicodeUpperLower( p, iLen, g_LowerCase );
 }
 
+std::string head(std::string const &source, int32_t const length)
+{
+	if (std::abs(length) >= source.size())
+	{
+		return source;
+	}
+	if (length < 0)
+	{
+		return source.substr(0, source.size() + length);
+	}
+	return source.substr(length);
+}
+
+std::string tail(std::string const &source, int32_t const length)
+{
+	if (std::abs(length) >= source.size())
+	{
+		return source;
+	}
+	if (length < 0)
+	{
+		return source.substr(-length);
+	}
+	return source.substr(source.size() - length);
+}
+
 int StringToInt( const RString &sString )
 {
 	int ret;

--- a/src/RageUtil.cpp
+++ b/src/RageUtil.cpp
@@ -1869,6 +1869,16 @@ void MakeLower( wchar_t *p, size_t iLen )
 	UnicodeUpperLower( p, iLen, g_LowerCase );
 }
 
+char GetAsciiUpper(char const &ch)
+{
+	return (ch >= 'a' && ch <= 'z')? char(ch + 'A' - 'a'): ch;
+}
+
+char GetAsciiLower(char const &ch)
+{
+	return (ch >= 'A' && ch <= 'Z')? char(ch + 'a' - 'A'): ch;
+}
+
 std::string head(std::string const &source, int32_t const length)
 {
 	if (std::abs(length) >= source.size())

--- a/src/RageUtil.h
+++ b/src/RageUtil.h
@@ -362,7 +362,6 @@ struct tm GetLocalTime();
 
 RString ssprintf( const char *fmt, ...) PRINTF(1,2);
 RString vssprintf( const char *fmt, va_list argList );
-RString ConvertI64FormatString( const RString &sStr );
 
 /*
  * Splits a Path into 4 parts (Directory, Drive, Filename, Extention).  Supports UNC path names.

--- a/src/RageUtil.h
+++ b/src/RageUtil.h
@@ -395,6 +395,63 @@ void MakeLower( char *p, size_t iLen );
 void MakeUpper( wchar_t *p, size_t iLen );
 void MakeLower( wchar_t *p, size_t iLen );
 
+// Borrowed from http://stackoverflow.com/a/2886589/445373
+// We have many cases of string comparisons involving ignoring case.
+struct ci_char_traits: public std::char_traits<char>
+{
+	static bool eq(char a, char b)
+	{
+		return toupper(a) == toupper(b);
+	}
+	static bool ne(char a, char b)
+	{
+		return !eq(a, b);
+	}
+	static bool lt(char a, char b)
+	{
+		return toupper(a) < toupper(b);
+	}
+	static bool gt(char a, char b)
+	{
+		return lt(b, a);
+	}
+	static bool le(char a, char b)
+	{
+		return !lt(b, a);
+	}
+	static bool ge(char a, char b)
+	{
+		return !lt(a, b);
+	}
+	static int compare(char const *a, char const *b, size_t n)
+	{
+		while (n-- != 0)
+		{
+			if (lt(*a, *b))
+			{
+				return -1;
+			}
+			if (gt(*a, *b))
+			{
+				return 1;
+			}
+			++a;
+			++b;
+		}
+		
+		return 0;
+	}
+	static char const *find(char const *s, int n, char a)
+	{
+		while (n-- > 0 && ne(*s, a))
+		{
+			++s;
+		}
+		return s;
+	}
+};
+typedef std::basic_string<char, ci_char_traits> ci_string;
+
 // Borrowed from http://stackoverflow.com/a/7597469/445373
 // with negative extensions allowed and opposite function provided.
 std::string head(std::string const &source, int32_t const length);

--- a/src/RageUtil.h
+++ b/src/RageUtil.h
@@ -394,6 +394,12 @@ void MakeUpper( char *p, size_t iLen );
 void MakeLower( char *p, size_t iLen );
 void MakeUpper( wchar_t *p, size_t iLen );
 void MakeLower( wchar_t *p, size_t iLen );
+
+// Borrowed from http://stackoverflow.com/a/7597469/445373
+// with negative extensions allowed and opposite function provided.
+std::string head(std::string const &source, int32_t const length);
+std::string tail(std::string const &source, int32_t const length);
+
 /**
  * @brief Have a standard way of converting Strings to integers.
  * @param sString the string to convert.

--- a/src/RageUtil.h
+++ b/src/RageUtil.h
@@ -396,6 +396,10 @@ void MakeLower( wchar_t *p, size_t iLen );
 std::string MakeUpper( std::string const &str );
 std::string MakeLower( std::string const &str );
 
+// Borrowed from http://stackoverflow.com/a/24315631/445373
+// Allow string replacing strings within strings.
+void ReplaceAll( std::string &str, std::string const &from, std::string const &to );
+
 char GetAsciiUpper(char const &ch);
 char GetAsciiLower(char const &ch);
 

--- a/src/RageUtil.h
+++ b/src/RageUtil.h
@@ -393,6 +393,8 @@ void MakeUpper( char *p, size_t iLen );
 void MakeLower( char *p, size_t iLen );
 void MakeUpper( wchar_t *p, size_t iLen );
 void MakeLower( wchar_t *p, size_t iLen );
+std::string MakeUpper( std::string const &str );
+std::string MakeLower( std::string const &str );
 
 char GetAsciiUpper(char const &ch);
 char GetAsciiLower(char const &ch);

--- a/src/RageUtil.h
+++ b/src/RageUtil.h
@@ -683,6 +683,24 @@ struct char_traits_char_nocase: public std::char_traits<char>
 };
 typedef std::basic_string<char,char_traits_char_nocase> istring;
 
+struct ci_std_string_lt: std::binary_function<std::string, std::string, bool>
+{
+	inline bool operator()(std::string const &a, std::string const &b) const
+	{
+		istring x(a.c_str());
+		return x < b.c_str();
+	}
+};
+
+struct ci_std_string_eq: std::binary_function<std::string, std::string, bool>
+{
+	inline bool operator()(std::string const &a, std::string const &b) const
+	{
+		istring x(a.c_str());
+		return x < b.c_str();
+	}
+};
+
 /* Compatibility/convenience shortcuts. These are actually defined in RageFileManager.h, but
  * declared here since they're used in many places. */
 void GetDirListing( const RString &sPath, std::vector<RString> &AddTo, bool bOnlyDirs=false, bool bReturnPathToo=false );

--- a/src/RageUtil.h
+++ b/src/RageUtil.h
@@ -399,9 +399,16 @@ void MakeLower( wchar_t *p, size_t iLen );
 // We have many cases of string comparisons involving ignoring case.
 struct ci_char_traits: public std::char_traits<char>
 {
+private:
+	// As our strings are already UTF8, only focus on the ASCII characters for conversion.
+	static char smToUpper(char ch)
+	{
+		return (ch >= 'a' && ch <= 'z')? char(ch + 'A' - 'a'): ch;
+	}
+public:
 	static bool eq(char a, char b)
 	{
-		return toupper(a) == toupper(b);
+		return smToUpper(a) == smToUpper(b);
 	}
 	static bool ne(char a, char b)
 	{
@@ -409,7 +416,7 @@ struct ci_char_traits: public std::char_traits<char>
 	}
 	static bool lt(char a, char b)
 	{
-		return toupper(a) < toupper(b);
+		return smToUpper(a) < smToUpper(b);
 	}
 	static bool gt(char a, char b)
 	{

--- a/src/RageUtil.h
+++ b/src/RageUtil.h
@@ -395,6 +395,9 @@ void MakeLower( char *p, size_t iLen );
 void MakeUpper( wchar_t *p, size_t iLen );
 void MakeLower( wchar_t *p, size_t iLen );
 
+char GetAsciiUpper(char const &ch);
+char GetAsciiLower(char const &ch);
+
 // Borrowed from http://stackoverflow.com/a/2886589/445373
 // We have many cases of string comparisons involving ignoring case.
 struct ci_char_traits: public std::char_traits<char>

--- a/src/RageUtil_CharConversions.cpp
+++ b/src/RageUtil_CharConversions.cpp
@@ -97,7 +97,7 @@ static bool ConvertFromCP( RString &sText, int iCodePage )
 	if( encoding == kCFStringEncodingInvalidId )
 		return false;
 
-	CFStringRef old = CFStringCreateWithCString( kCFAllocatorDefault, sText, encoding );
+	CFStringRef old = CFStringCreateWithCString( kCFAllocatorDefault, sText.c_str(), encoding );
 
 	if( old == NULL )
 		return false;

--- a/src/RageUtil_FileDB.cpp
+++ b/src/RageUtil_FileDB.cpp
@@ -273,8 +273,8 @@ FileSet *FilenameDB::GetFileSet( const RString &sDir_, bool bCreate )
 		LOG->Warn( "FilenameDB::GetFileSet: m_Mutex was locked" );
 
 	/* Normalize the path. */
-	sDir.Replace("\\", "/"); /* foo\bar -> foo/bar */
-	sDir.Replace("//", "/"); /* foo//bar -> foo/bar */
+	ReplaceAll(sDir, "\\", "/"); /* foo\bar -> foo/bar */
+	ReplaceAll(sDir, "//", "/"); /* foo//bar -> foo/bar */
 
 	if( sDir == "" )
 		sDir = "/";

--- a/src/RageUtil_FileDB.cpp
+++ b/src/RageUtil_FileDB.cpp
@@ -12,12 +12,9 @@ void FileSet::GetFilesMatching( const RString &sBeginning_, const RString &sCont
 {
 	/* "files" is a case-insensitive mapping, by filename.  Use lower_bound to figure
 	 * out where to start. */
-	RString sBeginning = sBeginning_;
-	sBeginning.MakeLower();
-	RString sContaining = sContaining_;
-	sContaining.MakeLower();
-	RString sEnding = sEnding_;
-	sEnding.MakeLower();
+	RString sBeginning = MakeLower(sBeginning_);
+	RString sContaining = MakeLower(sContaining_);
+	RString sEnding = MakeLower(sEnding_);
 
 	std::set<File>::const_iterator i = files.lower_bound( File(sBeginning) );
 	for( ; i != files.end(); ++i )
@@ -282,8 +279,7 @@ FileSet *FilenameDB::GetFileSet( const RString &sDir_, bool bCreate )
 	if( sDir == "" )
 		sDir = "/";
 
-	RString sLower = sDir;
-	sLower.MakeLower();
+	RString sLower = MakeLower(sDir);
 
 	m_Mutex.Lock();
 
@@ -463,8 +459,7 @@ void FilenameDB::DelFileSet( std::map<RString, FileSet *>::iterator dir )
 void FilenameDB::DelFile( const RString &sPath )
 {
 	LockMut(m_Mutex);
-	RString lower = sPath;
-	lower.MakeLower();
+	RString lower = MakeLower(sPath);
 
 	auto fsi = dirs.find( lower );
 	DelFileSet( fsi );
@@ -520,7 +515,7 @@ void FilenameDB::FlushDirCache( const RString & /* sDir */ )
 				RString sParent = Dirname( sDir );
 				if( sParent == "./" )
 					sParent = "";
-				sParent.MakeLower();
+				sParent = MakeLower(sParent);
 				it = dirs.find( sParent );
 				if( it != dirs.end() )
 				{

--- a/src/RageUtil_FileDB.cpp
+++ b/src/RageUtil_FileDB.cpp
@@ -104,7 +104,7 @@ int FileSet::GetFileHash( const RString &sPath ) const
 static void SplitPath( RString sPath, RString &sDir, RString &sName )
 {
 	CollapsePath( sPath );
-	if( sPath.Right(1) == "/" )
+	if( EndsWith(sPath, "/") )
 		sPath.erase( sPath.size()-1 );
 
 	size_t iSep = sPath.find_last_of( '/' );

--- a/src/RageUtil_FileDB.h
+++ b/src/RageUtil_FileDB.h
@@ -16,8 +16,7 @@ struct File
 	void SetName( const RString &fn )
 	{
 		name = fn;
-		lname = name;
-		lname.MakeLower();
+		lname = MakeLower(name);
 	}
 
 	bool dir;
@@ -45,8 +44,7 @@ struct File
 	bool equal(const File &rhs) const { return lname == rhs.lname; }
 	bool equal(const RString &rhs) const
 	{
-		RString l = rhs;
-		l.MakeLower();
+		RString l = MakeLower(rhs);
 		return lname == l;
 	}
 };

--- a/src/RageUtil_FileDB.h
+++ b/src/RageUtil_FileDB.h
@@ -3,6 +3,7 @@
 
 #include <set>
 #include <map>
+#include "RageUtil.h"
 #include "RageTimer.h"
 #include "RageThreads.h"
 #include "RageFileManager.h"

--- a/src/RageUtil_WorkerThread.cpp
+++ b/src/RageUtil_WorkerThread.cpp
@@ -109,7 +109,7 @@ bool RageWorkerThread::DoRequest( int iRequest )
 
 void RageWorkerThread::WorkerMain()
 {
-	while(1)
+	for(;;)
 	{
 		bool bTimeToRunHeartbeat = false;
 		m_WorkerEvent.Lock();
@@ -167,7 +167,7 @@ void RageWorkerThread::WorkerMain()
 				/* Clear the time-out flag, indicating that we can work again. */
 				m_bTimedOut = false;
 
-				CHECKPOINT;
+				CHECKPOINT_M( ssprintf("Request %i time out cleared.", iRequest) );
 			}
 			else
 			{

--- a/src/RandomSample.cpp
+++ b/src/RandomSample.cpp
@@ -47,7 +47,7 @@ bool RandomSample::LoadSoundDir( RString sDir, int iMaxToLoad )
 		sDir += "/";
 #else
 	// make sure there's a slash at the end of this path
-	if( sDir.Right(1) != "/" )
+	if( !EndsWith(sDir, "/") )
 		sDir += "/";
 #endif
 

--- a/src/RollingNumbers.cpp
+++ b/src/RollingNumbers.cpp
@@ -125,7 +125,7 @@ void RollingNumbers::UpdateText()
 	{
 		return;
 	}
-	RString s = ssprintf( TEXT_FORMAT.GetValue(), m_fCurrentNumber );
+	RString s = fmt::sprintf( TEXT_FORMAT.GetValue(), m_fCurrentNumber );
 	if(COMMIFY)
 	{
 		s = Commify( s );

--- a/src/Screen.cpp
+++ b/src/Screen.cpp
@@ -410,9 +410,9 @@ void Screen::InternalRemoveCallback(callback_key_t key)
 class LunaScreen: public Luna<Screen>
 {
 public:
-	static int GetNextScreenName( T* p, lua_State *L ) { lua_pushstring(L, p->GetNextScreenName() ); return 1; }
+	static int GetNextScreenName( T* p, lua_State *L ) { lua_pushstring(L, p->GetNextScreenName().c_str() ); return 1; }
 	static int SetNextScreenName( T* p, lua_State *L ) { p->SetNextScreenName(SArg(1)); COMMON_RETURN_SELF; }
-	static int GetPrevScreenName( T* p, lua_State *L ) { lua_pushstring(L, p->GetPrevScreen() ); return 1; }
+	static int GetPrevScreenName( T* p, lua_State *L ) { lua_pushstring(L, p->GetPrevScreen().c_str()); return 1; }
 	static int lockinput( T* p, lua_State *L ) { p->SetLockInputSecs(FArg(1)); COMMON_RETURN_SELF; }
 	DEFINE_METHOD( GetScreenType,	GetScreenType() )
 

--- a/src/ScreenBookkeeping.cpp
+++ b/src/ScreenBookkeeping.cpp
@@ -173,7 +173,7 @@ void ScreenBookkeeping::UpdateView()
 						iCount = pProfile->GetSongNumTimesPlayed( pSong );
 						RString sTitle = ssprintf("%4d",iCount) + " " + pSong->GetDisplayFullTitle();
 						if( sTitle.length() > 22 )
-							sTitle = sTitle.Left(20) + "...";
+							sTitle = head(sTitle, 20) + "...";
 						s += sTitle + "\n";
 						iSongIndex++;
 					}

--- a/src/ScreenBookkeeping.cpp
+++ b/src/ScreenBookkeeping.cpp
@@ -156,7 +156,7 @@ void ScreenBookkeeping::UpdateView()
 				iCount += pProfile->GetSongNumTimesPlayed( pSong );
 				vpSongs.push_back( pSong );
 			}
-			m_textTitle.SetText( ssprintf(SONG_PLAYS.GetValue(), iCount) );
+			m_textTitle.SetText( fmt::sprintf(SONG_PLAYS.GetValue(), iCount) );
 			SongUtil::SortSongPointerArrayByNumPlays( vpSongs, pProfile, true );
 
 			const int iSongPerCol = 15;
@@ -185,7 +185,7 @@ void ScreenBookkeeping::UpdateView()
 		break;
 	case BookkeepingView_LastDays:
 		{
-			m_textTitle.SetText( ssprintf(LAST_DAYS.GetValue(), NUM_LAST_DAYS) );
+			m_textTitle.SetText( fmt::sprintf(LAST_DAYS.GetValue(), NUM_LAST_DAYS) );
 
 			int coins[NUM_LAST_DAYS];
 			BOOKKEEPER->GetCoinsLastDays( coins );
@@ -212,7 +212,7 @@ void ScreenBookkeeping::UpdateView()
 		break;
 	case BookkeepingView_LastWeeks:
 		{
-			m_textTitle.SetText( ssprintf(LAST_WEEKS.GetValue(), NUM_LAST_WEEKS) );
+			m_textTitle.SetText( fmt::sprintf(LAST_WEEKS.GetValue(), NUM_LAST_WEEKS) );
 
 			int coins[NUM_LAST_WEEKS];
 			BOOKKEEPER->GetCoinsLastWeeks( coins );

--- a/src/ScreenDebugOverlay.cpp
+++ b/src/ScreenDebugOverlay.cpp
@@ -155,7 +155,7 @@ static RString GetDebugButtonName( const IDebugLine *pLine )
 	case IDebugLine::all_screens:
 		return s;
 	case IDebugLine::gameplay_only:
-		return ssprintf( IN_GAMEPLAY.GetValue(), s.c_str() );
+		return fmt::sprintf( IN_GAMEPLAY.GetValue(), s.c_str() );
 	default:
 		FAIL_M(ssprintf("Invalid debug line type: %i", type));
 	}

--- a/src/ScreenEdit.cpp
+++ b/src/ScreenEdit.cpp
@@ -1866,11 +1866,11 @@ void ScreenEdit::UpdateTextInfo()
 
 	m_bTextInfoNeedsUpdate = false;
 
-	RString sNoteType = ssprintf( NOTES.GetValue(), NoteTypeToLocalizedString(m_SnapDisplay.GetNoteType()).c_str() );
+  RString sNoteType = fmt::sprintf( NOTES.GetValue(), NoteTypeToLocalizedString(m_SnapDisplay.GetNoteType()).c_str() );
 
 	RString sText;
-	sText += ssprintf( CURRENT_BEAT_FORMAT.GetValue(), CURRENT_BEAT.GetValue().c_str(), GetBeat() );
-	sText += ssprintf( CURRENT_SECOND_FORMAT.GetValue(), CURRENT_SECOND.GetValue().c_str(), GetAppropriateTiming().GetElapsedTimeFromBeat(GetBeat()) );
+  sText += fmt::sprintf( CURRENT_BEAT_FORMAT.GetValue(), CURRENT_BEAT.GetValue().c_str(), GetBeat() );
+	sText += fmt::sprintf( CURRENT_SECOND_FORMAT.GetValue(), CURRENT_SECOND.GetValue().c_str(), GetAppropriateTiming().GetElapsedTimeFromBeat(GetBeat()) );
 	switch( EDIT_MODE.GetValue() )
 	{
 	DEFAULT_FAIL( EDIT_MODE.GetValue() );
@@ -1879,35 +1879,35 @@ void ScreenEdit::UpdateTextInfo()
 	case EditMode_CourseMods:
 	case EditMode_Home:
 	case EditMode_Full:
-		sText += ssprintf( SNAP_TO_FORMAT.GetValue(), SNAP_TO.GetValue().c_str(), sNoteType.c_str() );
+		sText += fmt::sprintf( SNAP_TO_FORMAT.GetValue(), SNAP_TO.GetValue().c_str(), sNoteType.c_str() );
 		break;
 	}
 
 	if( m_NoteFieldEdit.m_iBeginMarker != -1 )
 	{
-		sText += ssprintf( SELECTION_BEAT_BEGIN_FORMAT.GetValue(), SELECTION_BEAT.GetValue().c_str(), NoteRowToBeat(m_NoteFieldEdit.m_iBeginMarker) );
+		sText += fmt::sprintf( SELECTION_BEAT_BEGIN_FORMAT.GetValue(), SELECTION_BEAT.GetValue().c_str(), NoteRowToBeat(m_NoteFieldEdit.m_iBeginMarker) );
 
 		if( m_NoteFieldEdit.m_iEndMarker != -1 )
-			sText += ssprintf( SELECTION_BEAT_END_FORMAT.GetValue(), NoteRowToBeat(m_NoteFieldEdit.m_iEndMarker) );
+			sText += fmt::sprintf( SELECTION_BEAT_END_FORMAT.GetValue(), NoteRowToBeat(m_NoteFieldEdit.m_iEndMarker) );
 		else
 			sText += SELECTION_BEAT_UNFINISHED_FORMAT;
 	}
 
 	if (EDIT_MODE.GetValue() == EditMode_Full)
 	{
-		sText += ssprintf( DIFFICULTY_FORMAT.GetValue(), DIFFICULTY.GetValue().c_str(), DifficultyToString( m_pSteps->GetDifficulty() ).c_str() );
+		sText += fmt::sprintf( DIFFICULTY_FORMAT.GetValue(), DIFFICULTY.GetValue().c_str(), DifficultyToString( m_pSteps->GetDifficulty() ).c_str() );
 		if ( m_InputPlayerNumber != PLAYER_INVALID )
-			sText += ssprintf( ROUTINE_PLAYER_FORMAT.GetValue(), ROUTINE_PLAYER.GetValue().c_str(), m_InputPlayerNumber + 1 );
-		//sText += ssprintf( DESCRIPTION_FORMAT.GetValue(), DESCRIPTION.GetValue().c_str(), m_pSteps->GetDescription().c_str() );
-		sText += ssprintf( CHART_NAME_FORMAT.GetValue(), CHART_NAME.GetValue().c_str(), m_pSteps->GetChartName().c_str() );
-		sText += ssprintf( STEP_AUTHOR_FORMAT.GetValue(), STEP_AUTHOR.GetValue().c_str(), m_pSteps->GetCredit().c_str() );
-		//sText += ssprintf( CHART_STYLE_FORMAT.GetValue(), CHART_STYLE.GetValue().c_str(), m_pSteps->GetChartStyle().c_str() );
-		sText += ssprintf( MAIN_TITLE_FORMAT.GetValue(), MAIN_TITLE.GetValue().c_str(), m_pSong->m_sMainTitle.c_str() );
+			sText += fmt::sprintf( ROUTINE_PLAYER_FORMAT.GetValue(), ROUTINE_PLAYER.GetValue().c_str(), m_InputPlayerNumber + 1 );
+		//sText += fmt::sprintf( DESCRIPTION_FORMAT.GetValue(), DESCRIPTION.GetValue().c_str(), m_pSteps->GetDescription().c_str() );
+		sText += fmt::sprintf( CHART_NAME_FORMAT.GetValue(), CHART_NAME.GetValue().c_str(), m_pSteps->GetChartName().c_str() );
+		sText += fmt::sprintf( STEP_AUTHOR_FORMAT.GetValue(), STEP_AUTHOR.GetValue().c_str(), m_pSteps->GetCredit().c_str() );
+		//sText += fmt::sprintf( CHART_STYLE_FORMAT.GetValue(), CHART_STYLE.GetValue().c_str(), m_pSteps->GetChartStyle().c_str() );
+		sText += fmt::sprintf( MAIN_TITLE_FORMAT.GetValue(), MAIN_TITLE.GetValue().c_str(), m_pSong->m_sMainTitle.c_str() );
 		if( m_pSong->m_sSubTitle.size() )
-			sText += ssprintf( SUBTITLE_FORMAT.GetValue(), SUBTITLE.GetValue().c_str(), m_pSong->m_sSubTitle.c_str() );
-		sText += ssprintf( SEGMENT_TYPE_FORMAT.GetValue(), SEGMENT_TYPE.GetValue().c_str(), TimingSegmentTypeToString(currentCycleSegment).c_str() );
+			sText += fmt::sprintf( SUBTITLE_FORMAT.GetValue(), SUBTITLE.GetValue().c_str(), m_pSong->m_sSubTitle.c_str() );
+		sText += fmt::sprintf( SEGMENT_TYPE_FORMAT.GetValue(), SEGMENT_TYPE.GetValue().c_str(), TimingSegmentTypeToString(currentCycleSegment).c_str() );
         const RString tapnoteType = TapNoteTypeToString( m_selectedTap.type );
-		sText += ssprintf( TAP_NOTE_TYPE_FORMAT.GetValue(), TAP_NOTE_TYPE.GetValue().c_str(), tapnoteType.c_str() );
+		sText += fmt::sprintf( TAP_NOTE_TYPE_FORMAT.GetValue(), TAP_NOTE_TYPE.GetValue().c_str(), tapnoteType.c_str() );
 
 		AttackArray &attacks =
 			(GAMESTATE->m_bIsUsingStepTiming ? m_pSteps->m_Attacks : m_pSong->m_Attacks);
@@ -1920,48 +1920,48 @@ void ScreenEdit::UpdateTextInfo()
 	if (cat == StepsTypeCategory_Couple || cat == StepsTypeCategory_Routine)
 	{
 		std::pair<int, int> tmp = m_NoteDataEdit.GetNumTapNotesTwoPlayer();
-		sText += ssprintf(NUM_STEPS_FORMAT_TWO_PLAYER.GetValue(),
+		sText += fmt::sprintf(NUM_STEPS_FORMAT_TWO_PLAYER.GetValue(),
 						  TAP_STEPS.GetValue().c_str(),
 						  tmp.first, tmp.second);
 		tmp = m_NoteDataEdit.GetNumJumpsTwoPlayer();
-		sText += ssprintf(NUM_JUMPS_FORMAT_TWO_PLAYER.GetValue(),
+		sText += fmt::sprintf(NUM_JUMPS_FORMAT_TWO_PLAYER.GetValue(),
 						  JUMPS.GetValue().c_str(),
 						  tmp.first, tmp.second);
 		tmp = m_NoteDataEdit.GetNumHandsTwoPlayer();
-		sText += ssprintf(NUM_HANDS_FORMAT_TWO_PLAYER.GetValue(),
+		sText += fmt::sprintf(NUM_HANDS_FORMAT_TWO_PLAYER.GetValue(),
 						  HANDS.GetValue().c_str(),
 						  tmp.first, tmp.second);
 		tmp = m_NoteDataEdit.GetNumHoldNotesTwoPlayer();
-		sText += ssprintf(NUM_HOLDS_FORMAT_TWO_PLAYER.GetValue(),
+		sText += fmt::sprintf(NUM_HOLDS_FORMAT_TWO_PLAYER.GetValue(),
 						  HOLDS.GetValue().c_str(),
 						  tmp.first, tmp.second);
 		tmp = m_NoteDataEdit.GetNumMinesTwoPlayer();
-		sText += ssprintf(NUM_MINES_FORMAT_TWO_PLAYER.GetValue(),
+		sText += fmt::sprintf(NUM_MINES_FORMAT_TWO_PLAYER.GetValue(),
 						  MINES.GetValue().c_str(),
 						  tmp.first, tmp.second);
 		tmp = m_NoteDataEdit.GetNumRollsTwoPlayer();
-		sText += ssprintf(NUM_ROLLS_FORMAT_TWO_PLAYER.GetValue(),
+		sText += fmt::sprintf(NUM_ROLLS_FORMAT_TWO_PLAYER.GetValue(),
 						  ROLLS.GetValue().c_str(),
 						  tmp.first, tmp.second);
 		tmp = m_NoteDataEdit.GetNumLiftsTwoPlayer();
-		sText += ssprintf(NUM_LIFTS_FORMAT_TWO_PLAYER.GetValue(),
+		sText += fmt::sprintf(NUM_LIFTS_FORMAT_TWO_PLAYER.GetValue(),
 						  LIFTS.GetValue().c_str(),
 						  tmp.first, tmp.second);
 		tmp = m_NoteDataEdit.GetNumFakesTwoPlayer();
-		sText += ssprintf(NUM_FAKES_FORMAT_TWO_PLAYER.GetValue(),
+		sText += fmt::sprintf(NUM_FAKES_FORMAT_TWO_PLAYER.GetValue(),
 						  FAKES.GetValue().c_str(),
 						  tmp.first, tmp.second);
 	}
 	else
 	{
-		sText += ssprintf( NUM_STEPS_FORMAT.GetValue(), TAP_STEPS.GetValue().c_str(), m_NoteDataEdit.GetNumTapNotes() );
-		sText += ssprintf( NUM_JUMPS_FORMAT.GetValue(), JUMPS.GetValue().c_str(), m_NoteDataEdit.GetNumJumps() );
-		sText += ssprintf( NUM_HANDS_FORMAT.GetValue(), HANDS.GetValue().c_str(), m_NoteDataEdit.GetNumHands() );
-		sText += ssprintf( NUM_HOLDS_FORMAT.GetValue(), HOLDS.GetValue().c_str(), m_NoteDataEdit.GetNumHoldNotes() );
-		sText += ssprintf( NUM_MINES_FORMAT.GetValue(), MINES.GetValue().c_str(), m_NoteDataEdit.GetNumMines() );
-		sText += ssprintf( NUM_ROLLS_FORMAT.GetValue(), ROLLS.GetValue().c_str(), m_NoteDataEdit.GetNumRolls() );
-		sText += ssprintf( NUM_LIFTS_FORMAT.GetValue(), LIFTS.GetValue().c_str(), m_NoteDataEdit.GetNumLifts() );
-		sText += ssprintf( NUM_FAKES_FORMAT.GetValue(), FAKES.GetValue().c_str(), m_NoteDataEdit.GetNumFakes() );
+		sText += fmt::sprintf( NUM_STEPS_FORMAT.GetValue(), TAP_STEPS.GetValue().c_str(), m_NoteDataEdit.GetNumTapNotes() );
+		sText += fmt::sprintf( NUM_JUMPS_FORMAT.GetValue(), JUMPS.GetValue().c_str(), m_NoteDataEdit.GetNumJumps() );
+		sText += fmt::sprintf( NUM_HANDS_FORMAT.GetValue(), HANDS.GetValue().c_str(), m_NoteDataEdit.GetNumHands() );
+		sText += fmt::sprintf( NUM_HOLDS_FORMAT.GetValue(), HOLDS.GetValue().c_str(), m_NoteDataEdit.GetNumHoldNotes() );
+		sText += fmt::sprintf( NUM_MINES_FORMAT.GetValue(), MINES.GetValue().c_str(), m_NoteDataEdit.GetNumMines() );
+		sText += fmt::sprintf( NUM_ROLLS_FORMAT.GetValue(), ROLLS.GetValue().c_str(), m_NoteDataEdit.GetNumRolls() );
+		sText += fmt::sprintf( NUM_LIFTS_FORMAT.GetValue(), LIFTS.GetValue().c_str(), m_NoteDataEdit.GetNumLifts() );
+		sText += fmt::sprintf( NUM_FAKES_FORMAT.GetValue(), FAKES.GetValue().c_str(), m_NoteDataEdit.GetNumFakes() );
 	}
 	switch( EDIT_MODE.GetValue() )
 	{
@@ -1971,20 +1971,20 @@ void ScreenEdit::UpdateTextInfo()
 	case EditMode_Home:
 		break;
 	case EditMode_Full:
-		sText += ssprintf( TIMING_MODE_FORMAT.GetValue(),
+		sText += fmt::sprintf( TIMING_MODE_FORMAT.GetValue(),
 				  TIMING_MODE.GetValue().c_str(),
 				  ( GAMESTATE->m_bIsUsingStepTiming ?
 				   STEP_TIMING.GetValue().c_str() :
 				   SONG_TIMING.GetValue().c_str() ) );
-		sText += ssprintf( BEAT_0_OFFSET_FORMAT.GetValue(),
+		sText += fmt::sprintf( BEAT_0_OFFSET_FORMAT.GetValue(),
 				  BEAT_0_OFFSET.GetValue().c_str(),
 				  GetAppropriateTiming().m_fBeat0OffsetInSeconds );
-		sText += ssprintf( PREVIEW_START_FORMAT.GetValue(), PREVIEW_START.GetValue().c_str(), m_pSong->m_fMusicSampleStartSeconds );
-		sText += ssprintf( PREVIEW_LENGTH_FORMAT.GetValue(), PREVIEW_LENGTH.GetValue().c_str(), m_pSong->m_fMusicSampleLengthSeconds );
+		sText += fmt::sprintf( PREVIEW_START_FORMAT.GetValue(), PREVIEW_START.GetValue().c_str(), m_pSong->m_fMusicSampleStartSeconds );
+		sText += fmt::sprintf( PREVIEW_LENGTH_FORMAT.GetValue(), PREVIEW_LENGTH.GetValue().c_str(), m_pSong->m_fMusicSampleLengthSeconds );
 		if(record_hold_seconds < record_hold_default - .001f ||
 			record_hold_seconds > record_hold_default + .001f)
 		{
-			sText += ssprintf(RECORD_HOLD_TIME_FORMAT.GetValue(), RECORD_HOLD_TIME.GetValue().c_str(), record_hold_seconds);
+			sText += fmt::sprintf(RECORD_HOLD_TIME_FORMAT.GetValue(), RECORD_HOLD_TIME.GetValue().c_str(), record_hold_seconds);
 		}
 		break;
 	}
@@ -2476,7 +2476,7 @@ bool ScreenEdit::InputEdit( const InputEventPlus &input, EditButton EditB )
 			m_pSteps = pSteps;
 			pSteps->GetNoteData( m_NoteDataEdit );
 
-			RString s = ssprintf(
+			RString s = fmt::sprintf(
 				SWITCHED_TO.GetValue() + " %s %s '%s' (%d of %d)",
 				GAMEMAN->GetStepsTypeInfo( st ).szName,
 				DifficultyToString( pSteps->GetDifficulty() ).c_str(),
@@ -5022,12 +5022,12 @@ static bool ConvertMappingInputToMapping(RString const& mapstr, int* mapping, RS
 		}
 		else if(!(mapping_input[track] >> mapping[track]))
 		{
-			error= ssprintf(NOT_A_TRACK.GetValue(), mapping_input[track].c_str());
+			error= fmt::sprintf(NOT_A_TRACK.GetValue(), mapping_input[track].c_str());
 			return false;
 		}
 		if(mapping[track] < 1 || mapping[track] > static_cast<int>(tracks_for_type))
 		{
-			error= ssprintf(OUT_OF_RANGE_ID.GetValue(), track+1, mapping[track], tracks_for_type);
+			error= fmt::sprintf(OUT_OF_RANGE_ID.GetValue(), track+1, mapping[track], tracks_for_type);
 			return false;
 		}
 		// Simpler for the user if they input track ids starting at 1.
@@ -5113,7 +5113,7 @@ void ScreenEdit::HandleAlterMenuChoice(AlterMenuChoice c, const vector<int> &ans
 				m_NoteFieldEdit.m_iBeginMarker, m_NoteFieldEdit.m_iEndMarker);
 			if(note_count >= PREFSMAN->m_EditClearPromptThreshold && prompt_clear)
 			{
-				ScreenPrompt::Prompt(SM_ConfirmClearArea, ssprintf(CONFIRM_CLEAR.GetValue(), note_count), PROMPT_YES_NO);
+				ScreenPrompt::Prompt(SM_ConfirmClearArea, fmt::sprintf(CONFIRM_CLEAR.GetValue(), note_count), PROMPT_YES_NO);
 			}
 			else
 			{
@@ -6490,7 +6490,7 @@ void ScreenEdit::DoKeyboardTrackMenu()
 			++foundKeysounds;
 		}
 
-		g_KeysoundTrack.rows.push_back(MenuRowDef(i, ssprintf(TRACK_NUM.GetValue(), i + 1),
+		g_KeysoundTrack.rows.push_back(MenuRowDef(i, fmt::sprintf(TRACK_NUM.GetValue(), i + 1),
 												  true, EditMode_Full, false, false, keyIndex, choices));
 	}
 	g_KeysoundTrack.rows.push_back(MenuRowDef(m_NoteDataEdit.GetNumTracks(), "Remove Keysound",
@@ -6517,7 +6517,7 @@ void ScreenEdit::DoHelp()
 			continue;
 		}
 
-		g_EditHelp.rows.push_back( MenuRowDef( -1, sDescription, false, EditMode_Practice, false, false, 0, sButtons ) );
+		g_EditHelp.rows.push_back( MenuRowDef( -1, sDescription.c_str(), false, EditMode_Practice, false, false, 0, sButtons.c_str() ) );
 	}
 
 	EditMiniMenu( &g_EditHelp );

--- a/src/ScreenEdit.cpp
+++ b/src/ScreenEdit.cpp
@@ -3753,8 +3753,8 @@ void ScreenEdit::HandleScreenMessage( const ScreenMessage SM )
 		if ( !GetAppropriateTiming().DoesLabelExist(sLabel) )
 		{
 			// XXX: these should be in the NotesWriters where they're needed.
-			sLabel.Replace("=", "_");
-			sLabel.Replace(",", "_");
+			std::replace(sLabel.begin(), sLabel.end(), '=', '_');
+			std::replace(sLabel.begin(), sLabel.end(), ',', '_');
 			GetAppropriateTimingForUpdate().AddSegment( LabelSegment(GetRow(), sLabel) );
 			SetDirty( true );
 		}
@@ -6374,7 +6374,7 @@ static bool IsMapped( EditButton eb, const MapEditToDI &editmap )
 
 static void ProcessKeyName( RString &s )
 {
-	s.Replace( "Key_", "" );
+	ReplaceAll(s, "Key_", "");
 }
 
 static void ProcessKeyNames( vector<RString> &vs, bool doSort )

--- a/src/ScreenEvaluation.cpp
+++ b/src/ScreenEvaluation.cpp
@@ -576,7 +576,7 @@ void ScreenEvaluation::Init()
 
 				// todo: check if format string is valid
 				// (two integer values in DETAILLINE_FORMAT) -aj
-				m_textDetailText[l][p].SetText( ssprintf(DETAILLINE_FORMAT,iActual,iPossible) );
+				m_textDetailText[l][p].SetText( fmt::sprintf(DETAILLINE_FORMAT,iActual,iPossible) );
 			}
 		}
 	}

--- a/src/ScreenGameplay.cpp
+++ b/src/ScreenGameplay.cpp
@@ -2977,7 +2977,19 @@ void ScreenGameplay::HandleScreenMessage( const ScreenMessage SM )
 	}
 	else if( SM >= SM_BattleTrickLevel1 && SM <= SM_BattleTrickLevel3 )
 	{
-		int iTrickLevel = SM-SM_BattleTrickLevel1+1;
+		int iTrickLevel;
+		if (SM == SM_BattleTrickLevel1)
+		{
+			iTrickLevel = 1;
+		}
+		else if (SM == SM_BattleTrickLevel2)
+		{
+			iTrickLevel = 2;
+		}
+		else
+		{
+			iTrickLevel = 3;
+		}
 		PlayAnnouncer( ssprintf("gameplay battle trick level%d",iTrickLevel), 3 );
 		if( SM == SM_BattleTrickLevel1 ) m_soundBattleTrickLevel1.Play(false);
 		else if( SM == SM_BattleTrickLevel2 ) m_soundBattleTrickLevel2.Play(false);
@@ -2985,7 +2997,19 @@ void ScreenGameplay::HandleScreenMessage( const ScreenMessage SM )
 	}
 	else if( SM >= SM_BattleDamageLevel1 && SM <= SM_BattleDamageLevel3 )
 	{
-		int iDamageLevel = SM-SM_BattleDamageLevel1+1;
+		int iDamageLevel;
+		if (SM == SM_BattleDamageLevel1)
+		{
+			iDamageLevel = 1;
+		}
+		else if (SM == SM_BattleDamageLevel2)
+		{
+			iDamageLevel = 2;
+		}
+		else
+		{
+			iDamageLevel = 3;
+		}
 		PlayAnnouncer( ssprintf("gameplay battle damage level%d",iDamageLevel), 3 );
 	}
 	else if( SM == SM_DoPrevScreen )

--- a/src/ScreenGameplay.cpp
+++ b/src/ScreenGameplay.cpp
@@ -1183,7 +1183,7 @@ void ScreenGameplay::LoadNextSong()
 	{
 		pi->GetPlayerStageStats()->m_iSongsPlayed++;
 		if( pi->m_ptextCourseSongNumber )
-			pi->m_ptextCourseSongNumber->SetText( ssprintf(SONG_NUMBER_FORMAT.GetValue(), pi->GetPlayerStageStats()->m_iSongsPassed+1) );
+			pi->m_ptextCourseSongNumber->SetText( fmt::sprintf(SONG_NUMBER_FORMAT.GetValue(), pi->GetPlayerStageStats()->m_iSongsPassed+1) );
 	}
 
 	if( GAMESTATE->m_bMultiplayer )

--- a/src/ScreenGameplay.cpp
+++ b/src/ScreenGameplay.cpp
@@ -1435,7 +1435,8 @@ void ScreenGameplay::LoadLights()
 	Difficulty d1 = Difficulty_Invalid;
 	if( asDifficulties.size() > 0 )
 	{
-		if( asDifficulties[0].CompareNoCase("selected") == 0 )
+		ci_string ciDiff(asDifficulties[0].c_str());
+		if (ciDiff == "selected")
 		{
 			// Base lights off current difficulty of active player
 			// Can be either P1 or P2 if they're individual or P1 if both are active

--- a/src/ScreenGameplaySyncMachine.cpp
+++ b/src/ScreenGameplaySyncMachine.cpp
@@ -27,7 +27,7 @@ void ScreenGameplaySyncMachine::Init()
 	// Allow themers to use either a .ssc or .sm file for this. -aj
 	SSCLoader loaderSSC;
 	SMLoader loaderSM;
-	if(sFile.Right(4) == ".ssc")
+	if(EndsWith(sFile, ".ssc"))
 		loaderSSC.LoadFromSimfile( sFile, m_Song );
 	else
 		loaderSM.LoadFromSimfile( sFile, m_Song );

--- a/src/ScreenHighScores.cpp
+++ b/src/ScreenHighScores.cpp
@@ -151,7 +151,7 @@ void ScoreScroller::ConfigureActor( Actor *pActor, int iItem )
 		}
 		// Because pSteps or pTrail can be NULL, what we're creating in Lua is not an array.
 		// It must be iterated using pairs(), not ipairs().
-		lua_setfield( L, -2, ssprintf("%d",i+1) );
+		lua_setfield( L, -2, fmt::sprintf("%d",i+1).c_str() );
 	}
 	lua_pop( L, 1 );
 	LUA->Release( L );

--- a/src/ScreenHowToPlay.cpp
+++ b/src/ScreenHowToPlay.cpp
@@ -142,7 +142,7 @@ void ScreenHowToPlay::Init()
 		RString sStepsPath = THEME->GetPathO(m_sName, "steps");
 		SSCLoader loaderSSC;
 		SMLoader loaderSM;
-		if( sStepsPath.Right(4) == ".ssc" )
+		if( EndsWith(sStepsPath, ".ssc") )
 			loaderSSC.LoadFromSimfile( sStepsPath, m_Song, false );
 		else
 			loaderSM.LoadFromSimfile( sStepsPath, m_Song, false );

--- a/src/ScreenInstallOverlay.cpp
+++ b/src/ScreenInstallOverlay.cpp
@@ -50,10 +50,15 @@ static void Parse( const RString &sDir, PlayAfterLaunchInfo &out )
 {
 	vector<RString> vsDirParts;
 	split( sDir, "/", vsDirParts, true );
-	if( vsDirParts.size() == 3 && vsDirParts[0].EqualsNoCase("Songs") )
+	ci_string dirPart(vsDirParts[0].c_str());
+	if( vsDirParts.size() == 3 && dirPart == "Songs" )
+	{
 		out.sSongDir = "/" + sDir;
-	else if( vsDirParts.size() == 2 && vsDirParts[0].EqualsNoCase("Themes") )
+	}
+	else if( vsDirParts.size() == 2 && dirPart == "Themes" )
+	{
 		out.sTheme = vsDirParts[1];
+	}
 }
 
 static const RString TEMP_ZIP_MOUNT_POINT = "/@temp-zip/";
@@ -70,11 +75,13 @@ static void InstallSmzip( const RString &sZipFile, PlayAfterLaunchInfo &out )
 		GetDirListingRecursive( TEMP_ZIP_MOUNT_POINT, "*", vsRawFiles);
 
 		vector<RString> vsPrettyFiles;
+		ci_string ctl("ctl");
 		for (auto const &s: vsRawFiles)
 		{
-			if( GetExtension(s).EqualsNoCase("ctl") )
+			if ( ctl == GetExtension(s).c_str() )
+			{
 				continue;
-
+			}
 			vsFiles.push_back(s);
 
 			RString s2 = tail(s, s.length() - TEMP_ZIP_MOUNT_POINT.length() );
@@ -287,8 +294,8 @@ static bool IsStepManiaProtocol(const RString &arg)
 
 static bool IsPackageFile(const RString &arg)
 {
-	RString ext = GetExtension(arg);
-	return ext.EqualsNoCase("smzip") || ext.EqualsNoCase("zip");
+	ci_string ext = GetExtension(arg).c_str();
+	return ext == "smzip" || ext == "zip";
 }
 
 PlayAfterLaunchInfo DoInstalls( CommandLineActions::CommandLineArgs args )

--- a/src/ScreenInstallOverlay.cpp
+++ b/src/ScreenInstallOverlay.cpp
@@ -77,7 +77,7 @@ static void InstallSmzip( const RString &sZipFile, PlayAfterLaunchInfo &out )
 
 			vsFiles.push_back(s);
 
-			RString s2 = s.Right( s.length() - TEMP_ZIP_MOUNT_POINT.length() );
+			RString s2 = tail(s, s.length() - TEMP_ZIP_MOUNT_POINT.length() );
 			vsPrettyFiles.push_back( s2 );
 		}
 		sort( vsPrettyFiles.begin(), vsPrettyFiles.end() );
@@ -87,7 +87,7 @@ static void InstallSmzip( const RString &sZipFile, PlayAfterLaunchInfo &out )
 	for (auto sSrcFile: vsFiles)
 	{
 		RString sDestFile = sSrcFile;
-		sDestFile = sDestFile.Right( sDestFile.length() - TEMP_ZIP_MOUNT_POINT.length() );
+		sDestFile = tail(sDestFile, sDestFile.length() - TEMP_ZIP_MOUNT_POINT.length() );
 
 		RString sDir, sThrowAway;
 		splitpath( sDestFile, sDir, sThrowAway, sThrowAway );

--- a/src/ScreenJukebox.cpp
+++ b/src/ScreenJukebox.cpp
@@ -129,8 +129,7 @@ void ScreenJukebox::SetSong()
 						aAttacks.push_back( Attack::FromGlobalCourseModifier( pEntry->sModifiers ) );
 					for (auto const &a: aAttacks)
 					{
-						RString s = a.sModifiers;
-						s.MakeLower();
+						RString s = MakeLower(a.sModifiers);
 						// todo: allow themers to modify this list? -aj
 						if( s.find("dark") != string::npos ||
 							s.find("stealth") != string::npos )

--- a/src/ScreenMapControllers.cpp
+++ b/src/ScreenMapControllers.cpp
@@ -94,7 +94,7 @@ void ScreenMapControllers::Init()
 			text.LoadFromFont( THEME->GetPathF(m_sName,"title") );
 			PlayerNumber pn = (PlayerNumber)c;
 			text.SetName( "Label"+PlayerNumberToString(pn) );
-			RString sText = ssprintf(PLAYER_SLOTS.GetValue(), PlayerNumberToLocalizedString(pn).c_str());
+			RString sText = fmt::sprintf(PLAYER_SLOTS.GetValue(), PlayerNumberToLocalizedString(pn).c_str());
 			text.SetText( sText );
 			ActorUtil::LoadAllCommands( text, m_sName );
 			m_Line.back()->AddChild( &m_textLabel[c] );

--- a/src/ScreenMapControllers.cpp
+++ b/src/ScreenMapControllers.cpp
@@ -806,8 +806,7 @@ void ScreenMapControllers::ActionRow::Load(RString const& scr_name,
 	ActorFrame* line, ActorScroller* scroller)
 {
 	m_action= action;
-	RString lower_name= name;
-	lower_name.MakeLower();
+	RString lower_name = MakeLower(name);
 	// Make the specific actor optional, use a fallback if it doesn't exist.
 	RString path= THEME->GetPathG(scr_name, lower_name, true);
 	if(path.empty())

--- a/src/ScreenNetSelectBase.cpp
+++ b/src/ScreenNetSelectBase.cpp
@@ -236,8 +236,8 @@ void ColorBitmapText::SetText( const RString& _sText, const RString& _sAlternate
 
 		if( m_sText.length() > 8 && i < m_sText.length() - 9 )
 		{
-			RString FirstThree = m_sText.substr( i, 3 );
-			if( FirstThree.CompareNoCase("|c0") == 0 && iCharsLeft > 8 )
+			ci_string firstThree = m_sText.substr( i, 3 ).c_str();
+			if( firstThree == "|c0" && iCharsLeft > 8 )
 			{
 				ColorChange cChange;
 				unsigned int r, g, b;

--- a/src/ScreenNetSelectMusic.cpp
+++ b/src/ScreenNetSelectMusic.cpp
@@ -160,39 +160,38 @@ void ScreenNetSelectMusic::HandleScreenMessage( const ScreenMessage SM )
 		// First check to see if this song is already selected. This is so that if
 		// you have multiple copies of the "same" song you can chose which copy to play.
 		Song* CurSong = m_MusicWheel.GetSelectedSong();
-
+		ci_string ciTitle(NSMAN->m_sMainTitle.c_str());
+		ci_string ciSubTitle(NSMAN->m_sSubTitle.c_str());
+		ci_string ciArtist(NSMAN->m_sArtist.c_str());
 		if(CurSong != NULL )
-
-			if( ( !CurSong->GetTranslitArtist().CompareNoCase( NSMAN->m_sArtist ) ) &&
-					( !CurSong->GetTranslitMainTitle().CompareNoCase( NSMAN->m_sMainTitle ) ) &&
-					( !CurSong->GetTranslitSubTitle().CompareNoCase( NSMAN->m_sSubTitle ) ) )
 		{
-			switch ( NSMAN->m_iSelectMode )
+			if (ciTitle == CurSong->GetTranslitMainTitle().c_str() &&
+				ciSubTitle == CurSong->GetTranslitSubTitle().c_str() &&
+				ciArtist == CurSong->GetTranslitArtist().c_str())
 			{
-			case 0:
-			case 1:
-				NSMAN->m_iSelectMode = 0;
-				NSMAN->SelectUserSong();
-				break;
-			case 2:	// Proper starting of song
-			case 3:	// Blind starting of song
-				StartSelectedSong();
-				goto done;
+				switch ( NSMAN->m_iSelectMode )
+				{
+				case 0:
+				case 1:
+					NSMAN->m_iSelectMode = 0;
+					NSMAN->SelectUserSong();
+					break;
+				case 2:	// Proper starting of song
+				case 3:	// Blind starting of song
+					StartSelectedSong();
+					goto done;
+				}
 			}
 		}
 
 		vector <Song *> AllSongs = SONGMAN->GetAllSongs();
-		unsigned i;
-		for( i=0; i < AllSongs.size(); i++ )
-		{
-			m_cSong = AllSongs[i];
-			if( ( !m_cSong->GetTranslitArtist().CompareNoCase( NSMAN->m_sArtist ) ) &&
-					( !m_cSong->GetTranslitMainTitle().CompareNoCase( NSMAN->m_sMainTitle ) ) &&
-					( !m_cSong->GetTranslitSubTitle().CompareNoCase( NSMAN->m_sSubTitle ) ) )
-					break;
-		}
-
-		bool haveSong = i != AllSongs.size();
+		
+		auto doesSongExist = [&ciTitle, &ciSubTitle, &ciArtist] (Song const *song) {
+			return ciTitle == song->GetTranslitMainTitle().c_str() &&
+			ciSubTitle == song->GetTranslitSubTitle().c_str() &&
+			ciArtist == song->GetTranslitArtist().c_str();
+		};
+		bool haveSong = std::any_of(AllSongs.begin(), AllSongs.end(), doesSongExist);
 
 		switch (NSMAN->m_iSelectMode)
 		{
@@ -546,7 +545,8 @@ void ScreenNetSelectMusic::MusicChanged()
 	if( GAMESTATE->m_pCurSong->HasMusic() )
 	{
 		// don't play the same sound over and over
-		if(SOUND->GetMusicPath().CompareNoCase(GAMESTATE->m_pCurSong->GetMusicPath()))
+		ci_string ciSoundPath(SOUND->GetMusicPath().c_str());
+		if (ciSoundPath != GAMESTATE->m_pCurSong->GetMusicPath().c_str())
 		{
 			SOUND->StopMusic();
 			SOUND->PlayMusic(

--- a/src/ScreenOptions.cpp
+++ b/src/ScreenOptions.cpp
@@ -298,7 +298,7 @@ void ScreenOptions::RestartOptions()
 	}
 
 
-	CHECKPOINT;
+	CHECKPOINT_M("Finalizing the resetting.");
 
 	PositionRows( false );
 	FOREACH_HumanPlayer( pn )
@@ -312,7 +312,7 @@ void ScreenOptions::RestartOptions()
 	{
 		AfterChangeRow( p );
 	}
-	CHECKPOINT;
+	CHECKPOINT_M("Resetting done.");
 }
 
 void ScreenOptions::BeginScreen()

--- a/src/ScreenOptionsCourseOverview.cpp
+++ b/src/ScreenOptionsCourseOverview.cpp
@@ -167,7 +167,7 @@ void ScreenOptionsCourseOverview::HandleScreenMessage( const ScreenMessage SM )
 		{
 			if( !EditCourseUtil::RemoveAndDeleteFile(GAMESTATE->m_pCurCourse) )
 			{
-				ScreenPrompt::Prompt( SM_None, ssprintf(ERROR_DELETING_FILE.GetValue(), GAMESTATE->m_pCurCourse->m_sPath.c_str()) );
+				ScreenPrompt::Prompt( SM_None, fmt::sprintf(ERROR_DELETING_FILE.GetValue(), GAMESTATE->m_pCurCourse->m_sPath.c_str()) );
 				return;
 			}
 

--- a/src/ScreenOptionsEditCourse.cpp
+++ b/src/ScreenOptionsEditCourse.cpp
@@ -202,12 +202,12 @@ void ScreenOptionsEditCourse::BeginScreen()
 	for( int i=0; i<NUM_SONG_ROWS; i++ )
 	{
 		{
-			MenuRowDef mrd = MenuRowDef( -1, "---", true, EditMode_Practice, true, false, 0, EMPTY.GetValue() );
+			MenuRowDef mrd = MenuRowDef( -1, "---", true, EditMode_Practice, true, false, 0, EMPTY.GetValue().c_str() );
 			for (auto *s: m_vpSongs)
 			{
 				mrd.choices.push_back( s->GetDisplayFullTitle() );
 			}
-			mrd.sName = ssprintf(SONG.GetValue() + " %d",i+1);
+			mrd.sName = fmt::sprintf(SONG.GetValue() + " %d",i+1);
 			OptionRowHandler *pHand = OptionRowHandlerUtil::MakeSimple( mrd );
 			pHand->m_Def.m_bAllowThemeTitle = false;	// already themed
 			pHand->m_Def.m_sExplanationName = "Choose Song";
@@ -220,7 +220,7 @@ void ScreenOptionsEditCourse::BeginScreen()
 			EditCourseOptionRowHandlerSteps *pHand = new EditCourseOptionRowHandlerSteps;
 			pHand->Load( i );
 			pHand->m_Def.m_vsChoices.push_back( "n/a" );
-			pHand->m_Def.m_sName = ssprintf(STEPS.GetValue() + " %d",i+1);
+			pHand->m_Def.m_sName = fmt::sprintf(STEPS.GetValue() + " %d",i+1);
 			pHand->m_Def.m_bAllowThemeTitle = false;	// already themed
 			pHand->m_Def.m_bAllowThemeItems = false;	// already themed
 			pHand->m_Def.m_sExplanationName = "Choose Steps";
@@ -314,7 +314,7 @@ void ScreenOptionsEditCourse::ExportOptions( int iRow, const vector<PlayerNumber
 		case EditCourseRow_Minutes:
 			GAMESTATE->m_pCurCourse->m_fGoalSeconds = 0;
 			int mins;
-			if( sscanf( sValue, "%d", &mins ) == 1 )
+			if( sscanf( sValue.c_str(), "%d", &mins ) == 1 )
 				GAMESTATE->m_pCurCourse->m_fGoalSeconds = mins * 60;
 			break;
 		}
@@ -498,7 +498,7 @@ void ScreenOptionsEditCourse::ProcessMenuStart( const InputEventPlus &input )
 
 	if( m_pRows[iRow]->GetRowType() == OptionRow::RowType_Exit  &&  iSongCount < unsigned(MIN_ENABLED_SONGS) )
 	{
-		ScreenPrompt::Prompt( SM_None, ssprintf(MUST_ENABLE_AT_LEAST.GetValue(),MIN_ENABLED_SONGS) );
+		ScreenPrompt::Prompt( SM_None, fmt::sprintf(MUST_ENABLE_AT_LEAST.GetValue(),MIN_ENABLED_SONGS) );
 		return;
 	}
 

--- a/src/ScreenOptionsExportPackage.cpp
+++ b/src/ScreenOptionsExportPackage.cpp
@@ -185,13 +185,19 @@ void ScreenOptionsExportPackageSubPage::BeginScreen()
 static RString ReplaceInvalidFileNameChars( RString sOldFileName )
 {
 	RString sNewFileName = sOldFileName;
-	const char charsToReplace[] = {
+	std::array<char, 26> charsToReplace = {
+		{
 		' ', '!', '@', '#', '$', '%', '^', '&', '*', '(', ')',
 		'+', '=', '[', ']', '{', '}', '|', ':', '\"', '\\',
 		'<', '>', ',', '?', '/'
+		}
 	};
-	for( unsigned i=0; i<sizeof(charsToReplace); i++ )
-		sNewFileName.Replace( charsToReplace[i], '_' );
+	
+	for (auto const &ch: charsToReplace)
+	{
+		std::replace(sNewFileName.begin(), sNewFileName.end(), ch, '_');
+	}
+	
 	return sNewFileName;
 }
 

--- a/src/ScreenOptionsManageCourses.cpp
+++ b/src/ScreenOptionsManageCourses.cpp
@@ -240,7 +240,7 @@ void ScreenOptionsManageCourses::ProcessMenuStart( const InputEventPlus & )
 		EditCourseUtil::GetAllEditCourses( vpCourses );
 		if( vpCourses.size() >= (size_t)EditCourseUtil::MAX_PER_PROFILE )
 		{
-			RString s = ssprintf( YOU_HAVE_MAX.GetValue()+"\n\n"+YOU_MUST_DELETE.GetValue(), EditCourseUtil::MAX_PER_PROFILE );
+			RString s = fmt::sprintf( YOU_HAVE_MAX.GetValue()+"\n\n"+YOU_MUST_DELETE.GetValue(), EditCourseUtil::MAX_PER_PROFILE );
 			ScreenPrompt::Prompt( SM_None, s );
 			return;
 		}

--- a/src/ScreenOptionsManageEditSteps.cpp
+++ b/src/ScreenOptionsManageEditSteps.cpp
@@ -255,7 +255,7 @@ void ScreenOptionsManageEditSteps::ProcessMenuStart( const InputEventPlus & )
 		SONGMAN->GetStepsLoadedFromProfile( v, ProfileSlot_Machine );
 		if( v.size() >= size_t(MAX_EDIT_STEPS_PER_PROFILE) )
 		{
-			RString s = ssprintf( YOU_HAVE_MAX_STEP_EDITS.GetValue()+"\n\n"+YOU_MUST_DELETE.GetValue(), MAX_EDIT_STEPS_PER_PROFILE );
+			RString s = fmt::sprintf( YOU_HAVE_MAX_STEP_EDITS.GetValue()+"\n\n"+YOU_MUST_DELETE.GetValue(), MAX_EDIT_STEPS_PER_PROFILE );
 			ScreenPrompt::Prompt( SM_None, s );
 			return;
 		}

--- a/src/ScreenOptionsManageProfiles.cpp
+++ b/src/ScreenOptionsManageProfiles.cpp
@@ -322,14 +322,14 @@ void ScreenOptionsManageProfiles::HandleScreenMessage( const ScreenMessage SM )
 			case ProfileAction_Delete:
 				{
 					RString sTitle = pProfile->m_sDisplayName;
-					RString sMessage = ssprintf( CONFIRM_DELETE_PROFILE.GetValue(), sTitle.c_str() );
+					RString sMessage = fmt::sprintf( CONFIRM_DELETE_PROFILE.GetValue(), sTitle.c_str() );
 					ScreenPrompt::Prompt( SM_BackFromDeleteConfirm, sMessage, PROMPT_YES_NO );
 				}
 				break;
 			case ProfileAction_Clear:
 				{
 					RString sTitle = pProfile->m_sDisplayName;
-					RString sMessage = ssprintf( CONFIRM_CLEAR_PROFILE.GetValue(), sTitle.c_str() );
+					RString sMessage = fmt::sprintf( CONFIRM_CLEAR_PROFILE.GetValue(), sTitle.c_str() );
 					ScreenPrompt::Prompt( SM_BackFromClearConfirm, sMessage, PROMPT_YES_NO );
 				}
 				break;

--- a/src/ScreenOptionsMaster.cpp
+++ b/src/ScreenOptionsMaster.cpp
@@ -107,7 +107,7 @@ void ScreenOptionsMaster::HandleScreenMessage( const ScreenMessage SM )
 		// Override ScreenOptions's calling of ExportOptions
 		m_iChangeMask = 0;
 
-		CHECKPOINT;
+		CHECKPOINT_M("Starting the export screen");
 
 		vector<PlayerNumber> vpns;
 		FOREACH_OptionsPlayer( p )
@@ -155,7 +155,7 @@ void ScreenOptionsMaster::HandleScreenMessage( const ScreenMessage SM )
 		if( m_iChangeMask & OPT_APPLY_SONG )
 			SONGMAN->SetPreferences();
 
-		CHECKPOINT;
+		CHECKPOINT_M("About to go to the next screen.");
 		this->HandleScreenMessage( SM_GoToNextScreen );
 		return;
 	}

--- a/src/ScreenOptionsMasterPrefs.cpp
+++ b/src/ScreenOptionsMasterPrefs.cpp
@@ -179,13 +179,18 @@ static void GameSel( int &sel, bool ToSel, const ConfOption *pConfOption )
 
 	if( ToSel )
 	{
-		const RString sCurGameName = PREFSMAN->GetCurrentGame();
+		ci_string sCurGameName = PREFSMAN->GetCurrentGame().c_str();
 
 		sel = 0;
 		for(unsigned i = 0; i < choices.size(); ++i)
-			if( !stricmp(choices[i], sCurGameName) )
+		{
+			if (sCurGameName == choices[i].c_str())
+			{
 				sel = i;
-	} else {
+			}
+		}
+	}
+	else {
 		vector<const Game*> aGames;
 		GAMEMAN->GetEnabledGames( aGames );
 		PREFSMAN->SetCurrentGame(aGames[sel]->m_szName);
@@ -221,15 +226,23 @@ static void Language( int &sel, bool ToSel, const ConfOption *pConfOption )
 	if( ToSel )
 	{
 		sel = -1;
+		ci_string ciThemeLang(THEME->GetCurLanguage().c_str());
 		for( unsigned i=0; sel == -1 && i < vs.size(); ++i )
-			if( !stricmp(vs[i], THEME->GetCurLanguage()) )
+		{
+			if (ciThemeLang == vs[i].c_str())
+			{
 				sel = i;
-
+			}
+		}
 		// If the current language doesn't exist, we'll show BASE_LANGUAGE, so select that.
+		ci_string ciBaseLang(SpecialFiles::BASE_LANGUAGE.c_str());
 		for( unsigned i=0; sel == -1 && i < vs.size(); ++i )
-			if( !stricmp(vs[i], SpecialFiles::BASE_LANGUAGE) )
+		{
+			if (ciBaseLang == vs[i].c_str())
+			{
 				sel = i;
-
+			}
+		}
 		if( sel == -1 )
 		{
 			LOG->Warn( "Couldn't find language \"%s\" or fallback \"%s\"; using \"%s\"",
@@ -277,9 +290,14 @@ static void RequestedTheme( int &sel, bool ToSel, const ConfOption *pConfOption 
 	if( ToSel )
 	{
 		sel = 0;
+		ci_string ciTheme(PREFSMAN->m_sTheme.Get().c_str());
 		for( unsigned i=1; i<vsThemeNames.size(); i++ )
-			if( !stricmp(vsThemeNames[i], PREFSMAN->m_sTheme.Get()) )
+		{
+			if (ciTheme == vsThemeNames[i].c_str())
+			{
 				sel = i;
+			}
+		}
 	}
 	else
 	{
@@ -303,9 +321,14 @@ static void Announcer( int &sel, bool ToSel, const ConfOption *pConfOption )
 	if( ToSel )
 	{
 		sel = 0;
+		ci_string ciAnnouncer(ANNOUNCER->GetCurAnnouncerName().c_str());
 		for( unsigned i=1; i<choices.size(); i++ )
-			if( !stricmp(choices[i], ANNOUNCER->GetCurAnnouncerName()) )
+		{
+			if (ciAnnouncer == choices[i].c_str())
+			{
 				sel = i;
+			}
+		}
 	}
 	else
 	{
@@ -330,9 +353,14 @@ static void DefaultNoteSkin( int &sel, bool ToSel, const ConfOption *pConfOption
 		PlayerOptions po;
 		po.FromString( PREFSMAN->m_sDefaultModifiers );
 		sel = 0;
+		ci_string ciSkin(po.m_sNoteSkin.c_str());
 		for( unsigned i=0; i < choices.size(); i++ )
-			if( !stricmp(choices[i], po.m_sNoteSkin) )
+		{
+			if (ciSkin == choices[i].c_str())
+			{
 				sel = i;
+			}
+		}
 	}
 	else
 	{

--- a/src/ScreenOptionsMasterPrefs.cpp
+++ b/src/ScreenOptionsMasterPrefs.cpp
@@ -898,13 +898,14 @@ int ConfOption::GetEffects() const
 ConfOption *ConfOption::Find( RString name )
 {
 	InitializeConfOptions();
-	for( unsigned i = 0; i < g_ConfOptions.size(); ++i )
+	ci_string ciName(name.c_str());
+	for (auto &opt: g_ConfOptions)
 	{
-		ConfOption *opt = &g_ConfOptions[i];
-		RString match(opt->name);
-		if( match.CompareNoCase(name) )
-			continue;
-		return opt;
+		RString match(opt.name);
+		if (ciName == match.c_str())
+		{
+			return &opt;
+		}
 	}
 
 	return NULL;

--- a/src/ScreenOptionsMasterPrefs.h
+++ b/src/ScreenOptionsMasterPrefs.h
@@ -49,7 +49,13 @@ struct ConfOption
 #define PUSH( c )	if(c) names.push_back(c);
 		PUSH(c0);PUSH(c1);PUSH(c2);PUSH(c3);PUSH(c4);PUSH(c5);PUSH(c6);PUSH(c7);PUSH(c8);PUSH(c9);PUSH(c10);PUSH(c11);PUSH(c12);PUSH(c13);PUSH(c14);PUSH(c15);PUSH(c16);PUSH(c17);PUSH(c18);PUSH(c19);
 	}
-	void AddOption( const RString &sName ) { PUSH(sName); }
+	void AddOption( const RString &sName )
+	{
+		if (sName.size() > 0)
+		{
+			names.push_back(sName);
+		}
+	}
 #undef PUSH
 
 	ConfOption( const char *n, MoveData_t m,

--- a/src/ScreenOptionsMemoryCard.cpp
+++ b/src/ScreenOptionsMemoryCard.cpp
@@ -213,7 +213,7 @@ void ScreenOptionsMemoryCard::ProcessMenuStart( const InputEventPlus & )
 		}
 		else
 		{
-			RString s = ssprintf(ERROR_MOUNTING_CARD.GetValue(), MEMCARDMAN->GetCardError(PLAYER_1).c_str() );
+			RString s = fmt::sprintf(ERROR_MOUNTING_CARD.GetValue(), MEMCARDMAN->GetCardError(PLAYER_1).c_str() );
 			ScreenPrompt::Prompt( SM_None, s );
 		}
 	}

--- a/src/ScreenPackages.cpp
+++ b/src/ScreenPackages.cpp
@@ -151,7 +151,7 @@ void ScreenPackages::Update( float fDeltaTime )
 	if ( m_fLastUpdate >= 1.0 )
 	{
 		if ( m_bIsDownloading && m_bGotHeader )
-			m_sStatus = ssprintf( DOWNLOAD_PROGRESS.GetValue(), int((m_iDownloaded-m_bytesLastUpdate)/1024) );
+			m_sStatus = fmt::sprintf( DOWNLOAD_PROGRESS.GetValue(), int((m_iDownloaded-m_bytesLastUpdate)/1024) );
 
 		m_bytesLastUpdate = m_iDownloaded;
 		UpdateProgress();

--- a/src/ScreenPackages.cpp
+++ b/src/ScreenPackages.cpp
@@ -496,10 +496,8 @@ void ScreenPackages::EnterURL( const RString & sURL )
 
 	// Determine if this is a website, or a package?
 	// Criteria: does it end with *zip?
-	if( tail(sAddress, 3).CompareNoCase("zip") == 0 )
-		m_bIsPackage=true;
-	else
-		m_bIsPackage = false;
+	ci_string zip(tail(sAddress, 3).c_str());
+	m_bIsPackage = ( zip == "zip" );
 
 	m_sBaseAddress = "http://" + Server;
 	if( Port != 80 )

--- a/src/ScreenPackages.cpp
+++ b/src/ScreenPackages.cpp
@@ -496,7 +496,7 @@ void ScreenPackages::EnterURL( const RString & sURL )
 
 	// Determine if this is a website, or a package?
 	// Criteria: does it end with *zip?
-	if( sAddress.Right(3).CompareNoCase("zip") == 0 )
+	if( tail(sAddress, 3).CompareNoCase("zip") == 0 )
 		m_bIsPackage=true;
 	else
 		m_bIsPackage = false;
@@ -506,7 +506,7 @@ void ScreenPackages::EnterURL( const RString & sURL )
 		m_sBaseAddress += ssprintf( ":%d", Port );
 	m_sBaseAddress += "/";
 
-	if( sAddress.Right(1) != "/" )
+	if( !EndsWith(sAddress, "/") )
 	{
 		m_sEndName = Basename( sAddress );
 		m_sBaseAddress += Dirname( sAddress );

--- a/src/ScreenSaveSync.cpp
+++ b/src/ScreenSaveSync.cpp
@@ -27,7 +27,7 @@ static RString GetPromptText()
 		AdjustSync::GetSyncChangeTextSong( vs );
 		if( !vs.empty() )
 		{
-			s += ssprintf(
+			s += fmt::sprintf(
 				CHANGED_TIMING_OF.GetValue()+"\n"
 				"%s:\n"
 				"\n",

--- a/src/ScreenSelect.cpp
+++ b/src/ScreenSelect.cpp
@@ -37,7 +37,7 @@ void ScreenSelect::Init()
 	RString choice_names= CHOICE_NAMES;
 	if(BeginsWith(choice_names, "lua,"))
 	{
-		RString command= choice_names.Right(choice_names.size()-4);
+		RString command= tail(choice_names, -4);
 		Lua* L= LUA->Get();
 		if(LuaHelpers::RunExpression(L, command, m_sName + "::ChoiceNames"))
 		{

--- a/src/ScreenSelect.cpp
+++ b/src/ScreenSelect.cpp
@@ -53,7 +53,7 @@ void ScreenSelect::Init()
 					lua_rawgeti(L, 1, i);
 					if(!lua_isstring(L, -1))
 					{
-						LuaHelpers::ReportScriptErrorFmt(m_sName + "::ChoiceNames element %zu is not a string.", i);
+						LuaHelpers::ReportScriptError(fmt::sprintf("%s::ChoiceNames element %zu is not a string.", m_sName, i));
 					}
 					else
 					{

--- a/src/ScreenSelect.cpp
+++ b/src/ScreenSelect.cpp
@@ -35,7 +35,7 @@ void ScreenSelect::Init()
 	// Load choices
 	// Allow lua as an alternative to metrics.
 	RString choice_names= CHOICE_NAMES;
-	if(choice_names.Left(4) == "lua,")
+	if(BeginsWith(choice_names, "lua,"))
 	{
 		RString command= choice_names.Right(choice_names.size()-4);
 		Lua* L= LUA->Get();

--- a/src/ScreenSelectMaster.cpp
+++ b/src/ScreenSelectMaster.cpp
@@ -276,7 +276,7 @@ void ScreenSelectMaster::Init()
 		for( unsigned part = 0; part < parts.size(); ++part )
 		{
 			int from, to;
-			if( sscanf( parts[part], "%d:%d", &from, &to ) != 2 )
+			if( sscanf( parts[part].c_str(), "%d:%d", &from, &to ) != 2 )
 			{
 				LuaHelpers::ReportScriptErrorFmt( "%s::OptionOrder%s parse error", m_sName.c_str(), MenuDirToString(dir).c_str() );
 				continue;

--- a/src/ScreenSelectMaster.cpp
+++ b/src/ScreenSelectMaster.cpp
@@ -93,7 +93,7 @@ void ScreenSelectMaster::Init()
 		{
 			RString sElement = "Cursor" + PLAYER_APPEND_NO_SPACE(p);
 			m_sprCursor[p].Load( THEME->GetPathG(m_sName,sElement) );
-			sElement.Replace( " ", "" );
+			ReplaceAll(sElement, " ", "");
 			m_sprCursor[p]->SetName( sElement );
 			this->AddChild( m_sprCursor[p] );
 			LOAD_ALL_COMMANDS( m_sprCursor[p] );

--- a/src/ScreenSelectMusic.cpp
+++ b/src/ScreenSelectMusic.cpp
@@ -505,7 +505,7 @@ bool ScreenSelectMusic::Input( const InputEventPlus &input )
 			if ( songToDelete && PREFSMAN->m_bAllowSongDeletion.Get() )
 			{
 				m_pSongAwaitingDeletionConfirmation = songToDelete;
-				ScreenPrompt::Prompt(SM_ConfirmDeleteSong, ssprintf(PERMANENTLY_DELETE.GetValue(), songToDelete->m_sMainTitle.c_str(), songToDelete->GetSongDir().c_str()), PROMPT_YES_NO);
+				ScreenPrompt::Prompt(SM_ConfirmDeleteSong, fmt::sprintf(PERMANENTLY_DELETE.GetValue(), songToDelete->m_sMainTitle.c_str(), songToDelete->GetSongDir().c_str()), PROMPT_YES_NO);
 				return true;
 			}
 		}

--- a/src/ScreenServiceAction.cpp
+++ b/src/ScreenServiceAction.cpp
@@ -60,7 +60,7 @@ static RString ClearMachineEdits()
 	PROFILEMAN->LoadMachineProfile();
 
 	int iNumErrors = iNumAttempted-iNumSuccessful;
-	return ssprintf(MACHINE_EDITS_CLEARED.GetValue(),iNumSuccessful,iNumErrors);
+	return fmt::sprintf(MACHINE_EDITS_CLEARED.GetValue(),iNumSuccessful,iNumErrors);
 }
 
 static PlayerNumber GetFirstReadyMemoryCard()
@@ -92,7 +92,7 @@ static RString ClearMemoryCardEdits()
 	if( !MEMCARDMAN->IsMounted(pn) )
 		MEMCARDMAN->MountCard(pn);
 
-	RString sDir = MEM_CARD_MOUNT_POINT[pn] + (RString)PREFSMAN->m_sMemoryCardProfileSubdir + "/";
+	RString sDir = MEM_CARD_MOUNT_POINT[pn] + PREFSMAN->m_sMemoryCardProfileSubdir.Get() + "/";
 	vector<RString> vsEditFiles;
 	GetDirListing( sDir+EDIT_STEPS_SUBDIR+"*.edit", vsEditFiles, false, true );
 	GetDirListing( sDir+EDIT_COURSES_SUBDIR+"*.crs", vsEditFiles, false, true );
@@ -106,7 +106,7 @@ static RString ClearMemoryCardEdits()
 
 	MEMCARDMAN->UnmountCard(pn);
 
-	return ssprintf(EDITS_CLEARED.GetValue(),iNumSuccessful,iNumAttempted-iNumSuccessful);
+	return fmt::sprintf(EDITS_CLEARED.GetValue(),iNumSuccessful,iNumAttempted-iNumSuccessful);
 }
 
 
@@ -130,9 +130,9 @@ static RString TransferStatsMachineToMemoryCard()
 	MEMCARDMAN->UnmountCard(pn);
 
 	if( bSaved )
-		return ssprintf(MACHINE_STATS_SAVED.GetValue(),pn+1);
+		return fmt::sprintf(MACHINE_STATS_SAVED.GetValue(),pn+1);
 	else
-		return ssprintf(ERROR_SAVING_MACHINE_STATS.GetValue(),pn+1);
+		return fmt::sprintf(ERROR_SAVING_MACHINE_STATS.GetValue(),pn+1);
 }
 
 static LocalizedString STATS_NOT_LOADED		( "ScreenServiceAction", "Stats not loaded - No memory cards ready." );
@@ -158,15 +158,15 @@ static RString TransferStatsMemoryCardToMachine()
 	switch( lr )
 	{
 	case ProfileLoadResult_Success:
-		s = ssprintf(MACHINE_STATS_LOADED.GetValue(),pn+1);
+		s = fmt::sprintf(MACHINE_STATS_LOADED.GetValue(),pn+1);
 		break;
 	case ProfileLoadResult_FailedNoProfile:
 		*PROFILEMAN->GetMachineProfile() = backup;
-		s = ssprintf(THERE_IS_NO_PROFILE.GetValue(),pn+1);
+		s = fmt::sprintf(THERE_IS_NO_PROFILE.GetValue(),pn+1);
 		break;
 	case ProfileLoadResult_FailedTampered:
 		*PROFILEMAN->GetMachineProfile() = backup;
-		s = ssprintf(PROFILE_CORRUPT.GetValue(),pn+1);
+		s = fmt::sprintf(PROFILE_CORRUPT.GetValue(),pn+1);
 		break;
 	default:
 		FAIL_M(ssprintf("Invalid profile load result: %i", lr));
@@ -194,7 +194,7 @@ static void CopyEdits( const RString &sFromProfileDir, const RString &sToProfile
 		{
 			if( DoesFileExist(sToDir+i) )
 				iNumOverwritten++;
-			bool bSuccess = FileCopy( sFromDir+*i, sToDir+i );
+			bool bSuccess = FileCopy( sFromDir+i, sToDir+i );
 			if( bSuccess )
 				iNumSucceeded++;
 			else
@@ -251,11 +251,11 @@ static RString CopyEdits( const RString &sFromProfileDir, const RString &sToProf
 
 	vector<RString> vs;
 	vs.push_back( sDisplayDir );
-	vs.push_back( ssprintf( COPIED.GetValue(), iNumSucceeded ) + ", " + ssprintf( OVERWRITTEN.GetValue(), iNumOverwritten ) );
+	vs.push_back( fmt::sprintf( COPIED.GetValue(), iNumSucceeded ) + ", " + fmt::sprintf( OVERWRITTEN.GetValue(), iNumOverwritten ) );
 	if( iNumIgnored )
-		vs.push_back( ssprintf( IGNORED.GetValue(), iNumIgnored ) );
+		vs.push_back( fmt::sprintf( IGNORED.GetValue(), iNumIgnored ) );
 	if( iNumErrored )
-		vs.push_back( ssprintf( FAILED.GetValue(), iNumErrored ) );
+		vs.push_back( fmt::sprintf( FAILED.GetValue(), iNumErrored ) );
 	return join( "\n", vs );
 }
 
@@ -322,10 +322,10 @@ static RString CopyEditsMachineToMemoryCard()
 		MEMCARDMAN->MountCard(pn);
 
 	RString sFromDir = PROFILEMAN->GetProfileDir(ProfileSlot_Machine);
-	RString sToDir = MEM_CARD_MOUNT_POINT[pn] + (RString)PREFSMAN->m_sMemoryCardProfileSubdir + "/";
+	RString sToDir = MEM_CARD_MOUNT_POINT[pn] + PREFSMAN->m_sMemoryCardProfileSubdir.Get() + "/";
 
 	vector<RString> vs;
-	vs.push_back( ssprintf( COPIED_TO_CARD.GetValue(), pn+1 ) );
+	vs.push_back( fmt::sprintf( COPIED_TO_CARD.GetValue(), pn+1 ) );
 	RString s = CopyEdits( sFromDir, sToDir, PREFSMAN->m_sMemoryCardProfileSubdir );
 	vs.push_back( s );
 
@@ -349,17 +349,17 @@ static RString SyncEditsMachineToMemoryCard()
 	int iNumFailed = 0;
 
 	RString sFromDir = PROFILEMAN->GetProfileDir(ProfileSlot_Machine);
-	RString sToDir = MEM_CARD_MOUNT_POINT[pn] + (RString)PREFSMAN->m_sMemoryCardProfileSubdir + "/";
+	RString sToDir = MEM_CARD_MOUNT_POINT[pn] + PREFSMAN->m_sMemoryCardProfileSubdir.Get() + "/";
 	SyncEdits( sFromDir, sToDir, iNumAdded, iNumDeleted, iNumOverwritten, iNumFailed );
 
 	MEMCARDMAN->UnmountCard(pn);
 
-	RString sRet = ssprintf( COPIED_TO_CARD.GetValue(), pn+1 ) + " ";
-	sRet += ssprintf( ADDED.GetValue(), iNumAdded ) + ", " + ssprintf( OVERWRITTEN.GetValue(), iNumOverwritten );
+	RString sRet = fmt::sprintf( COPIED_TO_CARD.GetValue(), pn+1 ) + " ";
+	sRet += fmt::sprintf( ADDED.GetValue(), iNumAdded ) + ", " + fmt::sprintf( OVERWRITTEN.GetValue(), iNumOverwritten );
 	if( iNumDeleted )
-		sRet += RString(" ") + ssprintf( DELETED.GetValue(), iNumDeleted );
+		sRet += RString(" ") + fmt::sprintf( DELETED.GetValue(), iNumDeleted );
 	if( iNumFailed )
-		sRet += RString("; ") + ssprintf( FAILED.GetValue(), iNumFailed );
+		sRet += RString("; ") + fmt::sprintf( FAILED.GetValue(), iNumFailed );
 	return sRet;
 }
 
@@ -377,7 +377,7 @@ static RString CopyEditsMemoryCardToMachine()
 	ProfileManager::GetMemoryCardProfileDirectoriesToTry( vsSubDirs );
 
 	vector<RString> vs;
-	vs.push_back( ssprintf( COPIED_FROM_CARD.GetValue(), pn+1 ) );
+	vs.push_back( fmt::sprintf( COPIED_FROM_CARD.GetValue(), pn+1 ) );
 
 	for (auto &sSubDir: vsSubDirs)
 	{

--- a/src/ScreenTextEntry.cpp
+++ b/src/ScreenTextEntry.cpp
@@ -106,7 +106,7 @@ bool ScreenTextEntry::FloatValidate( const RString &sAnswer, RString &sErrorOut 
 	float f;
 	if( StringToFloat(sAnswer, f) )
 		return true;
-	sErrorOut = ssprintf( INVALID_FLOAT.GetValue(), sAnswer.c_str() );
+	sErrorOut = fmt::sprintf( INVALID_FLOAT.GetValue(), sAnswer.c_str() );
 	return false;
 }
 
@@ -116,7 +116,7 @@ bool ScreenTextEntry::IntValidate( const RString &sAnswer, RString &sErrorOut )
 	int f;
 	if(sAnswer >> f)
 		return true;
-	sErrorOut = ssprintf( INVALID_INT.GetValue(), sAnswer.c_str() );
+	sErrorOut = fmt::sprintf( INVALID_INT.GetValue(), sAnswer.c_str() );
 	return false;
 }
 

--- a/src/ScreenTextEntry.cpp
+++ b/src/ScreenTextEntry.cpp
@@ -449,10 +449,10 @@ static bool ValidateFromLua( const RString &sAnswer, RString &sErrorOut )
 	g_ValidateFunc.PushSelf( L );
 
 	// Argument 1 (answer):
-	lua_pushstring( L, sAnswer );
+	lua_pushstring( L, sAnswer.c_str() );
 
 	// Argument 2 (error out):
-	lua_pushstring( L, sErrorOut );
+	lua_pushstring( L, sErrorOut.c_str() );
 
 	bool valid= false;
 
@@ -489,7 +489,7 @@ static void OnOKFromLua( const RString &sAnswer )
 
 	g_OnOKFunc.PushSelf( L );
 	// Argument 1 (answer):
-	lua_pushstring( L, sAnswer );
+	lua_pushstring( L, sAnswer.c_str() );
 	RString error= "Lua error in ScreenTextEntry OnOK: ";
 	LuaHelpers::RunScriptOnStack(L, error, 1, 0, true);
 
@@ -522,10 +522,10 @@ static bool ValidateAppendFromLua( const RString &sAnswerBeforeChar, RString &sA
 	g_ValidateAppendFunc.PushSelf( L );
 
 	// Argument 1 (AnswerBeforeChar):
-	lua_pushstring( L, sAnswerBeforeChar );
+	lua_pushstring( L, sAnswerBeforeChar.c_str() );
 
 	// Argument 2 (Append):
-	lua_pushstring( L, sAppend );
+	lua_pushstring( L, sAppend.c_str() );
 
 	bool append= false;
 
@@ -556,7 +556,7 @@ static RString FormatAnswerForDisplayFromLua( const RString &sAnswer )
 
 	g_FormatAnswerForDisplayFunc.PushSelf( L );
 	// Argument 1 (Answer):
-	lua_pushstring( L, sAnswer );
+	lua_pushstring( L, sAnswer.c_str() );
 
 	RString answer;
 	RString error= "Lua error in ScreenTextEntry FormatAnswerForDisplay: ";

--- a/src/ScrollBar.cpp
+++ b/src/ScrollBar.cpp
@@ -66,7 +66,7 @@ void ScrollBar::SetPercentage( float fCenterPercent, float fSizePercent )
 	fStartPercent	= fmodf( fStartPercent+1, 1 );
 	fEndPercent	= fmodf( fEndPercent+1, 1 );
 
-	CHECKPOINT;
+	CHECKPOINT_M("Comparing percentages before final calculations.");
 	float fPartTopY[2], fPartBottomY[2];
 
 	if( fStartPercent < fEndPercent )	// we only need to one 1 stretch thumb part
@@ -84,7 +84,7 @@ void ScrollBar::SetPercentage( float fCenterPercent, float fSizePercent )
 		fPartBottomY[1]	= SCALE( 1.0f,		0.0f, 1.0f, -iBarContentHeight/2.0f, +iBarContentHeight/2.0f );
 	}
 
-	CHECKPOINT;
+	CHECKPOINT_M("Before the scroll stretch.");
 
 	for( unsigned i = 0; i < m_sprScrollStretchThumb.size(); ++i)
 	{
@@ -96,7 +96,7 @@ void ScrollBar::SetPercentage( float fCenterPercent, float fSizePercent )
 			);
 		m_sprScrollStretchThumb[i]->StretchTo( rect );
 	}
-	CHECKPOINT;
+	CHECKPOINT_M("After the scroll stretch.");
 }
 
 /*

--- a/src/Song.cpp
+++ b/src/Song.cpp
@@ -283,7 +283,7 @@ bool Song::LoadFromSongDir( RString sDir, bool load_autosave )
 	ASSERT_M( sDir != "", "Songs can't be loaded from an empty directory!" );
 
 	// make sure there is a trailing slash at the end of sDir
-	if( sDir.Right(1) != "/" )
+	if( !EndsWith(sDir, "/") )
 		sDir += "/";
 
 	// save song dir

--- a/src/Song.cpp
+++ b/src/Song.cpp
@@ -575,7 +575,7 @@ void FixupPath( RString &path, const RString &sSongPath )
 void Song::TidyUpData( bool from_cache, bool /* duringCache */ )
 {
 	// We need to do this before calling any of HasMusic, HasHasCDTitle, etc.
-	ASSERT_M(m_sSongDir.Left(3) != "../", m_sSongDir); // meaningless
+	ASSERT_M(!BeginsWith(m_sSongDir, "../"), m_sSongDir); // meaningless
 	FixupPath(m_sSongDir, "");
 	FixupPath(m_sMusicFile, m_sSongDir);
 	FOREACH_ENUM(InstrumentTrack, i)
@@ -704,7 +704,7 @@ void Song::TidyUpData( bool from_cache, bool /* duringCache */ )
 				m_bHasMusic= true;
 				m_sMusicFile= music_list[0];
 				if(music_list.size() > 1 &&
-					!m_sMusicFile.Left(5).CompareNoCase("intro"))
+					!head(m_sMusicFile, 5).CompareNoCase("intro"))
 				{
 					m_sMusicFile= music_list[1];
 				}
@@ -1626,7 +1626,7 @@ RString Song::GetSongAssetPath( RString sPath, const RString &sSongPath )
 		return sRelPath;
 
 	// The song contains a path; treat it as relative to the top SM directory.
-	if( sPath.Left(3) == "../" )
+	if( BeginsWith(sPath, "../"))
 	{
 		// The path begins with "../".  Resolve it wrt. the song directory.
 		sPath = sRelPath;
@@ -1636,7 +1636,7 @@ RString Song::GetSongAssetPath( RString sPath, const RString &sSongPath )
 
 	/* If the path still begins with "../", then there were an unreasonable number
 	 * of them at the beginning of the path. Ignore the path entirely. */
-	if( sPath.Left(3) == "../" )
+	if( BeginsWith(sPath, "../"))
 		return RString();
 
 	return sPath;

--- a/src/Song.cpp
+++ b/src/Song.cpp
@@ -1946,43 +1946,43 @@ class LunaSong: public Luna<Song>
 public:
 	static int GetDisplayFullTitle( T* p, lua_State *L )
 	{
-		lua_pushstring(L, p->GetDisplayFullTitle() ); return 1;
+		lua_pushstring(L, p->GetDisplayFullTitle().c_str() ); return 1;
 	}
 	static int GetTranslitFullTitle( T* p, lua_State *L )
 	{
-		lua_pushstring(L, p->GetTranslitFullTitle() ); return 1;
+		lua_pushstring(L, p->GetTranslitFullTitle().c_str() ); return 1;
 	}
 	static int GetDisplayMainTitle( T* p, lua_State *L )
 	{
-		lua_pushstring(L, p->GetDisplayMainTitle() ); return 1;
+		lua_pushstring(L, p->GetDisplayMainTitle().c_str() ); return 1;
 	}
 	static int GetTranslitMainTitle( T* p, lua_State *L )
 	{
-		lua_pushstring(L, p->GetTranslitMainTitle() ); return 1;
+		lua_pushstring(L, p->GetTranslitMainTitle().c_str() ); return 1;
 	}
 	static int GetDisplaySubTitle( T* p, lua_State *L )
 	{
-		lua_pushstring(L, p->GetDisplaySubTitle() ); return 1;
+		lua_pushstring(L, p->GetDisplaySubTitle().c_str() ); return 1;
 	}
 	static int GetTranslitSubTitle( T* p, lua_State *L )
 	{
-		lua_pushstring(L, p->GetTranslitSubTitle() ); return 1;
+		lua_pushstring(L, p->GetTranslitSubTitle().c_str() ); return 1;
 	}
 	static int GetDisplayArtist( T* p, lua_State *L )
 	{
-		lua_pushstring(L, p->GetDisplayArtist() ); return 1;
+		lua_pushstring(L, p->GetDisplayArtist().c_str() ); return 1;
 	}
 	static int GetTranslitArtist( T* p, lua_State *L )
 	{
-		lua_pushstring(L, p->GetTranslitArtist() ); return 1;
+		lua_pushstring(L, p->GetTranslitArtist().c_str() ); return 1;
 	}
 	static int GetGenre( T* p, lua_State *L )
 	{
-		lua_pushstring(L, p->m_sGenre ); return 1;
+		lua_pushstring(L, p->m_sGenre.c_str() ); return 1;
 	}
 	static int GetOrigin( T* p, lua_State *L )
 	{
-		lua_pushstring(L, p->m_sOrigin ); return 1;
+		lua_pushstring(L, p->m_sOrigin.c_str() ); return 1;
 	}
 	static int GetAllSteps( T* p, lua_State *L )
 	{
@@ -1999,14 +1999,14 @@ public:
 	}
 	static int GetSongDir( T* p, lua_State *L )
 	{
-		lua_pushstring(L, p->GetSongDir() );
+		lua_pushstring(L, p->GetSongDir().c_str() );
 		return 1;
 	}
 	static int GetMusicPath( T* p, lua_State *L )
 	{
 		RString s = p->GetMusicPath();
 		if( !s.empty() )
-			lua_pushstring(L, s);
+			lua_pushstring(L, s.c_str());
 		else
 			lua_pushnil(L);
 		return 1;
@@ -2015,7 +2015,7 @@ public:
 	{
 		RString s = p->GetBannerPath();
 		if( !s.empty() )
-			lua_pushstring(L, s);
+			lua_pushstring(L, s.c_str());
 		else
 			lua_pushnil(L);
 		return 1;
@@ -2024,7 +2024,7 @@ public:
 	{
 		RString s = p->GetBackgroundPath();
 		if( !s.empty() )
-			lua_pushstring(L, s);
+			lua_pushstring(L, s.c_str());
 		else
 			lua_pushnil(L);
 		return 1;
@@ -2033,7 +2033,7 @@ public:
 	{
 		RString s = p->GetPreviewVidPath();
 		if( !s.empty() )
-			lua_pushstring(L, s);
+			lua_pushstring(L, s.c_str());
 		else
 			lua_pushnil(L);
 		return 1;
@@ -2041,14 +2041,14 @@ public:
 	static int GetPreviewMusicPath(T* p, lua_State* L)
 	{
 		RString s= p->GetPreviewMusicPath();
-		lua_pushstring(L, s);
+		lua_pushstring(L, s.c_str());
 		return 1;
 	}
 	static int GetJacketPath( T* p, lua_State *L )
 	{
 		RString s = p->GetJacketPath();
 		if( !s.empty() )
-			lua_pushstring(L, s);
+			lua_pushstring(L, s.c_str());
 		else
 			lua_pushnil(L);
 		return 1;
@@ -2057,7 +2057,7 @@ public:
 	{
 		RString s = p->GetCDImagePath();
 		if( !s.empty() )
-			lua_pushstring(L, s);
+			lua_pushstring(L, s.c_str());
 		else
 			lua_pushnil(L);
 		return 1;
@@ -2066,7 +2066,7 @@ public:
 	{
 		RString s = p->GetDiscPath();
 		if( !s.empty() )
-			lua_pushstring(L, s);
+			lua_pushstring(L, s.c_str());
 		else
 			lua_pushnil(L);
 		return 1;
@@ -2075,7 +2075,7 @@ public:
 	{
 		RString s = p->GetCDTitlePath();
 		if( !s.empty() )
-			lua_pushstring(L, s);
+			lua_pushstring(L, s.c_str());
 		else
 			lua_pushnil(L);
 		return 1;
@@ -2084,14 +2084,14 @@ public:
 	{
 		RString s = p->GetLyricsPath();
 		if( !s.empty() )
-			lua_pushstring(L, s);
+			lua_pushstring(L, s.c_str());
 		else
 			lua_pushnil(L);
 		return 1;
 	}
 	static int GetSongFilePath(  T* p, lua_State *L )
 	{
-		lua_pushstring(L, p->GetSongFilePath() );
+		lua_pushstring(L, p->GetSongFilePath().c_str() );
 		return 1;
 	}
 	static int IsTutorial( T* p, lua_State *L )
@@ -2106,7 +2106,7 @@ public:
 	}
 	static int GetGroupName( T* p, lua_State *L )
 	{
-		lua_pushstring(L, p->m_sGroupName);
+		lua_pushstring(L, p->m_sGroupName.c_str());
 		return 1;
 	}
 	static int MusicLengthSeconds( T* p, lua_State *L )

--- a/src/Song.cpp
+++ b/src/Song.cpp
@@ -1814,7 +1814,7 @@ bool Song::Matches(RString sGroup, RString sSong) const
 		return false;
 	}
 	RString sDir = this->GetSongDir();
-	sDir.Replace("\\","/");
+	std::replace(sDir.begin(), sDir.end(), '\\', '/');
 	vector<RString> bits;
 	split( sDir, "/", bits );
 	ASSERT(bits.size() >= 2); // should always have at least two parts

--- a/src/Song.cpp
+++ b/src/Song.cpp
@@ -670,7 +670,7 @@ void Song::TidyUpData( bool from_cache, bool /* duringCache */ )
 				filename != song_dir_listing.end(); ++filename)
 		{
 			bool matched_something= false;
-			RString file_ext= GetExtension(*filename).MakeLower();
+			RString file_ext= MakeLower(GetExtension(*filename));
 			if(!file_ext.empty())
 			{
 				for(size_t tf= 0; tf < lists_to_fill.size(); ++ tf)
@@ -904,8 +904,7 @@ void Song::TidyUpData( bool from_cache, bool /* duringCache */ )
 				break; // done
 
 			// ignore DWI "-char" graphics
-			RString lower = image_list[i];
-			lower.MakeLower();
+			RString lower = MakeLower(image_list[i]);
 			if(BlacklistedImages.find(lower) != BlacklistedImages.end())
 				continue;	// skip
 

--- a/src/Song.cpp
+++ b/src/Song.cpp
@@ -910,25 +910,32 @@ void Song::TidyUpData( bool from_cache, bool /* duringCache */ )
 				continue;	// skip
 
 			// Skip any image that we've already classified
+			ci_string usedImage = image_list[i].c_str();
 
-			if(m_bHasBanner && m_sBannerFile.EqualsNoCase(image_list[i]))
+			if(m_bHasBanner && usedImage == m_sBannerFile.c_str())
+			{
 				continue;	// skip
-
-			if(m_bHasBackground && m_sBackgroundFile.EqualsNoCase(image_list[i]))
+			}
+			if(m_bHasBackground && usedImage == m_sBackgroundFile.c_str())
+			{
 				continue;	// skip
-
-			if(has_cdtitle && m_sCDTitleFile.EqualsNoCase(image_list[i]))
+			}
+			if(has_cdtitle && usedImage == m_sCDTitleFile.c_str())
+			{
 				continue;	// skip
-
-			if(has_jacket && m_sJacketFile.EqualsNoCase(image_list[i]))
+			}
+			if(has_jacket && usedImage == m_sJacketFile.c_str())
+			{
 				continue;	// skip
-
-			if(has_disc && m_sDiscFile.EqualsNoCase(image_list[i]))
+			}
+			if(has_disc && usedImage == m_sDiscFile.c_str())
+			{
 				continue;	// skip
-
-			if(has_cdimage && m_sCDFile.EqualsNoCase(image_list[i]))
+			}
+			if(has_cdimage && usedImage == m_sCDFile.c_str())
+			{
 				continue;	// skip
-
+			}
 			RString sPath = m_sSongDir + image_list[i];
 
 			// We only care about the dimensions.

--- a/src/Song.cpp
+++ b/src/Song.cpp
@@ -703,8 +703,8 @@ void Song::TidyUpData( bool from_cache, bool /* duringCache */ )
 				LOG->Trace("Song '%s' points to a music file that doesn't exist, found music file '%s'", m_sSongDir.c_str(), music_list[0].c_str());
 				m_bHasMusic= true;
 				m_sMusicFile= music_list[0];
-				if(music_list.size() > 1 &&
-					!head(m_sMusicFile, 5).CompareNoCase("intro"))
+				ci_string intro(head(m_sMusicFile, 5).c_str());
+				if(music_list.size() > 1 && intro == "intro")
 				{
 					m_sMusicFile= music_list[1];
 				}
@@ -1809,9 +1809,11 @@ void Song::DeleteSteps( const Steps* pSteps, bool bReAutoGen )
 
 bool Song::Matches(RString sGroup, RString sSong) const
 {
-	if( sGroup.size() && sGroup.CompareNoCase(this->m_sGroupName) != 0)
+	ci_string ciGroup(sGroup.c_str());
+	if( sGroup.size() && ciGroup != this->m_sGroupName.c_str())
+	{
 		return false;
-
+	}
 	RString sDir = this->GetSongDir();
 	sDir.Replace("\\","/");
 	vector<RString> bits;
@@ -1820,11 +1822,11 @@ bool Song::Matches(RString sGroup, RString sSong) const
 	const RString &sLastBit = bits[bits.size()-1];
 
 	// match on song dir or title (ala DWI)
-	if( !sSong.CompareNoCase(sLastBit) )
+	ci_string ciSong(sSong.c_str());
+	if (ciSong == sLastBit.c_str() || ciSong == this->GetTranslitFullTitle().c_str())
+	{
 		return true;
-	if( !sSong.CompareNoCase(this->GetTranslitFullTitle()) )
-		return true;
-
+	}
 	return false;
 }
 

--- a/src/SongCacheIndex.cpp
+++ b/src/SongCacheIndex.cpp
@@ -139,7 +139,7 @@ RString SongCacheIndex::MangleName( const RString &Name )
 {
 	/* We store paths in an INI.  We can't store '='. */
 	RString ret = Name;
-	ret.Replace( "=", "");
+	ReplaceAll(ret, "=", "");
 	return ret;
 }
 

--- a/src/SongManager.cpp
+++ b/src/SongManager.cpp
@@ -2153,7 +2153,7 @@ public:
 	static int SongToPreferredSortSectionName( T* p, lua_State *L )
 	{
 		const Song* pSong = Luna<Song>::check(L,1);
-		lua_pushstring(L, p->SongToPreferredSortSectionName(pSong));
+		lua_pushstring(L, p->SongToPreferredSortSectionName(pSong).c_str());
 		return 1;
 	}
 	static int WasLoadedFromAdditionalSongs( T* p, lua_State *L )

--- a/src/SongManager.cpp
+++ b/src/SongManager.cpp
@@ -1383,7 +1383,7 @@ Song* SongManager::GetSongFromDir(RString dir) const
 	}
 
 	dir.Replace('\\', '/');
-	dir.MakeLower();
+	dir = MakeLower(dir);
 	auto entry = m_SongsByDir.find(dir);
 	if(entry != m_SongsByDir.end())
 	{
@@ -1903,8 +1903,7 @@ void SongManager::AddSongToList(Song* new_song)
 {
 	new_song->SetEnabled(true);
 	m_pSongs.push_back(new_song);
-	RString dir= new_song->GetSongDir();
-	dir.MakeLower();
+	RString dir= MakeLower(new_song->GetSongDir());
 	m_SongsByDir.insert(std::make_pair(dir, new_song));
 }
 

--- a/src/SongManager.cpp
+++ b/src/SongManager.cpp
@@ -998,7 +998,8 @@ void SongManager::InitRandomAttacks()
 					continue;
 				}
 
-				if( !sType.EqualsNoCase("ATTACK") )
+				ci_string ciType(sType.c_str());
+				if( ciType != "ATTACK" )
 				{
 					LuaHelpers::ReportScriptErrorFmt( "Got \"%s:%s\" tag with wrong declaration", sType.c_str(), sAttack.c_str() );
 					continue;

--- a/src/SongManager.cpp
+++ b/src/SongManager.cpp
@@ -183,8 +183,7 @@ void SongManager::SanityCheckGroupDir( RString sDir ) const
 		{
 			if(ext == aud)
 			{
-				RageException::Throw(
-					FOLDER_CONTAINS_MUSIC_FILES.GetValue(), sDir.c_str());
+				RageException::Throw( FOLDER_CONTAINS_MUSIC_FILES.GetValue().c_str(), sDir.c_str());
 			}
 		}
 	}

--- a/src/SongManager.cpp
+++ b/src/SongManager.cpp
@@ -1576,7 +1576,7 @@ void SongManager::UpdatePreferredSort(RString sPreferredSongs, RString sPreferre
 				 * and if it does, add all the songs in that group to the list. */
 				if( EndsWith(sLine,"/*") )
 				{
-					RString group = sLine.Left( sLine.length() - RString("/*").length() );
+					RString group = head(sLine, sLine.length() - 2 );
 					if( DoesSongGroupExist(group) )
 					{
 						// add all songs in group

--- a/src/SongManager.cpp
+++ b/src/SongManager.cpp
@@ -265,7 +265,7 @@ static LocalizedString LOADING_SONGS ( "SongManager", "Loading songs..." );
 void SongManager::LoadStepManiaSongDir( RString sDir, LoadingWindow *ld )
 {
 	// Make sure sDir has a trailing slash.
-	if( sDir.Right(1) != "/" )
+	if( !EndsWith(sDir, "/") )
 		sDir += "/";
 
 	// Find all group directories in "Songs" folder
@@ -1375,8 +1375,10 @@ Course* SongManager::GetRandomCourse()
 
 Song* SongManager::GetSongFromDir(RString dir) const
 {
-	if(dir.Right(1) != "/")
-	{ dir += "/"; }
+	if(!EndsWith(dir, "/"))
+	{
+		dir += "/";
+	}
 
 	dir.Replace('\\', '/');
 	dir.MakeLower();
@@ -1566,7 +1568,7 @@ void SongManager::UpdatePreferredSort(RString sPreferredSongs, RString sPreferre
 					section = PreferredSortSection();
 				}
 
-				section.sName = sLine.Right( sLine.length() - RString("---").length() );
+				section.sName = tail(sLine, sLine.length() - RString("---").length() );
 				TrimLeft( section.sName );
 				TrimRight( section.sName );
 			}

--- a/src/SongManager.cpp
+++ b/src/SongManager.cpp
@@ -1382,7 +1382,7 @@ Song* SongManager::GetSongFromDir(RString dir) const
 		dir += "/";
 	}
 
-	dir.Replace('\\', '/');
+	std::replace(dir.begin(), dir.end(), '\\', '/');
 	dir = MakeLower(dir);
 	auto entry = m_SongsByDir.find(dir);
 	if(entry != m_SongsByDir.end())
@@ -1442,7 +1442,7 @@ Course* SongManager::GetCourseFromName( RString sName ) const
 
 Song *SongManager::FindSong( RString sPath ) const
 {
-	sPath.Replace( '\\', '/' );
+	std::replace(sPath.begin(), sPath.end(), '\\', '/');
 	vector<RString> bits;
 	split( sPath, "/", bits );
 
@@ -1471,7 +1471,7 @@ Song *SongManager::FindSong( RString sGroup, RString sSong ) const
 
 Course *SongManager::FindCourse( RString sPath ) const
 {
-	sPath.Replace( '\\', '/' );
+	std::replace(sPath.begin(), sPath.end(), '\\', '/');
 	vector<RString> bits;
 	split( sPath, "/", bits );
 

--- a/src/SongManager.cpp
+++ b/src/SongManager.cpp
@@ -939,7 +939,9 @@ void SongManager::InitAutogenCourses()
 		do {
 			RString sArtist = i >= apSongs.size()? RString(""): apSongs[i]->GetDisplayArtist();
 			RString sTranslitArtist = i >= apSongs.size()? RString(""): apSongs[i]->GetTranslitArtist();
-			if( i < apSongs.size() && !sCurArtist.CompareNoCase(sArtist) )
+			ci_string ciCurrentArtist(sCurArtist.c_str());
+			ci_string ciCurrentTransl(sTranslitArtist.c_str());
+			if( i < apSongs.size() && ciCurrentArtist == sArtist.c_str() )
 			{
 				aSongs.push_back( apSongs[i] );
 				++iCurArtistCount;
@@ -948,9 +950,9 @@ void SongManager::InitAutogenCourses()
 
 			/* Different artist, or we're at the end. If we have enough entries for
 			 * the last artist, add it. Skip blanks and "Unknown artist". */
-			if( iCurArtistCount >= 3 && sCurArtistTranslit != "" &&
-				sCurArtistTranslit.CompareNoCase("Unknown artist") &&
-				sCurArtist.CompareNoCase("Unknown artist") )
+			if (iCurArtistCount >= 3 && sCurArtistTranslit != "" &&
+				ciCurrentTransl != "Unknown artist" &&
+				ciCurrentArtist != "Unknown artist" )
 			{
 				pCourse = new Course;
 				CourseUtil::AutogenOniFromArtist( sCurArtist, sCurArtistTranslit, aSongs, Difficulty_Hard, *pCourse );
@@ -1396,10 +1398,13 @@ Course* SongManager::GetCourseFromPath( RString sPath ) const
 	if( sPath == "" )
 		return NULL;
 
+	ci_string ciPath(sPath.c_str());
 	for (auto *c: m_pCourses)
 	{
-		if( sPath.CompareNoCase(c->m_sPath) == 0 )
+		if (ciPath == c->m_sPath.c_str())
+		{
 			return c;
+		}
 	}
 
 	return NULL;
@@ -1410,9 +1415,10 @@ Course* SongManager::GetCourseFromName( RString sName ) const
 	if( sName == "" )
 		return NULL;
 
+	ci_string ciName(sName.c_str());
 	for (auto *course: m_pCourses)
 	{
-		if( sName.CompareNoCase(course->GetDisplayFullTitle()) == 0 )
+		if (ciName == course->GetDisplayFullTitle().c_str())
 		{
 			return course;
 		}
@@ -1751,10 +1757,10 @@ void SongManager::UpdateRankingCourses()
 	{
 		bool bLotsOfStages = c->GetEstimatedNumStages() > 7;
 		c->m_SortOrder_Ranking = bLotsOfStages? 3 : 2;
-
-		for( unsigned j = 0; j < RankingCourses.size(); j++ )
+		ci_string ciPath(c->m_sPath.c_str());
+		for (auto const &rank: RankingCourses)
 		{
-			if( !RankingCourses[j].CompareNoCase(c->m_sPath) )
+			if (ciPath == rank.c_str())
 			{
 				c->m_SortOrder_Ranking = 1;
 			}

--- a/src/SongOptions.cpp
+++ b/src/SongOptions.cpp
@@ -154,8 +154,7 @@ void SongOptions::FromString( const RString &sMultipleMods )
 
 bool SongOptions::FromOneModString( const RString &sOneMod, RString &sErrorOut )
 {
-	RString sBit = sOneMod;
-	sBit.MakeLower();
+	RString sBit = MakeLower(sOneMod);
 	Trim( sBit );
 
 	Regex mult("^([0-9]+(\\.[0-9]+)?)xmusic$");

--- a/src/SongUtil.cpp
+++ b/src/SongUtil.cpp
@@ -393,13 +393,22 @@ static bool CompareSongPointersByTitle( const Song *pSong1, const Song *pSong2 )
 	s1 = SongUtil::MakeSortString(s1);
 	s2 = SongUtil::MakeSortString(s2);
 
-	int ret = strcmp( s1, s2 );
-	if(ret < 0) return true;
-	if(ret > 0) return false;
+	ci_string x1(s1.c_str());
+	ci_string x2(s2.c_str());
+	if (x1 < x2)
+	{
+		return true;
+	}
+	if (x1 > x2)
+	{
+		return false;
+	}
 
 	/* The titles are the same.  Ensure we get a consistent ordering
 	 * by comparing the unique SongFilePaths. */
-	return pSong1->GetSongFilePath().CompareNoCase(pSong2->GetSongFilePath()) < 0;
+	ci_string t1(pSong1->GetSongFilePath().c_str());
+	ci_string t2(pSong2->GetSongFilePath().c_str());
+	return t1 < t2;
 }
 
 void SongUtil::SortSongPointerArrayByTitle( vector<Song*> &vpSongsInOut )

--- a/src/SongUtil.cpp
+++ b/src/SongUtil.cpp
@@ -267,9 +267,9 @@ void SongUtil::AdjustDuplicateSteps( Song *pSong )
 			 * bug in an earlier version. */
 			DeleteDuplicateSteps( pSong, vSteps );
 
-			CHECKPOINT;
+			CHECKPOINT_M("Before sorting the notes.");
 			StepsUtil::SortNotesArrayByDifficulty( vSteps );
-			CHECKPOINT;
+			CHECKPOINT_M("After sorting the notes.");
 			for( unsigned k=1; k<vSteps.size(); k++ )
 			{
 				vSteps[k]->SetDifficulty( Difficulty_Edit );
@@ -304,15 +304,15 @@ void SongUtil::DeleteDuplicateSteps( Song *pSong, vector<Steps*> &vSteps )
 {
 	/* vSteps have the same StepsType and Difficulty.  Delete them if they have the
 	 * same m_sDescription, m_sCredit, m_iMeter and SMNoteData. */
-	CHECKPOINT;
+	CHECKPOINT_M("Before the steps loop.");
 	for( unsigned i=0; i<vSteps.size(); i++ )
 	{
-		CHECKPOINT;
+		CHECKPOINT_M("Inside the steps loop.");
 		const Steps *s1 = vSteps[i];
 
 		for( unsigned j=i+1; j<vSteps.size(); j++ )
 		{
-			CHECKPOINT;
+			CHECKPOINT_M("Analyzing another step for duplication.");
 			const Steps *s2 = vSteps[j];
 
 			if( s1->GetDescription() != s2->GetDescription() )

--- a/src/SongUtil.cpp
+++ b/src/SongUtil.cpp
@@ -594,7 +594,7 @@ RString SongUtil::GetSectionNameFromSongAndSort( const Song* pSong, SortOrder so
 			else if( s[0] < 'A' || s[0] > 'Z')
 				return SORT_OTHER.GetValue();
 			else
-				return s.Left(1);
+				return head(s, 1);
 		}
 	case SORT_GENRE:
 		if( !pSong->m_sGenre.empty() )
@@ -775,7 +775,7 @@ RString SongUtil::MakeUniqueEditDescription( const Song *pSong, StepsType st, co
 	{
 		// make name "My Edit" -> "My Edit2"
 		RString sNum = ssprintf("%d", i+1);
-		sTemp = sPreferredDescription.Left( MAX_STEPS_DESCRIPTION_LENGTH - sNum.size() ) + sNum;
+		sTemp = head(sPreferredDescription, MAX_STEPS_DESCRIPTION_LENGTH - sNum.size() ) + sNum;
 
 		if( IsEditDescriptionUnique(pSong, st, sTemp, NULL) )
 			return sTemp;
@@ -1122,7 +1122,7 @@ void SongID::FromSong( const Song *p )
 
 	// HACK for backwards compatibility:
 	// Strip off leading "/".  2005/05/21 file layer changes added a leading slash.
-	if( sDir.Left(1) == "/" )
+	if( BeginsWith(sDir, "/"))
 		sDir.erase( sDir.begin() );
 
 	m_Cache.Unset();
@@ -1136,7 +1136,7 @@ Song *SongID::ToSong() const
 		// HACK for backwards compatibility: Re-add the leading "/".
 		// 2005/05/21 file layer changes added a leading slash.
 		RString sDir2 = sDir;
-		if( sDir2.Left(1) != "/" )
+		if( !BeginsWith(sDir2, "/"))
 			sDir2 = "/" + sDir2;
 
 		if( !sDir2.empty() )

--- a/src/SongUtil.cpp
+++ b/src/SongUtil.cpp
@@ -365,7 +365,7 @@ static bool CompareSongPointersBySortValueDescending( const Song *pSong1, const 
 
 RString SongUtil::MakeSortString( RString s )
 {
-	s.MakeUpper();
+	s = MakeUpper(s);
 
 	// Make sure that non-alphanumeric strings are placed at the very end.
 	if( s.size() > 0 )

--- a/src/SongUtil.cpp
+++ b/src/SongUtil.cpp
@@ -814,9 +814,9 @@ bool SongUtil::ValidateCurrentEditStepsDescription( const RString &sAnswer, RStr
 	}
 
 	static const RString sInvalidChars = "\\/:*?\"<>|";
-	if( strpbrk(sAnswer, sInvalidChars) != NULL )
+	if( strpbrk(sAnswer.c_str(), sInvalidChars.c_str()) != NULL )
 	{
-		sErrorOut = ssprintf( EDIT_NAME_CANNOT_CONTAIN.GetValue(), sInvalidChars.c_str() );
+		sErrorOut = fmt::sprintf( EDIT_NAME_CANNOT_CONTAIN.GetValue(), sInvalidChars.c_str() );
 		return false;
 	}
 
@@ -864,9 +864,9 @@ bool SongUtil::ValidateCurrentStepsChartName(const RString &answer, RString &err
 	if (answer.empty()) return true;
 
 	static const RString sInvalidChars = "\\/:*?\"<>|";
-	if( strpbrk(answer, sInvalidChars) != NULL )
+	if( strpbrk(answer.c_str(), sInvalidChars.c_str()) != NULL )
 	{
-		error = ssprintf( CHART_NAME_CANNOT_CONTAIN.GetValue(), sInvalidChars.c_str() );
+		error = fmt::sprintf( CHART_NAME_CANNOT_CONTAIN.GetValue(), sInvalidChars.c_str() );
 		return false;
 	}
 
@@ -898,9 +898,9 @@ bool SongUtil::ValidateCurrentStepsCredit( const RString &sAnswer, RString &sErr
 
 	// Borrow from EditDescription testing. Perhaps this should be abstracted? -Wolfman2000
 	static const RString sInvalidChars = "\\/:*?\"<>|";
-	if( strpbrk(sAnswer, sInvalidChars) != NULL )
+	if( strpbrk(sAnswer.c_str(), sInvalidChars.c_str()) != NULL )
 	{
-		sErrorOut = ssprintf( AUTHOR_NAME_CANNOT_CONTAIN.GetValue(), sInvalidChars.c_str() );
+		sErrorOut = fmt::sprintf( AUTHOR_NAME_CANNOT_CONTAIN.GetValue(), sInvalidChars.c_str() );
 		return false;
 	}
 
@@ -920,7 +920,7 @@ bool SongUtil::ValidateCurrentSongPreview(const RString& answer, RString& error)
 	song->m_PreviewFile= real_file;
 	if(!valid)
 	{
-		error= ssprintf(PREVIEW_DOES_NOT_EXIST.GetValue(), answer.c_str());
+		error= fmt::sprintf(PREVIEW_DOES_NOT_EXIST.GetValue(), answer.c_str());
 	}
 	return valid;
 }
@@ -938,7 +938,7 @@ bool SongUtil::ValidateCurrentStepsMusic(const RString &answer, RString &error)
 	pSteps->SetMusicFile(real_file);
 	if(!valid)
 	{
-		error= ssprintf(MUSIC_DOES_NOT_EXIST.GetValue(), answer.c_str());
+		error= fmt::sprintf(MUSIC_DOES_NOT_EXIST.GetValue(), answer.c_str());
 	}
 	return valid;
 }

--- a/src/StatsManager.cpp
+++ b/src/StatsManager.cpp
@@ -273,7 +273,7 @@ void StatsManager::CommitStatsToProfiles( const StageStats *pSS )
 		}
 
 		RString sDate = DateTime::GetNowDate().GetString();
-		sDate.Replace(":","-");
+		std::replace(sDate.begin(), sDate.end(), ':', '-');
 
 		const RString UPLOAD_DIR = "/Save/Upload/";
 		RString sFileNameNoExtension = Profile::MakeUniqueFileNameNoExtension(UPLOAD_DIR, sDate + " " );

--- a/src/StatsManager.cpp
+++ b/src/StatsManager.cpp
@@ -113,7 +113,7 @@ void StatsManager::CalcAccumPlayedStageStats()
 void AddPlayerStatsToProfile( Profile *pProfile, const StageStats &ss, PlayerNumber pn )
 {
 	ss.AssertValid( pn );
-	CHECKPOINT;
+	CHECKPOINT_M("About to add player stats.");
 
 	StyleID sID;
 	sID.FromStyle( ss.m_player[pn].m_pStyle );
@@ -215,12 +215,12 @@ void StatsManager::CommitStatsToProfiles( const StageStats *pSS )
 	pMachineProfile->m_iTotalGameplaySeconds += iGameplaySeconds;
 	pMachineProfile->m_iNumTotalSongsPlayed += pSS->m_vpPlayedSongs.size();
 
-	CHECKPOINT;
+	CHECKPOINT_M("Multiplayer check.");
 	if( !GAMESTATE->m_bMultiplayer )	// FIXME
 	{
 		FOREACH_HumanPlayer( pn )
 		{
-			CHECKPOINT;
+			CHECKPOINT_M("Analyzing a player now.");
 
 			Profile* pPlayerProfile = PROFILEMAN->GetProfile( pn );
 			if( pPlayerProfile )
@@ -238,7 +238,7 @@ void StatsManager::CommitStatsToProfiles( const StageStats *pSS )
 				AddPlayerStatsToProfile( pPlayerProfile, *pSS, pn );
 			}
 
-			CHECKPOINT;
+			CHECKPOINT_M("Done analyzing a player.");
 		}
 	}
 

--- a/src/StepMania.cpp
+++ b/src/StepMania.cpp
@@ -1235,9 +1235,9 @@ RString StepMania::SaveScreenshot( RString Dir, bool SaveCompressed, bool MakeSi
 	 * As before, we ignore the extension. -aj */
 	RString FileNameNoExtension = NamePrefix + DateTime::GetNowDateTime().GetString() + NameSuffix;
 	// replace space with underscore.
-	FileNameNoExtension.Replace(" ","_");
+	ReplaceAll(FileNameNoExtension, " ", "_");
 	// colons are illegal in filenames.
-	FileNameNoExtension.Replace(":","");
+	ReplaceAll(FileNameNoExtension, ":", "");
 
 	// Save the screenshot. If writing lossy to a memcard, use
 	// SAVE_LOSSY_LOW_QUAL, so we don't eat up lots of space.

--- a/src/StepMania.cpp
+++ b/src/StepMania.cpp
@@ -783,7 +783,7 @@ RageDisplay *CreateDisplay()
 		}
 		else
 		{
-			RageException::Throw( ERROR_UNKNOWN_VIDEO_RENDERER.GetValue(), sRenderer.c_str() );
+			RageException::Throw( ERROR_UNKNOWN_VIDEO_RENDERER.GetValue().c_str(), sRenderer.c_str() );
 		}
 
 		if( pRet == NULL )

--- a/src/StepMania.cpp
+++ b/src/StepMania.cpp
@@ -1644,7 +1644,7 @@ int LuaFunc_SaveScreenshot(lua_State *L)
 	}
 	RString path= dir + filename;
 	lua_pushboolean(L, !filename.empty());
-	lua_pushstring(L, path);
+	lua_pushstring(L, path.c_str());
 	return 2;
 }
 void LuaFunc_Register_SaveScreenshot(lua_State *L);

--- a/src/StepMania.cpp
+++ b/src/StepMania.cpp
@@ -674,6 +674,7 @@ bool CheckVideoDefaultSettings()
 		LOG->Trace( "Video card has changed from %s to %s.  Applying new defaults.", PREFSMAN->m_sLastSeenVideoDriver.Get().c_str(), sVideoDriver.c_str() );
 	}
 
+	ci_string ciRenderer(PREFSMAN->m_sVideoRenderers.Get().c_str());
 	if( bSetDefaultVideoParams )
 	{
 		PREFSMAN->m_sVideoRenderers.Set( defaults.sVideoRenderers );
@@ -692,7 +693,7 @@ bool CheckVideoDefaultSettings()
 		// Update last seen video card
 		PREFSMAN->m_sLastSeenVideoDriver.Set( GetVideoDriverName() );
 	}
-	else if( PREFSMAN->m_sVideoRenderers.Get().CompareNoCase(defaults.sVideoRenderers) )
+	else if( ciRenderer != defaults.sVideoRenderers.c_str() )
 	{
 		LOG->Warn("Video renderer list has been changed from '%s' to '%s'",
 				defaults.sVideoRenderers.c_str(), PREFSMAN->m_sVideoRenderers.Get().c_str() );
@@ -755,27 +756,28 @@ RageDisplay *CreateDisplay()
 	for( unsigned i=0; i<asRenderers.size(); i++ )
 	{
 		RString sRenderer = asRenderers[i];
+		ci_string ciRenderer(sRenderer.c_str());
 
-		if( sRenderer.CompareNoCase("opengl")==0 )
+		if( ciRenderer == "opengl" )
 		{
 #if defined(SUPPORT_OPENGL)
 			pRet = new RageDisplay_Legacy;
 #endif
 		}
-		else if( sRenderer.CompareNoCase("gles2")==0 )
+		else if( ciRenderer == "gles2" )
 		{
 #if defined(SUPPORT_GLES2)
 			pRet = new RageDisplay_GLES2;
 #endif
 		}
-		else if( sRenderer.CompareNoCase("d3d")==0 )
+		else if( ciRenderer == "d3d" )
 		{
 // TODO: ANGLE/RageDisplay_Modern
 #if defined(SUPPORT_D3D)
 			pRet = new RageDisplay_D3D;
 #endif
 		}
-		else if( sRenderer.CompareNoCase("null")==0 )
+		else if( ciRenderer == "null" )
 		{
 			return new RageDisplay_Null;
 		}

--- a/src/StepMania.cpp
+++ b/src/StepMania.cpp
@@ -134,7 +134,7 @@ static RString GetActualGraphicOptionsString()
 {
 	const VideoModeParams &params = DISPLAY->GetActualVideoModeParams();
 	RString sFormat = "%s %s %dx%d %d "+COLOR.GetValue()+" %d "+TEXTURE.GetValue()+" %dHz %s %s";
-	RString sLog = ssprintf( sFormat,
+	RString sLog = fmt::sprintf( sFormat,
 		DISPLAY->GetApiDescription().c_str(),
 		(params.windowed? WINDOWED : FULLSCREEN).GetValue().c_str(),
 		(int)params.width,
@@ -348,7 +348,7 @@ void StepMania::ResetGame()
 	{
 		RString sGameName = GAMESTATE->GetCurrentGame()->m_szName;
 		if( !THEME->DoesThemeExist(sGameName) )
-			sGameName = PREFSMAN->m_sDefaultTheme; // was previously "default" -aj
+			sGameName = PREFSMAN->m_sDefaultTheme.Get(); // was previously "default" -aj
 		THEME->SwitchThemeAndLanguage( sGameName, THEME->GetCurLanguage(), PREFSMAN->m_bPseudoLocalize );
 		TEXTUREMAN->DoDelayedDelete();
 	}
@@ -744,7 +744,7 @@ RageDisplay *CreateDisplay()
 	RString error = ERROR_INITIALIZING_CARD.GetValue()+"\n\n"+
 		ERROR_DONT_FILE_BUG.GetValue()+"\n\n"
 		VIDEO_TROUBLESHOOTING_URL "\n\n"+
-		ssprintf(ERROR_VIDEO_DRIVER.GetValue(), GetVideoDriverName().c_str())+"\n\n";
+		fmt::sprintf(ERROR_VIDEO_DRIVER.GetValue(), GetVideoDriverName().c_str())+"\n\n";
 
 	vector<RString> asRenderers;
 	split( PREFSMAN->m_sVideoRenderers, ",", asRenderers, true );
@@ -792,7 +792,7 @@ RageDisplay *CreateDisplay()
 		RString sError = pRet->Init( params, PREFSMAN->m_bAllowUnacceleratedRenderer );
 		if( !sError.empty() )
 		{
-			error += ssprintf(ERROR_INITIALIZING.GetValue(), sRenderer.c_str())+"\n" + sError;
+			error += fmt::sprintf(ERROR_INITIALIZING.GetValue(), sRenderer.c_str())+"\n" + sError;
 			SAFE_DELETE( pRet );
 			error += "\n\n\n";
 			continue;

--- a/src/Steps.cpp
+++ b/src/Steps.cpp
@@ -559,7 +559,7 @@ bool Steps::MakeValidEditDescription( RString &sPreferredDescription )
 {
 	if( int(sPreferredDescription.size()) > MAX_STEPS_DESCRIPTION_LENGTH )
 	{
-		sPreferredDescription = head(sPreferredDescription, MAX_STEPS_DESCRIPTION_LENGTH));
+		sPreferredDescription = head(sPreferredDescription, MAX_STEPS_DESCRIPTION_LENGTH);
 		return true;
 	}
 	return false;
@@ -673,7 +673,7 @@ public:
 	*/
 	static int GetChartName(T *p, lua_State *L)
 	{
-		lua_pushstring(L, p->GetChartName());
+		lua_pushstring(L, p->GetChartName().c_str());
 		return 1;
 	}
 	static int GetDisplayBpms( T* p, lua_State *L )

--- a/src/Steps.cpp
+++ b/src/Steps.cpp
@@ -104,8 +104,7 @@ bool Steps::GetNoteDataFromSimfile()
 {
 	// Replace the line below with the Steps' cache file.
 	RString stepFile = this->GetFilename();
-	RString extension = GetExtension(stepFile);
-	extension.MakeLower(); // must do this because the code is expecting lowercase
+	RString extension = MakeLower(GetExtension(stepFile));
 
 	if (extension.empty() || extension == "ssc"
 		|| extension == "ats") // remember cache files.

--- a/src/Steps.cpp
+++ b/src/Steps.cpp
@@ -559,7 +559,7 @@ bool Steps::MakeValidEditDescription( RString &sPreferredDescription )
 {
 	if( int(sPreferredDescription.size()) > MAX_STEPS_DESCRIPTION_LENGTH )
 	{
-		sPreferredDescription = sPreferredDescription.Left( MAX_STEPS_DESCRIPTION_LENGTH );
+		sPreferredDescription = head(sPreferredDescription, MAX_STEPS_DESCRIPTION_LENGTH));
 		return true;
 	}
 	return false;

--- a/src/Steps.cpp
+++ b/src/Steps.cpp
@@ -123,7 +123,7 @@ bool Steps::GetNoteDataFromSimfile()
 			*/
 			SMLoader backup_loader;
 			RString transformedStepFile = stepFile;
-			transformedStepFile.Replace(".ssc", ".sm");
+			ReplaceAll(transformedStepFile, ".ssc", ".sm");
 
 			return backup_loader.LoadNoteDataFromSimfile(transformedStepFile, *this);
 		}

--- a/src/StepsUtil.cpp
+++ b/src/StepsUtil.cpp
@@ -185,7 +185,9 @@ void StepsUtil::SortStepsByTypeAndDifficulty( vector<Steps*> &arraySongPointers 
 
 bool StepsUtil::CompareStepsPointersByDescription(const Steps *pStep1, const Steps *pStep2)
 {
-	return pStep1->GetDescription().CompareNoCase( pStep2->GetDescription() ) < 0;
+	ci_string x1(pStep1->GetDescription().c_str());
+	ci_string x2(pStep2->GetDescription().c_str());
+	return x1 < x2;
 }
 
 void StepsUtil::SortStepsByDescription( vector<Steps*> &arraySongPointers )

--- a/src/Style.cpp
+++ b/src/Style.cpp
@@ -179,7 +179,7 @@ public:
 		ret.Set( L, "Track" );
 		lua_pushnumber( L, p->m_ColumnInfo[pn][iCol].fXOffset );
 		ret.Set( L,  "XOffset" );
-		lua_pushstring( L, p->ColToButtonName(iCol) );
+		lua_pushstring( L, p->ColToButtonName(iCol).c_str() );
 		ret.Set( L, "Name" );
 
 		ret.PushSelf(L);

--- a/src/ThemeManager.cpp
+++ b/src/ThemeManager.cpp
@@ -253,7 +253,8 @@ RString ThemeManager::GetThemeAuthor( const RString &sThemeName )
 
 static bool EqualsNoCase( const RString &s1, const RString &s2 )
 {
-	return s1.EqualsNoCase(s2);
+	ci_string ci1(s1.c_str());
+	return ci1 == s2.c_str();
 }
 void ThemeManager::GetLanguages( vector<RString>& AddTo )
 {

--- a/src/ThemeManager.cpp
+++ b/src/ThemeManager.cpp
@@ -137,7 +137,7 @@ static void FileNameToMetricsGroupAndElement( const RString &sFileName, RString 
 	}
 	else
 	{
-		sMetricsGroupOut = sFileName.Left( iIndexOfFirstSpace );
+		sMetricsGroupOut = head(sFileName, iIndexOfFirstSpace );
 		sElementOut = sFileName.Right( sFileName.size() - iIndexOfFirstSpace - 1 );
 	}
 }
@@ -222,7 +222,7 @@ bool ThemeManager::IsThemeSelectable( const RString &sThemeName )
 	if( !DoesThemeExist(sThemeName) )
 		return false;
 
-	return sThemeName.Left(1) != "_";
+	return !BeginsWith(sThemeName, "_");
 }
 
 RString ThemeManager::GetThemeDisplayName( const RString &sThemeName )
@@ -1160,7 +1160,7 @@ void ThemeManager::GetLanguagesForTheme( const RString &sThemeName, vector<RStri
 			continue;
 
 		// strip ".ini"
-		RString s2 = s.Left( s.size()-4 );
+		RString s2 = head(s, -4 );
 
 		asLanguagesOut.push_back( s2 );
 	}
@@ -1281,7 +1281,7 @@ void ThemeManager::GetMetricsThatBeginWith( const RString &sMetricsGroup_, const
 			for( XAttrs::const_iterator j = cur->m_attrs.lower_bound( sValueName ); j != cur->m_attrs.end(); ++j )
 			{
 				const RString &sv = j->first;
-				if( sv.Left(sValueName.size()) == sValueName )
+				if( head(sv, sValueName.size()) == sValueName )
 					vsValueNamesOut.insert( sv );
 				else	// we passed the last metric that matched sValueName
 					break;

--- a/src/ThemeManager.cpp
+++ b/src/ThemeManager.cpp
@@ -557,15 +557,13 @@ struct CompareLanguageTag
 	RString m_sLanguageString;
 	CompareLanguageTag( const RString &sLang )
 	{
-		m_sLanguageString = RString("(lang ") + sLang + ")";
+		m_sLanguageString = MakeLower("(lang " + sLang + ")");
 		LOG->Trace( "try \"%s\"", sLang.c_str() );
-		m_sLanguageString.MakeLower();
 	}
 
 	bool operator()( const RString &sFile ) const
 	{
-		RString sLower( sFile );
-		sLower.MakeLower();
+		RString sLower = MakeLower( sFile );
 		size_t iPos = sLower.find( m_sLanguageString );
 		return iPos != RString::npos;
 	}

--- a/src/ThemeManager.cpp
+++ b/src/ThemeManager.cpp
@@ -1206,24 +1206,24 @@ void ThemeManager::GetOptionNames( vector<RString>& AddTo )
 
 static RString PseudoLocalize( RString s )
 {
-	s.Replace( "a", "àá" );
-	s.Replace( "A", "ÀÀ" );
-	s.Replace( "e", "éé" );
-	s.Replace( "E", "ÉÉ" );
-	s.Replace( "i", "íí" );
-	s.Replace( "I", "ÍÍ" );
-	s.Replace( "o", "óó" );
-	s.Replace( "O", "ÓÓ" );
-	s.Replace( "u", "üü" );
-	s.Replace( "U", "ÜÜ" );
-	s.Replace( "n", "ñ" );
-	s.Replace( "N", "Ñ" );
-	s.Replace( "c", "ç" );
-	s.Replace( "C", "Ç" );
+	ReplaceAll(s, "a", "àá" );
+	ReplaceAll(s, "A", "ÀÀ" );
+	ReplaceAll(s, "e", "éé" );
+	ReplaceAll(s, "E", "ÉÉ" );
+	ReplaceAll(s, "i", "íí" );
+	ReplaceAll(s, "I", "ÍÍ" );
+	ReplaceAll(s, "o", "óó" );
+	ReplaceAll(s, "O", "ÓÓ" );
+	ReplaceAll(s, "u", "üü" );
+	ReplaceAll(s, "U", "ÜÜ" );
+	ReplaceAll(s, "n", "ñ" );
+	ReplaceAll(s, "N", "Ñ" );
+	ReplaceAll(s, "c", "ç" );
+	ReplaceAll(s, "C", "Ç" );
 	// transformations that help expose punctuation assumptions
-	//s.Replace( ":", " :" );	// this messes up "::" help text tip separator markers
-	s.Replace( "?", " ?" );
-	s.Replace( "!", " !" );
+	//ReplaceAll(s, ":", " :" );	// this messes up "::" help text tip separator markers
+	ReplaceAll(s, "?", " ?" );
+	ReplaceAll(s, "!", " !" );
 
 	return s;
 }
@@ -1241,8 +1241,8 @@ RString ThemeManager::GetString( const RString &sMetricsGroup, const RString &sV
 	DEBUG_ASSERT( sValueName.find('=') == sValueName.npos );
 
 	// TODO: Move this escaping into IniFile?
-	sValueName.Replace( "\r\n", "\\n" );
-	sValueName.Replace( "\n", "\\n" );
+	ReplaceAll(sValueName, "\r\n", "\\n" );
+	ReplaceAll(sValueName, "\n", "\\n" );
 
 	ASSERT( g_pLoadedThemeData != NULL );
 	RString s = GetMetricRaw( g_pLoadedThemeData->iniStrings, sMetricsGroup, sValueName );
@@ -1251,7 +1251,7 @@ RString ThemeManager::GetString( const RString &sMetricsGroup, const RString &sV
 	// Don't EvalulateString.  Strings are raw and shouldn't allow Lua.
 	//EvaluateString( s );
 
-	s.Replace( "\\n", "\n" );
+	ReplaceAll(s, "\\n", "\n" );
 
 	if( m_bPseudoLocalize )
 	{
@@ -1344,16 +1344,16 @@ public:
 		{
 			luaL_error(L, "Cannot fetch string with empty group name or empty value name.");
 		}
-		lua_pushstring(L, p->GetString(group, name));
+		lua_pushstring(L, p->GetString(group, name).c_str());
 		return 1;
 	}
 	static int GetPathInfoB( T* p, lua_State *L )
 	{
 		ThemeManager::PathInfo pi;
 		p->GetPathInfo( pi, EC_BGANIMATIONS, SArg(1), SArg(2) );
-		lua_pushstring(L, pi.sResolvedPath);
-		lua_pushstring(L, pi.sMatchingMetricsGroup);
-		lua_pushstring(L, pi.sMatchingElement);
+		lua_pushstring(L, pi.sResolvedPath.c_str());
+		lua_pushstring(L, pi.sMatchingMetricsGroup.c_str());
+		lua_pushstring(L, pi.sMatchingElement.c_str());
 		return 3;
 	}
 	// GENERAL_GET_PATH uses lua_toboolean instead of BArg because that makes
@@ -1362,7 +1362,7 @@ public:
 	static int get_path_name(T* p, lua_State* L) \
 	{ \
 		lua_pushstring(L, p->get_path_name( \
-				SArg(1), SArg(2), lua_toboolean(L, 3) != 0 )); \
+				SArg(1), SArg(2), lua_toboolean(L, 3) != 0 ).c_str()); \
 		return 1; \
 	}
 	GENERAL_GET_PATH(GetPathF);
@@ -1388,8 +1388,8 @@ public:
 
 	DEFINE_METHOD( GetCurrentThemeDirectory, GetCurThemeDir() );
 	DEFINE_METHOD( GetCurLanguage, GetCurLanguage() );
-	static int GetThemeDisplayName( T* p, lua_State *L )			{  lua_pushstring(L, p->GetThemeDisplayName(p->GetCurThemeName())); return 1; }
-	static int GetThemeAuthor( T* p, lua_State *L )			{  lua_pushstring(L, p->GetThemeAuthor(p->GetCurThemeName())); return 1; }
+	static int GetThemeDisplayName( T* p, lua_State *L )			{  lua_pushstring(L, p->GetThemeDisplayName(p->GetCurThemeName()).c_str()); return 1; }
+	static int GetThemeAuthor( T* p, lua_State *L )			{  lua_pushstring(L, p->GetThemeAuthor(p->GetCurThemeName()).c_str()); return 1; }
 	DEFINE_METHOD( DoesThemeExist, DoesThemeExist(SArg(1)) );
 	DEFINE_METHOD( IsThemeSelectable, IsThemeSelectable(SArg(1)) );
 	DEFINE_METHOD( DoesLanguageExist, DoesLanguageExist(SArg(1)) );

--- a/src/ThemeManager.cpp
+++ b/src/ThemeManager.cpp
@@ -396,7 +396,7 @@ void ThemeManager::SwitchThemeAndLanguage( const RString &sThemeName_, const RSt
 	// select. This requires a preference, which allows it to be adapted for
 	// other purposes (e.g. PARASTAR).
 	if( !IsThemeSelectable(sThemeName) )
-		sThemeName = PREFSMAN->m_sDefaultTheme;
+		sThemeName = PREFSMAN->m_sDefaultTheme.Get();
 #endif
 
 	ASSERT( IsThemeSelectable(sThemeName) );

--- a/src/ThemeManager.cpp
+++ b/src/ThemeManager.cpp
@@ -138,7 +138,7 @@ static void FileNameToMetricsGroupAndElement( const RString &sFileName, RString 
 	else
 	{
 		sMetricsGroupOut = head(sFileName, iIndexOfFirstSpace );
-		sElementOut = sFileName.Right( sFileName.size() - iIndexOfFirstSpace - 1 );
+		sElementOut = tail(sFileName, sFileName.size() - iIndexOfFirstSpace - 1 );
 	}
 }
 

--- a/src/UnlockManager.cpp
+++ b/src/UnlockManager.cpp
@@ -230,16 +230,25 @@ const UnlockEntry *UnlockManager::FindStepsType(const Song *pSong,
 const UnlockEntry *UnlockManager::FindCourse( const Course *pCourse ) const
 {
 	for (auto &e: m_UnlockEntries)
+	{
 		if( e.m_Course.ToCourse() == pCourse )
+		{
 			return &e;
+		}
+	}
 	return NULL;
 }
 
 const UnlockEntry *UnlockManager::FindModifier( const RString &sOneMod ) const
 {
+	ci_string ciMod(sOneMod.c_str());
 	for (auto &e: m_UnlockEntries)
-		if( e.GetModifier().CompareNoCase(sOneMod) == 0 )
+	{
+		if (ciMod == e.GetModifier().c_str())
+		{
 			return &e;
+		}
+	}
 	return NULL;
 }
 

--- a/src/UnlockManager.cpp
+++ b/src/UnlockManager.cpp
@@ -806,7 +806,7 @@ class LunaUnlockEntry: public Luna<UnlockEntry>
 {
 public:
 	static int IsLocked( T* p, lua_State *L )		{ lua_pushboolean(L, p->IsLocked() ); return 1; }
-	static int GetDescription( T* p, lua_State *L )		{ lua_pushstring(L, p->GetDescription() ); return 1; }
+	static int GetDescription( T* p, lua_State *L )		{ lua_pushstring(L, p->GetDescription().c_str() ); return 1; }
 	static int GetUnlockRewardType( T* p, lua_State *L )	{ lua_pushnumber(L, p->m_Type ); return 1; }
 	static int GetRequirement( T* p, lua_State *L )		{ UnlockRequirement i = Enum::Check<UnlockRequirement>( L, 1 ); lua_pushnumber(L, p->m_fRequirement[i] ); return 1; }
 	static int GetRequirePassHardSteps( T* p, lua_State *L ){ lua_pushboolean(L, p->m_bRequirePassHardSteps); return 1; }
@@ -868,7 +868,7 @@ public:
 	}
 	static int GetCode( T* p, lua_State *L )
 	{
-		lua_pushstring( L, p->m_sEntryID );
+		lua_pushstring( L, p->m_sEntryID.c_str() );
 		return 1;
 	}
 
@@ -937,7 +937,7 @@ public:
 		lua_pushnumber( L, p->PointsUntilNextUnlock(ut) );
 		return 1;
 	}
-	static int FindEntryID( T* p, lua_State *L )			{ RString sName = SArg(1); RString s = p->FindEntryID(sName); if( s.empty() ) lua_pushnil(L); else lua_pushstring(L, s); return 1; }
+	static int FindEntryID( T* p, lua_State *L )			{ RString sName = SArg(1); RString s = p->FindEntryID(sName); if( s.empty() ) lua_pushnil(L); else lua_pushstring(L, s.c_str()); return 1; }
 	static int UnlockEntryID( T* p, lua_State *L )			{ RString sUnlockEntryID = SArg(1); p->UnlockEntryID(sUnlockEntryID); COMMON_RETURN_SELF; }
 	static int UnlockEntryIndex( T* p, lua_State *L )		{ int iUnlockEntryID = IArg(1); p->UnlockEntryIndex(iUnlockEntryID); COMMON_RETURN_SELF; }
 	static int LockEntryID( T * p, lua_State * L)

--- a/src/XmlFile.cpp
+++ b/src/XmlFile.cpp
@@ -53,7 +53,7 @@ void XNodeStringValue::GetValue( RString &out ) const		{ out = m_sValue; }
 void XNodeStringValue::GetValue( int &out ) const		{ out = StringToInt(m_sValue); }
 void XNodeStringValue::GetValue( float &out ) const		{ out = StringToFloat(m_sValue); }
 void XNodeStringValue::GetValue( bool &out ) const		{ out = StringToInt(m_sValue) != 0; }
-void XNodeStringValue::GetValue( unsigned &out ) const		{ out = strtoul(m_sValue,NULL,0); }
+void XNodeStringValue::GetValue( unsigned &out ) const		{ out = strtoul(m_sValue.c_str(),NULL,0); }
 void XNodeStringValue::PushValue( lua_State *L ) const
 {
 	LuaHelpers::Push( L, m_sValue );

--- a/src/XmlToLua.cpp
+++ b/src/XmlToLua.cpp
@@ -302,7 +302,7 @@ void actor_template_t::store_cmd(RString const& cmd_name, RString const& full_cm
 {
 	if(BeginsWith(full_cmd, "%"))
 	{
-		RString cmd_text= full_cmd.Right(full_cmd.size()-1);
+		RString cmd_text= tail(full_cmd, -1);
 		convert_lua_chunk(cmd_text);
 		fields[cmd_name]= cmd_text;
 		return;
@@ -393,7 +393,7 @@ void actor_template_t::store_cmd(RString const& cmd_name, RString const& full_cm
 void actor_template_t::store_field(RString const& field_name, RString const& value, bool cmd_convert, RString const& pref, RString const& suf)
 {
 	// OITG apparently allowed "Oncommand" as valid.
-	if(field_name.Right(7).MakeLower() != "command")
+	if(tail(field_name, 7).MakeLower() != "command")
 	{
 		cmd_convert= false;
 	}
@@ -454,13 +454,13 @@ void actor_template_t::load_frames_from_file(RString const& fname, RString const
 			RString field_type= head(attr->first, 5);
 			if(field_type == "Frame")
 			{
-				int id= StringToInt(attr->first.Right(attr->first.size()-5));
+				int id= StringToInt(tail(attr->first, -5));
 				make_space_for_frame(id);
 				attr->second->GetValue(frames[id].frame);
 			}
 			else if(field_type == "Delay")
 			{
-				int id= StringToInt(attr->first.Right(attr->first.size()-5));
+				int id= StringToInt(tail(attr->first, -5));
 				make_space_for_frame(id);
 				attr->second->GetValue(frames[id].delay);
 			}

--- a/src/XmlToLua.cpp
+++ b/src/XmlToLua.cpp
@@ -145,7 +145,7 @@ void string_arg_conv(vector<RString>& args)
 }
 void lower_string_conv(vector<RString>& args)
 {
-	args[0].MakeLower();
+	args[0] = MakeLower(args[0]);
 }
 void hidden_conv(vector<RString>& args)
 {
@@ -184,8 +184,7 @@ void blend_conv(vector<RString>& args)
 	COMMON_ARG_VERIFY(2);
 	for(int i= 0; i < NUM_BlendMode; ++i)
 	{
-		RString blend_str= BlendModeToString(static_cast<BlendMode>(i));
-		blend_str.MakeLower();
+		RString blend_str = MakeLower(BlendModeToString(static_cast<BlendMode>(i)));
 		if(args[1] == blend_str)
 		{
 			args[1]= "\"BlendMode_" + BlendModeToString(static_cast<BlendMode>(i)) + "\"";
@@ -198,8 +197,7 @@ void cull_conv(vector<RString>& args)
 	COMMON_ARG_VERIFY(2);
 	for(int i= 0; i < NUM_CullMode; ++i)
 	{
-		RString cull_str= CullModeToString(static_cast<CullMode>(i));
-		cull_str.MakeLower();
+		RString cull_str = MakeLower(CullModeToString(static_cast<CullMode>(i)));
 		if(args[1] == cull_str)
 		{
 			args[1]= "\"CullMode_" + CullModeToString(static_cast<CullMode>(i)) + "\"";
@@ -393,7 +391,7 @@ void actor_template_t::store_cmd(RString const& cmd_name, RString const& full_cm
 void actor_template_t::store_field(RString const& field_name, RString const& value, bool cmd_convert, RString const& pref, RString const& suf)
 {
 	// OITG apparently allowed "Oncommand" as valid.
-	if(tail(field_name, 7).MakeLower() != "command")
+	if(MakeLower(tail(field_name, 7)) != "command")
 	{
 		cmd_convert= false;
 	}

--- a/src/XmlToLua.cpp
+++ b/src/XmlToLua.cpp
@@ -98,7 +98,7 @@ RString add_extension_to_relative_path_from_found_file(
 {
 	size_t rel_last_slash= after_slash_or_zero(relative_path);
 	size_t found_last_slash= after_slash_or_zero(found_file);
-	return relative_path.Left(rel_last_slash) +
+	return head(relative_path, rel_last_slash) +
 		found_file.substr(found_last_slash, string::npos);
 }
 
@@ -300,7 +300,7 @@ void actor_template_t::make_space_for_frame(int id)
 
 void actor_template_t::store_cmd(RString const& cmd_name, RString const& full_cmd)
 {
-	if(full_cmd.Left(1) == "%")
+	if(BeginsWith(full_cmd, "%"))
 	{
 		RString cmd_text= full_cmd.Right(full_cmd.size()-1);
 		convert_lua_chunk(cmd_text);
@@ -399,7 +399,7 @@ void actor_template_t::store_field(RString const& field_name, RString const& val
 	}
 	if(cmd_convert)
 	{
-		RString real_field_name= field_name.Left(field_name.size()-7) + "Command";
+		RString real_field_name= head(field_name, -7) + "Command";
 		store_cmd(real_field_name, value);
 	}
 	else
@@ -451,7 +451,7 @@ void actor_template_t::load_frames_from_file(RString const& fname, RString const
 		{
 			// Frame and Delay fields have names of the form "Frame0000" where the
 			// "0000" part is the id of the frame.
-			RString field_type= attr->first.Left(5);
+			RString field_type= head(attr->first, 5);
 			if(field_type == "Frame")
 			{
 				int id= StringToInt(attr->first.Right(attr->first.size()-5));
@@ -737,7 +737,7 @@ void convert_xml_file(RString const& fname, RString const& dirname)
 	condition_set_t conditions;
 	plate.load_node(xml, dirname, conditions);
 	RageFile* file= new RageFile;
-	RString out_name= fname.Left(fname.size()-4) + ".lua";
+	RString out_name= head(fname, -4) + ".lua";
 	if(!file->Open(out_name, RageFile::WRITE))
 	{
 		LOG->Trace("Could not open %s: %s", out_name.c_str(), file->GetError().c_str());

--- a/src/XmlToLua.cpp
+++ b/src/XmlToLua.cpp
@@ -249,7 +249,7 @@ void convert_lua_chunk(RString& chunk_text)
 {
 	for(auto chunk = chunks_to_replace.begin(); chunk != chunks_to_replace.end(); ++chunk)
 	{
-		chunk_text.Replace(chunk->first, chunk->second);
+		ReplaceAll(chunk_text, chunk->first, chunk->second);
 	}
 }
 

--- a/src/arch/ArchHooks/ArchHooks_MacOSX.mm
+++ b/src/arch/ArchHooks/ArchHooks_MacOSX.mm
@@ -319,7 +319,7 @@ void ArchHooks::MountInitialFilesystems( const RString &sDirOfExecutable )
 		CFStringRef dataPath = CFURLCopyFileSystemPath( dataUrl, kCFURLPOSIXPathStyle );
 		CFStringGetCString( dataPath, dir, PATH_MAX, kCFStringEncodingUTF8 );
 
-		if( strncmp(sDirOfExecutable, dir, sDirOfExecutable.length()) == 0 )
+		if( strncmp(sDirOfExecutable.c_str(), dir, sDirOfExecutable.length()) == 0 )
 			FILEMAN->Mount( "zip", dir + sDirOfExecutable.length(), "/" );
 		CFRelease( dataPath );
 		CFRelease( dataUrl );

--- a/src/arch/Dialog/Dialog.cpp
+++ b/src/arch/Dialog/Dialog.cpp
@@ -28,15 +28,25 @@ DialogDriver *MakeDialogDriver()
 	for( unsigned i = 0; pRet == NULL && i < asDriversToTry.size(); ++i )
 	{
 		sDriver = asDriversToTry[i];
+		ci_string ciDriver(sDriver.c_str());
 
 #ifdef USE_DIALOG_DRIVER_COCOA
-		if( !asDriversToTry[i].CompareNoCase("Cocoa") )	pRet = new DialogDriver_MacOSX;
+		if( ciDriver == "Cocoa" )
+		{
+			pRet = new DialogDriver_MacOSX;
+		}
 #endif
 #ifdef USE_DIALOG_DRIVER_WIN32
-		if( !asDriversToTry[i].CompareNoCase("Win32") )	pRet = new DialogDriver_Win32;
+		if( ciDriver == "Win32" )
+		{
+			pRet = new DialogDriver_Win32;
+		}
 #endif
 #ifdef USE_DIALOG_DRIVER_NULL
-		if( !asDriversToTry[i].CompareNoCase("Null") )	pRet = new DialogDriver_Null;
+		if( ciDriver == "Null" )
+		{
+			pRet = new DialogDriver_Null;
+		}
 #endif
 
 		if( pRet == NULL )
@@ -87,11 +97,13 @@ static bool MessageIsIgnored( RString sID )
 #if !defined(SMPACKAGE)
 	vector<RString> asList;
 	split( g_sIgnoredDialogs, ",", asList );
-	for( unsigned i = 0; i < asList.size(); ++i )
-		if( !sID.CompareNoCase(asList[i]) )
-			return true;
-#endif
+	ci_string cid(sID.c_str());
+	return std::any_of(asList.begin(), asList.end(), [&cid](RString const &item) {
+		return cid == item.c_str();
+	});
+#else
 	return false;
+#endif
 }
 
 void Dialog::IgnoreMessage( RString sID )

--- a/src/arch/Dialog/DialogDriver.cpp
+++ b/src/arch/Dialog/DialogDriver.cpp
@@ -26,7 +26,7 @@ DialogDriver *DialogDriver::Create()
 
 	for (auto const &Driver: asDriversToTry)
 	{
-		auto iter = RegisterDialogDriver::g_pRegistrees->find( istring(Driver) );
+		auto iter = RegisterDialogDriver::g_pRegistrees->find( istring(Driver.c_str()) );
 
 		if( iter == RegisterDialogDriver::g_pRegistrees->end() )
 			continue;

--- a/src/arch/Dialog/DialogDriver_MacOSX.cpp
+++ b/src/arch/Dialog/DialogDriver_MacOSX.cpp
@@ -14,7 +14,7 @@ static CFOptionFlags ShowAlert( CFOptionFlags flags, const RString& sMessage, CF
 				CFStringRef alt = NULL, CFStringRef other = NULL)
 {
 	CFOptionFlags result;
-	CFStringRef text = CFStringCreateWithCString( NULL, sMessage, kCFStringEncodingUTF8 );
+	CFStringRef text = CFStringCreateWithCString( NULL, sMessage.c_str(), kCFStringEncodingUTF8 );
 
 	if( text == NULL )
 	{

--- a/src/arch/LoadingWindow/LoadingWindow.cpp
+++ b/src/arch/LoadingWindow/LoadingWindow.cpp
@@ -26,18 +26,29 @@ LoadingWindow *LoadingWindow::Create()
 	for( unsigned i = 0; ret == NULL && i < DriversToTry.size(); ++i )
 	{
 		Driver = DriversToTry[i];
-
+		ci_string ciDriver(Driver.c_str());
 #ifdef USE_LOADING_WINDOW_MACOSX
-		if( !DriversToTry[i].CompareNoCase("MacOSX") )	ret = new LoadingWindow_MacOSX;
+		if( ciDriver == "MacOSX" )
+		{
+			ret = new LoadingWindow_MacOSX;
+		}
 #endif
 #ifdef USE_LOADING_WINDOW_GTK
-		if( !DriversToTry[i].CompareNoCase("Gtk") )	ret = new LoadingWindow_Gtk;
+		if( ciDriver == "Gtk" )
+		{
+			ret = new LoadingWindow_Gtk;
+		}
 #endif
 #ifdef USE_LOADING_WINDOW_WIN32
-		if( !DriversToTry[i].CompareNoCase("Win32") )	ret = new LoadingWindow_Win32;
+		if( ciDriver "Win32" )
+		{
+			ret = new LoadingWindow_Win32;
+		}
 #endif
-		if( !DriversToTry[i].CompareNoCase("Null") )	ret = new LoadingWindow_Null;
-
+		if( ciDriver == "Null")
+		{
+			ret = new LoadingWindow_Null;
+		}
 		if( ret == NULL )
 			continue;
 

--- a/src/arch/LoadingWindow/LoadingWindow_MacOSX.mm
+++ b/src/arch/LoadingWindow/LoadingWindow_MacOSX.mm
@@ -129,7 +129,7 @@ void LoadingWindow_MacOSX::SetText( RString str )
 {
 	if( !g_Helper )
 		return;
-	NSString *s = [[NSString alloc] initWithUTF8String:str];
+	NSString *s = [[NSString alloc] initWithUTF8String:str.c_str()];
 	[g_Helper->m_Text performSelectorOnMainThread:@selector(setString:) withObject:(s ? s : @"") waitUntilDone:NO];
 	[s release];
 }

--- a/src/arch/LowLevelWindow/LowLevelWindow_MacOSX.mm
+++ b/src/arch/LowLevelWindow/LowLevelWindow_MacOSX.mm
@@ -327,7 +327,7 @@ void *LowLevelWindow_MacOSX::GetProcAddress( RString s )
 	const uint32_t options = NSLOOKUPSYMBOLINIMAGE_OPTION_RETURN_ON_ERROR;
 	
 	for( uint32_t i = 0; i < count && !symbol; ++i )
-		symbol = NSLookupSymbolInImage( _dyld_get_image_header(i), symbolName, options );
+		symbol = NSLookupSymbolInImage( _dyld_get_image_header(i), symbolName.c_str(), options );
 	return symbol ? NSAddressOfSymbol( symbol ) : NULL;
 }
 

--- a/src/arch/MemoryCard/MemoryCardDriverThreaded_MacOSX.cpp
+++ b/src/arch/MemoryCard/MemoryCardDriverThreaded_MacOSX.cpp
@@ -222,7 +222,7 @@ void MemoryCardDriverThreaded_MacOSX::GetUSBStorageDevices( vector<UsbStorageDev
 
 bool MemoryCardDriverThreaded_MacOSX::TestWrite( UsbStorageDevice *pDevice )
 {
-	if( access(pDevice->sOsMountDir, W_OK) )
+	if( access(pDevice->sOsMountDir.c_str(), W_OK) )
 	{
 		pDevice->SetError( "TestFailed" );
 		return false;

--- a/src/arch/MemoryCard/MemoryCardDriverThreaded_MacOSX.cpp
+++ b/src/arch/MemoryCard/MemoryCardDriverThreaded_MacOSX.cpp
@@ -153,7 +153,7 @@ void MemoryCardDriverThreaded_MacOSX::GetUSBStorageDevices( vector<UsbStorageDev
 		// Now that we have the disk name, look up the IOServices associated with it.
 		CFMutableDictionaryRef dict;
 
-		if( !(dict = IOBSDNameMatching(kIOMasterPortDefault, 0, sDisk)) )
+		if( !(dict = IOBSDNameMatching(kIOMasterPortDefault, 0, sDisk.c_str())) )
 			continue;
 
 		// Look for certain properties: Leaf, Ejectable, Writable.

--- a/src/arch/MovieTexture/MovieTexture.cpp
+++ b/src/arch/MovieTexture/MovieTexture.cpp
@@ -21,15 +21,13 @@ bool RageMovieTexture::GetFourCC( RString fn, RString &handler, RString &type )
 {
 	RString ignore, ext;
 	splitpath( fn, ignore, ignore, ext);
-	if( !ext.CompareNoCase(".mpg") ||
-		!ext.CompareNoCase(".mpeg") ||
-		!ext.CompareNoCase(".mpv") ||
-		!ext.CompareNoCase(".mpe") )
+	ci_string ciExt(ext.c_str());
+	if (ciExt == ".mpg" || ciExt == ".mpeg" || ciExt == ".mpv" || ciExt == ".mpe")
 	{
 		handler = type = "MPEG";
 		return true;
 	}
-	if( !ext.CompareNoCase(".ogv") )
+	if( ciExt == ".ogv" )
 	{
 		handler = type = "Ogg";
 		return true;

--- a/src/arch/MovieTexture/MovieTexture_FFMpeg.cpp
+++ b/src/arch/MovieTexture/MovieTexture_FFMpeg.cpp
@@ -208,9 +208,9 @@ int MovieDecoder_FFMpeg::ReadPacket()
 	if( m_iEOF > 0 )
 		return 0;
 
-	while( 1 )
+	for(;;)
 	{
-		CHECKPOINT;
+		CHECKPOINT_M("Analyzing the ffmpeg packets.");
 		if( m_iCurrentPacketOffset != -1 )
 		{
 			m_iCurrentPacketOffset = -1;
@@ -261,7 +261,7 @@ int MovieDecoder_FFMpeg::DecodePacket( float fTargetTime )
 			(m_pStream->codec->frame_number % 2) == 0;
 
 		int iGotFrame;
-		CHECKPOINT;
+		CHECKPOINT_M("About to unleash the ffmpeg hack.");
 		/* Hack: we need to send size = 0 to flush frames at the end, but we have
 		 * to give it a buffer to read from since it tries to read anyway. */
 		m_Packet.data = m_Packet.size ? m_Packet.data : NULL;
@@ -269,7 +269,7 @@ int MovieDecoder_FFMpeg::DecodePacket( float fTargetTime )
 				m_pStream->codec, 
 				&m_Frame, &iGotFrame,
 				&m_Packet );
-		CHECKPOINT;
+		CHECKPOINT_M("Done with ffmpeg hack.");
 
 		if( len < 0 )
 		{

--- a/src/arch/MovieTexture/MovieTexture_Generic.cpp
+++ b/src/arch/MovieTexture/MovieTexture_Generic.cpp
@@ -65,7 +65,7 @@ RString MovieTexture_Generic::Init()
 
 	UpdateFrame();
 
-	CHECKPOINT;
+	CHECKPOINT_M("Done initializing.");
 
 	return RString();
 }
@@ -185,7 +185,7 @@ void MovieTexture_Generic::CreateTexture()
 	if( m_uTexHandle || m_pRenderTarget != NULL )
 		return;
 
-	CHECKPOINT;
+	CHECKPOINT_M("About to create a texture.");
 
 	m_iSourceWidth  = m_pDecoder->GetWidth();
 	m_iSourceHeight = m_pDecoder->GetHeight();
@@ -327,7 +327,7 @@ bool MovieTexture_Generic::DecodeFrame()
 			m_fClock = -fDelay;
 		}
 
-		CHECKPOINT;
+		CHECKPOINT_M("Decoding: about to read a frame.");
 
 		/* Read a frame. */
 		float fTargetTime = -1;
@@ -436,7 +436,7 @@ void MovieTexture_Generic::DecodeSeconds( float fSeconds )
 		if( fTime > 0 )
 			return;
 
-		CHECKPOINT;
+		CHECKPOINT_M("Time to update the frame.");
 
 		UpdateFrame();
 
@@ -465,7 +465,7 @@ void MovieTexture_Generic::UpdateFrame()
 
 	if( m_pRenderTarget != NULL )
 	{
-		CHECKPOINT;
+		CHECKPOINT_M("Uploading a texture.");
 
 		/* If we have no m_pTextureLock, we still have to upload the texture. */
 		if( m_pTextureLock == NULL )
@@ -474,7 +474,7 @@ void MovieTexture_Generic::UpdateFrame()
 				m_pSurface,
 				0, 0,
 				m_pSurface->w, m_pSurface->h );
-		CHECKPOINT;
+		CHECKPOINT_M("Uploaded the texture.");
 
 		m_pRenderTarget->BeginRenderingTo( false );
 		m_pSprite->Draw();
@@ -482,14 +482,14 @@ void MovieTexture_Generic::UpdateFrame()
 	}
 	else
 	{
-		CHECKPOINT;
+		CHECKPOINT_M("Uploading a texture.");
 		if( m_pTextureLock == NULL )
 			DISPLAY->UpdateTexture(
 				m_uTexHandle,
 				m_pSurface,
 				0, 0,
 				m_iImageWidth, m_iImageHeight );
-		CHECKPOINT;
+		CHECKPOINT_M("Uploaded the texture.");
 	}
 }
 

--- a/src/arch/RageDriver.cpp
+++ b/src/arch/RageDriver.cpp
@@ -15,7 +15,7 @@ RageDriver *DriverList::Create( const RString &sDriverName )
 	if( m_pRegistrees == NULL )
 		return NULL;
 
-	auto iter = m_pRegistrees->find( istring(sDriverName) );
+	auto iter = m_pRegistrees->find( istring(sDriverName.c_str()) );
 	if( iter == m_pRegistrees->end() )
 		return NULL;
 	return (iter->second)();

--- a/src/arch/Sound/RageSoundDriver_Generic_Software.cpp
+++ b/src/arch/Sound/RageSoundDriver_Generic_Software.cpp
@@ -198,7 +198,7 @@ void RageSoundDriver::DecodeThread()
 			if( s.m_State != Sound::PLAYING )
 				continue;
 
-			CHECKPOINT;
+			CHECKPOINT_M("About to set a sound to stop playing fully.");
 			while( s.m_Buffer.num_writable() )
 			{
 				int iWrote = GetDataForSound( s );

--- a/src/archutils/Unix/BacktraceNames.cpp
+++ b/src/archutils/Unix/BacktraceNames.cpp
@@ -278,13 +278,13 @@ void BacktraceNames::FromAddr( const void *p )
 	 * __start   -> _start
 	 * __ZN7RageLog5TraceEPKcz -> _ZN7RageLog5TraceEPKcz (so demangling will work)
 	 */
-	if( Symbol.Left(1) == "_" )
+	if( BeginsWith(Symbol, "_" ))
 		Symbol = Symbol.substr(1);
 	/* After stripping off the leading _
 	 * _GLOBAL__I__ZN5ModelC2Ev -> _ZN5ModelC2Ev
 	 * _GLOBAL__D__Z12ForceToAsciiR7CStdStrIcE -> _Z12ForceToAsciiR7CStdStrIcE
 	 */
-	if( Symbol.Left(9) == "_GLOBAL__" )
+	if( BeginsWith(Symbol, "_GLOBAL__" ))
 		Symbol = Symbol.substr(11);
 	
 }

--- a/src/archutils/Unix/BacktraceNames.cpp
+++ b/src/archutils/Unix/BacktraceNames.cpp
@@ -42,7 +42,7 @@ void BacktraceNames::Demangle()
 		return;
 	
 	int status = 0;
-	char *name = abi::__cxa_demangle( Symbol, NULL, NULL, &status );
+	char *name = abi::__cxa_demangle( Symbol.c_str(), NULL, NULL, &status );
 	if( name )
 	{
 		Symbol = name;

--- a/src/archutils/Unix/CrashHandler.cpp
+++ b/src/archutils/Unix/CrashHandler.cpp
@@ -323,7 +323,7 @@ static void BacktraceAllThreads( CrashData& crash )
 	}
 }
 
-void CrashHandler::ForceCrash( std::string const reason )
+void CrashHandler::ForceCrash( std::string const &reason )
 {
 	CrashData crash;
 	memset( &crash, 0, sizeof(crash) );

--- a/src/archutils/Unix/CrashHandler.cpp
+++ b/src/archutils/Unix/CrashHandler.cpp
@@ -363,7 +363,7 @@ void CrashHandler::ForceDeadlock( RString reason, uint64_t iID )
 
 	strncpy( crash.m_ThreadName[0], RageThread::GetCurrentThreadName(), sizeof(crash.m_ThreadName[0])-1 );
 
-	strncpy( crash.reason, reason, std::min(sizeof(crash.reason) - 1, reason.length()) );
+	strncpy( crash.reason, reason.c_str(), std::min(sizeof(crash.reason) - 1, reason.length()) );
 	crash.reason[ sizeof(crash.reason)-1 ] = 0;
 
 	RunCrashHandler( &crash );

--- a/src/archutils/Unix/CrashHandler.cpp
+++ b/src/archutils/Unix/CrashHandler.cpp
@@ -323,13 +323,13 @@ static void BacktraceAllThreads( CrashData& crash )
 	}
 }
 
-void CrashHandler::ForceCrash( const char *reason )
+void CrashHandler::ForceCrash( std::string const reason )
 {
 	CrashData crash;
 	memset( &crash, 0, sizeof(crash) );
 
 	crash.type = CrashData::FORCE_CRASH;
-	strncpy( crash.reason, reason, sizeof(crash.reason) );
+	strncpy( crash.reason, reason.c_str(), sizeof(crash.reason) );
 	crash.reason[ sizeof(crash.reason)-1 ] = 0;
 
 	GetBacktrace( crash.BacktracePointers[0], BACKTRACE_MAX_SIZE, NULL );

--- a/src/archutils/Unix/CrashHandler.h
+++ b/src/archutils/Unix/CrashHandler.h
@@ -9,7 +9,7 @@ namespace CrashHandler
 	void CrashHandlerHandleArgs( int argc, char* argv[] );
 	void InitializeCrashHandler();
 	void CrashSignalHandler( int signal, siginfo_t *si, const ucontext_t *uc );
-	void ForceCrash( std::string const reason );
+	void ForceCrash( std::string const &reason );
 	void ForceDeadlock( RString reason, uint64_t CrashHandle );
 }
 

--- a/src/archutils/Unix/CrashHandler.h
+++ b/src/archutils/Unix/CrashHandler.h
@@ -9,7 +9,7 @@ namespace CrashHandler
 	void CrashHandlerHandleArgs( int argc, char* argv[] );
 	void InitializeCrashHandler();
 	void CrashSignalHandler( int signal, siginfo_t *si, const ucontext_t *uc );
-	void ForceCrash( const char *reason );
+	void ForceCrash( std::string const reason );
 	void ForceDeadlock( RString reason, uint64_t CrashHandle );
 }
 

--- a/src/archutils/Unix/CrashHandlerChild.cpp
+++ b/src/archutils/Unix/CrashHandlerChild.cpp
@@ -195,10 +195,10 @@ static void child_process()
 #endif
 	sCrashInfoPath += "/crashinfo.txt";
 	
-	FILE *CrashDump = fopen( sCrashInfoPath, "w+" );
+	FILE *CrashDump = fopen( sCrashInfoPath.c_str(), "w+" );
 	if(CrashDump == NULL)
 	{
-		fprintf( stderr, "Couldn't open " + sCrashInfoPath + ": %s\n", strerror(errno) );
+		fprintf( stderr, "Couldn't open %s: %s\n", sCrashInfoPath.c_str(), strerror(errno) );
 		exit(1);
 	}
 	
@@ -247,7 +247,7 @@ static void child_process()
 	
 	fprintf(CrashDump, "Checkpoints:\n");
 	for( unsigned i=0; i<Checkpoints.size(); ++i )
-		fputs( Checkpoints[i], CrashDump );
+		fputs( Checkpoints[i].c_str(), CrashDump );
 	fprintf( CrashDump, "\n" );
 	
 	for( int i = 0; i < CrashData::MAX_BACKTRACE_THREADS; ++i )

--- a/src/archutils/Win32/Crash.cpp
+++ b/src/archutils/Win32/Crash.cpp
@@ -624,9 +624,9 @@ void CrashHandler::ForceDeadlock( RString reason, uint64_t iID )
 	debug_crash();
 }
 
-void CrashHandler::ForceCrash( const char *reason )
+void CrashHandler::ForceCrash( std::string const reason )
 {
-	strncpy( g_CrashInfo.m_CrashReason, reason, sizeof(g_CrashInfo.m_CrashReason) );
+	strncpy( g_CrashInfo.m_CrashReason, reason.c_str(), sizeof(g_CrashInfo.m_CrashReason) );
 	g_CrashInfo.m_CrashReason[ sizeof(g_CrashInfo.m_CrashReason)-1 ] = 0;
 
 	debug_crash();

--- a/src/archutils/Win32/Crash.h
+++ b/src/archutils/Win32/Crash.h
@@ -8,7 +8,7 @@ namespace CrashHandler
 
 	void do_backtrace( const void **buf, size_t size, HANDLE hProcess, HANDLE hThread, const CONTEXT *pContext );
 	void SymLookup( const void *ptr, char *buf );
-	void ForceCrash( const char *reason );
+	void ForceCrash( std::string const reason );
 	void ForceDeadlock( RString reason, uint64_t iID );
 
 	/* Inform the crash handler of a foreground window that may be fullscreen.

--- a/src/global.cpp
+++ b/src/global.cpp
@@ -20,7 +20,7 @@ using CrashHandler::DebugBreak;
 #include "archutils/Unix/CrashHandler.h"
 #endif
 
-void NORETURN sm_crash( std::string const reason )
+void NORETURN sm_crash( std::string const &reason )
 {
 #if ( defined(_WINDOWS) && defined(CRASH_HANDLER) ) || defined(MACOSX) || defined(_XDBG)
 	/* If we're being debugged, throw a debug break so it'll suspend the process. */

--- a/src/global.cpp
+++ b/src/global.cpp
@@ -20,7 +20,7 @@ using CrashHandler::DebugBreak;
 #include "archutils/Unix/CrashHandler.h"
 #endif
 
-void NORETURN sm_crash( const char *reason )
+void NORETURN sm_crash( std::string const reason )
 {
 #if ( defined(_WINDOWS) && defined(CRASH_HANDLER) ) || defined(MACOSX) || defined(_XDBG)
 	/* If we're being debugged, throw a debug break so it'll suspend the process. */

--- a/src/global.h
+++ b/src/global.h
@@ -53,6 +53,9 @@
 /* Everything will need string for one reason or another: */
 #include <string>
 
+/* ...and the formatting library to go with it: */
+#include "format.h"
+
 /* And vector: */
 #include <vector>
 

--- a/src/global.h
+++ b/src/global.h
@@ -137,7 +137,7 @@ void NORETURN sm_crash( std::string const &reason = "Internal error" );
 /** @brief Use this to catch switching on invalid values */
 #define DEFAULT_FAIL(i) 	default: FAIL_M( ssprintf("%s = %i", #i, (i)) )
 
-void ShowWarningOrTrace( const char *file, int line, const char *message, bool bWarning ); // don't pull in LOG here
+void ShowWarningOrTrace( const char *file, int line, std::string const &message, bool bWarning ); // don't pull in LOG here
 #define WARN(MESSAGE) (ShowWarningOrTrace(__FILE__, __LINE__, MESSAGE, true))
 #if !defined(CO_EXIST_WITH_MFC)
 #define TRACE(MESSAGE) (ShowWarningOrTrace(__FILE__, __LINE__, MESSAGE, false))

--- a/src/global.h
+++ b/src/global.h
@@ -88,11 +88,8 @@ namespace Checkpoints
 {
 	void SetCheckpoint( const char *file, int line, std::string const &message );
 }
-/** @brief Set a checkpoint with no message. */
-#define CHECKPOINT (Checkpoints::SetCheckpoint(__FILE__, __LINE__, NULL))
 /** @brief Set a checkpoint with a specified message. */
 #define CHECKPOINT_M(m) (Checkpoints::SetCheckpoint(__FILE__, __LINE__, m))
-
 
 /**
  * @brief Define a macro to tell the compiler that a function doesn't return.

--- a/src/global.h
+++ b/src/global.h
@@ -114,7 +114,7 @@ namespace Checkpoints
  * @param reason the crash reason as determined by prior function calls.
  * @return nothing: there is no escape without quitting the program.
  */
-void NORETURN sm_crash( const char *reason = "Internal error" );
+void NORETURN sm_crash( std::string const reason = "Internal error" );
 
 /**
  * @brief Assertion that sets an optional message and brings up the crash
@@ -175,9 +175,8 @@ template<int> struct CompileAssertDecl { };
 #define CONST_FUNCTION
 #endif
 
-#include "StdString.h"
 /** @brief Use RStrings throughout the program. */
-typedef StdString::CStdString RString;
+typedef std::string RString;
 
 #if !defined(WIN32)
 /** @brief Define stricmp to be strcasecmp. */

--- a/src/global.h
+++ b/src/global.h
@@ -86,7 +86,7 @@
 /** @brief RageThreads defines (don't pull in all of RageThreads.h here) */
 namespace Checkpoints
 {
-	void SetCheckpoint( const char *file, int line, const char *message );
+	void SetCheckpoint( const char *file, int line, std::string const &message );
 }
 /** @brief Set a checkpoint with no message. */
 #define CHECKPOINT (Checkpoints::SetCheckpoint(__FILE__, __LINE__, NULL))
@@ -117,7 +117,7 @@ namespace Checkpoints
  * @param reason the crash reason as determined by prior function calls.
  * @return nothing: there is no escape without quitting the program.
  */
-void NORETURN sm_crash( std::string const reason = "Internal error" );
+void NORETURN sm_crash( std::string const &reason = "Internal error" );
 
 /**
  * @brief Assertion that sets an optional message and brings up the crash


### PR DESCRIPTION
This was my attempt to remove StdString::CStdString, aka RString, from our codebase to replace with std::string. At this point, it can compile and link on Mac OS X, but definitely not run: there are issues with mounting the correct paths.

Windows and Linux have not been touched yet.

A few things were learned that can hopefully be utilized for next time:

* Address `CHECKPOINT` and `CHECKPOINT_M` early. That can possibly be done even in the master branch.
* Address the implicit preference casts early. That can possibly be done even in the master branch.
* Find a cleaner way of working around the lower level buffer calls.
* Find a cleaner way of comparing the strings in upper and lower case. That may already exist with `istring`, but I did not notice it when I started that.

If anyone wants to try this out, feel free, but here be dragons.