### PR TITLE
Follow symbolic links when searching for executable directory

### DIFF
--- a/src/RageFileManager.cpp
+++ b/src/RageFileManager.cpp
@@ -172,6 +172,42 @@ public:
 };
 static RageFileDriverMountpoints *g_Mountpoints = NULL;
 
+static RString ExtractDirectory( RString sPath )
+{
+	// return the directory containing sPath
+	size_t n = sPath.find_last_of("/");
+	if( n != sPath.npos )
+		sPath.erase(n);
+	else
+		sPath.erase();
+	return sPath;
+}
+
+static RString ReadlinkRecursive( RString sPath )
+{
+#if defined(UNIX) || defined(MACOSX)
+	// unices support symbolic links; dereference them
+	RString dereferenced = sPath;
+	do
+	{
+		sPath = dereferenced;
+		char derefPath[512];
+		ssize_t linkSize = readlink(sPath, derefPath, sizeof(derefPath));
+		if ( linkSize != -1 && linkSize != sizeof(derefPath) )
+		{
+			dereferenced = RString( derefPath, linkSize );
+			if (derefPath[0] != '/')
+			{
+				// relative link
+				dereferenced = RString( ExtractDirectory(sPath) + "/" + dereferenced);
+			}
+		}
+	} while (sPath != dereferenced);
+#endif
+
+	return sPath;
+}
+
 static RString GetDirOfExecutable( RString argv0 )
 {
 	// argv[0] can be wrong in most OS's; try to avoid using it.
@@ -196,11 +232,7 @@ static RString GetDirOfExecutable( RString argv0 )
 #endif
 
 	// strip off executable name
-	size_t n = sPath.find_last_of("/");
-	if( n != sPath.npos )
-		sPath.erase(n);
-	else
-		sPath.erase();
+	sPath = ExtractDirectory(sPath);
 
 	if( !bIsAbsolutePath )
 	{
@@ -219,17 +251,18 @@ static RString GetDirOfExecutable( RString argv0 )
 			{
 				if( access(*i + "/" + argv0, X_OK|R_OK) )
 					continue;
-				sPath = *i;
+				sPath = ExtractDirectory(ReadlinkRecursive(*i + "/" + argv0));
 				break;
 			}
 			if( sPath.empty() )
 				sPath = GetCwd(); // What?
 			else if( sPath[0] != '/' ) // For example, if . is in $PATH.
 				sPath = GetCwd() + "/" + sPath;
+
 		}
 		else
 		{
-			sPath = GetCwd() + "/" + sPath;
+			sPath = ExtractDirectory(ReadlinkRecursive(GetCwd() + "/" + argv0));
 		}
 #else
 		sPath = GetCwd() + "/" + sPath;


### PR DESCRIPTION
By default on linux, stepmania installs to `/usr/local/stepmania-5.0/stepmania`. Since this is not on the default path, I find myself creating a symbolic link from `/usr/local/bin/stepmania -> /usr/local/stepmania-5.0/stepmania` (or similar). However, this causes stepmania to think it is running from `/usr/local/bin` instead of its actual install directory, and so it fails to find the Songs and Themes directories, etc.

This PR fixes things such that Stepmania finds the full path of the directory containing the *actual* binary, and not some symbolic link to it.

I tested it very thoroughly on Linux - launching stepmania by absolute path to binary, relative path, relative path to a symlink pointing to the absolute binary path, relative path to a symlink pointing to the relative binary path, absolute path to a symlink pointing to the relative binary path, and absolute path to a symlink pointing to the absolute binary path. It all works as it should. The behavior on Windows is effectively unchanged.