### PR TITLE
Fix mistranslation in one line:  Themes/_fallback/Languages/ja.ini

### DIFF
--- a/Themes/_fallback/Languages/ja.ini
+++ b/Themes/_fallback/Languages/ja.ini
@@ -1,4 +1,4 @@
-﻿// Stepmania用日本語言語パック(fallback用) Ver.2-20150411
+// Stepmania用日本語言語パック(fallback用) Ver.2-20150411
 
 // 翻訳終わった部分には済マーク入れます
 // 5.0.7の追加オプションの説明を追加
@@ -550,7 +550,7 @@ EasterEggs=このオプションをOnにして、Perfect以上で250コンボ繋
 EditClearPromptThreshold=プロンプト画面を開かなくても削除されるノートの数を設定します。
 FastLoad=Onにすると、起動時にSongs/Coursesフォルダのチェックを簡略化します。
 HiddenSongs=Onにすると、譜面ファイルに「#SELECTABLE:NO」と記述されている曲が\nミュージックホイールから選択できなくなります。
-LifeDifficulty=この値を小さくするとゲージの減りが大きくなり回復が小さくなります。
+LifeDifficulty=この値を大きくするとゲージの減りが大きくなり回復が小さくなります。
 MinTNSToHideNotes=ノートが消滅する判定を指定します。
 Speed Increment=ノート速度オプションの増分の最小値を指定します。
 Speed Increment Large=ノート速度オプションの増分の最大値を指定します。


### PR DESCRIPTION
I fixed mistranslation of explanation LIFE DIFFICULTY in Advanced Options Japanese version.
The English sentence is "Increase this value to cause your life meter to drain faster and refill slower".
When some user changes to increase LIFE DIFFICULTY for easier to expect clear the game, they will confuse.