### PR TITLE
reduce udev logging of PIUIO LightState changes

### DIFF
--- a/src/arch/Lights/LightsDriver_Linux_PIUIO_Leds.cpp
+++ b/src/arch/Lights/LightsDriver_Linux_PIUIO_Leds.cpp
@@ -85,6 +85,13 @@ void LightsDriver_Linux_PIUIO_Leds::Set( const LightsState *ls )
 {
 	FOREACH_CabinetLight(light)
 	{
+		// Only SetLight if LightsState has changed since previous iteration.
+		// This reduces unncessary strain on udev.  -dguzek
+		if (ls->m_bCabinetLights[light] == previousLS.m_bCabinetLights[light] )
+		{
+			continue;
+		}
+
 		if (!SetLight(cabinet_leds[light], ls->m_bCabinetLights[light]))
 		{
 			LOG->Warn("Error setting cabinet light %s",
@@ -101,6 +108,11 @@ void LightsDriver_Linux_PIUIO_Leds::Set( const LightsState *ls )
 		{
 			FOREACH_GameButton_Custom(gb)
 			{
+				if (ls->m_bGameButtonLights[c][gb] == previousLS.m_bGameButtonLights[c][gb])
+				{
+					continue;
+				}
+
 				if (!SetLight(dance_leds[c][gb], ls->m_bGameButtonLights[c][gb]))
 				{
 					LOG->Warn("Error setting button light %s",
@@ -116,6 +128,11 @@ void LightsDriver_Linux_PIUIO_Leds::Set( const LightsState *ls )
 		{
 			FOREACH_GameButton_Custom(gb)
 			{
+				if (ls->m_bGameButtonLights[c][gb] == previousLS.m_bGameButtonLights[c][gb])
+				{
+					continue;
+				}
+
 				if (!SetLight(pump_leds[c][gb], ls->m_bGameButtonLights[c][gb]))
 				{
 					LOG->Warn("Error setting button light %s",
@@ -129,12 +146,14 @@ void LightsDriver_Linux_PIUIO_Leds::Set( const LightsState *ls )
 	{
 		return;
 	}
+
+	previousLS = *ls;
 }
 
 /*
  * (c) 2014 StepMania team
  * All rights reserved.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the
  * "Software"), to deal in the Software without restriction, including
@@ -144,7 +163,7 @@ void LightsDriver_Linux_PIUIO_Leds::Set( const LightsState *ls )
  * copyright notice(s) and this permission notice appear in all copies of
  * the Software and that both the above copyright notice(s) and this
  * permission notice appear in supporting documentation.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
  * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
  * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF

--- a/src/arch/Lights/LightsDriver_Linux_PIUIO_Leds.h
+++ b/src/arch/Lights/LightsDriver_Linux_PIUIO_Leds.h
@@ -7,6 +7,9 @@
 
 class LightsDriver_Linux_PIUIO_Leds : public LightsDriver
 {
+private:
+	LightsState previousLS;
+
 public:
 	LightsDriver_Linux_PIUIO_Leds();
 	virtual ~LightsDriver_Linux_PIUIO_Leds();
@@ -19,7 +22,7 @@ public:
 /*
  * (c) 2014 StepMania team
  * All rights reserved.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the
  * "Software"), to deal in the Software without restriction, including
@@ -29,7 +32,7 @@ public:
  * copyright notice(s) and this permission notice appear in all copies of
  * the Software and that both the above copyright notice(s) and this
  * permission notice appear in supporting documentation.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
  * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
  * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF


### PR DESCRIPTION
Previously, the code here logged every LightState of every PIUIO_Led light with every call of `Set()`.

This commit adds checks to see if each of the PIUIO_Leds have changed LightState since the last `Set()` and skips logging the current LightState if there is no change.  Each set of lights was already being looped through; the new code here just issues a continue to skip logging where possible.

This helps reduce CPU usage when PIUIO_Leds are in use as the LightsDriver.

I've done some informal verification by eyeballing the output of htop:

Before - *udev* using ~10.0% CPU
---
![before](https://cloud.githubusercontent.com/assets/1253483/9055276/517f88a6-3a57-11e5-8f33-9eaf399e65da.png)

After - *udev* using ~0.0% CPU
---
![after](https://cloud.githubusercontent.com/assets/1253483/9055275/517f1ce0-3a57-11e5-9dfc-ef385af2fd3b.png)

Still, this sort stuff is admittedly outside my expertise, so any comments/criticisms are welcome!