### PR TITLE
Made CMake configuration work on FreeBSD

### DIFF
--- a/StepmaniaCore.cmake
+++ b/StepmaniaCore.cmake
@@ -113,7 +113,7 @@ elseif(MACOSX)
     MAC_FRAME_OPENGL
     MAC_FRAME_QUICKTIME
   )
-elseif(LINUX)
+elseif(LINUX OR BSD)
   include(TestBigEndian)
   include(ExternalProject)
 

--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -1,5 +1,5 @@
 include(CMakeProject-lua.cmake)
-if (NOT ${GLEW_FOUND})
+if (NOT BSD)
   include(CMakeProject-glew.cmake)
 endif()
 include(CMakeProject-json.cmake)

--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -1,5 +1,7 @@
 include(CMakeProject-lua.cmake)
-include(CMakeProject-glew.cmake)
+if (NOT ${GLEW_FOUND})
+  include(CMakeProject-glew.cmake)
+endif()
 include(CMakeProject-json.cmake)
 if (NOT SYSTEM_PCRE_FOUND)
   include(CMakeProject-pcre.cmake)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -535,7 +535,7 @@ else() # Unix / Linux
     endif()
   endif()
 
-  if (HAS_LIBDL)
+  if (LINUX)
     list(APPEND SMDATA_LINK_LIB
       "${DL_LIBRARY}"
     )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -535,9 +535,11 @@ else() # Unix / Linux
     endif()
   endif()
 
-  list(APPEND SMDATA_LINK_LIB
-    "${DL_LIBRARY}"
-  )
+  if (HAS_LIBDL)
+    list(APPEND SMDATA_LINK_LIB
+      "${DL_LIBRARY}"
+    )
+  endif()
 
   if(HAS_OGG)
     list(APPEND SMDATA_LINK_LIB


### PR DESCRIPTION
This PR allows the CMake configuration process succeed on FreeBSD (and possibly all other BSD flavours).

Building with `clang` requires a [few patches](https://gist.github.com/nilsding/cdd387ea8d32846a0b4c) though.  In order to link it successfully, set the LDFLAGS environment variable to `-L/usr/local/lib -lpng` so it links with libpng, otherwise StepMania will crash with a segfault (this normally should be done by cmake, but for some reason it doesn't).  It will also complain that it can't find `-lglew`, therefore in the file `$BUILDDIR/CMakeFiles/StepMania.dir/link.txt` replace every occurrence of it with `-lGLEW`.