### PR TITLE
Change RandomBGEndsAtLastBeat metric to true by default

### DIFF
--- a/Themes/_fallback/metrics.ini
+++ b/Themes/_fallback/metrics.ini
@@ -242,7 +242,7 @@ BottomEdge=SCREEN_BOTTOM
 RandomBGStartBeat=-1000
 RandomBGChangeMeasures=4
 RandomBGChangesWhenBPMChangesAtMeasureStart=true
-RandomBGEndsAtLastBeat=false
+RandomBGEndsAtLastBeat=true
 
 [Banner]
 # Scroll stuff when you roll over it, DDR Extreme style.


### PR DESCRIPTION
Setting the variable to true maintains behavior consistent with stable releases.