### PR TITLE
Allow changing WAV and OGG settings for all OSes.

### DIFF
--- a/CMake/DefineOptions.cmake
+++ b/CMake/DefineOptions.cmake
@@ -31,8 +31,15 @@ option(WITH_NO_ROLC_TOMCRYPT "Build without the ROLC assembly instructions for t
 # Turn this option off to not use the GPL exclusive components.
 option(WITH_GPL_LIBS "Build with GPL libraries." ON)
 
+# Turn this option off to disable using WAV files with the game.
+# Note that it is recommended to keep this on.
+option(WITH_WAV "Build with WAV Support." ON)
+
 # Turn this option off to disable using MP3 files with the game.
 option(WITH_MP3 "Build with MP3 Support." ON)
+
+# Turn this option off to disable using OGG files with the game.
+option(WITH_OGG "Build with OGG/Vorbis Support." ON)
 
 if(WIN32)
   option(WITH_MINIMAID "Build with Minimaid Lights Support." ON)
@@ -45,7 +52,6 @@ elseif(LINUX)
     option(WITH_PROFILING "Build with Profiling Support." OFF)
     option(WITH_GLES2 "Build with OpenGL ES 2.0 Support." ON)
     option(WITH_GTK2 "Build with GTK2 Support." ON)
-    option(WITH_OGG "Build with OGG/Vorbis Support." ON)
     option(WITH_PARALLEL_PORT "Build with Parallel Lights I/O Support." OFF)
     option(WITH_CRASH_HANDLER "Build with Crash Handler Support." ON)
 endif()

--- a/StepmaniaCore.cmake
+++ b/StepmaniaCore.cmake
@@ -132,6 +132,18 @@ if (WITH_VERSION_INFO)
 endif()
 
 # Dependencies go here.
+include(ExternalProject)
+
+if(NOT WITH_GPL_LIBS)
+  message("Disabling GPL exclusive libraries: no MP3 support.")
+  set(WITH_MP3 OFF)
+endif()
+
+if(WITH_WAV)
+  # TODO: Identify which headers to check for ensuring this will always work.
+  set(HAS_WAV TRUE)
+endif()
+
 if(WITH_MP3)
   if(WIN32 OR MACOSX)
     set(HAS_MP3 TRUE)
@@ -145,8 +157,23 @@ if(WITH_MP3)
   endif()
 endif()
 
+if(WITH_OGG)
+  if(WIN32 OR MACOSX)
+    set(HAS_OGG TRUE)
+  else()
+    find_package(Ogg)
+    find_package(Vorbis)
+    find_package(VorbisFile)
+
+    if(NOT (OGG_FOUND AND VORBIS_FOUND AND VORBISFILE_FOUND) )
+      message(FATAL_ERROR "Not all vorbis libraries were found. If you wish to skip vorbis support, set WITH_OGG to OFF when configuring.")
+    else()
+      set(HAS_OGG TRUE)
+    endif()
+  endif()
+endif()
+
 if(WIN32)
-  set(HAS_OGG TRUE)
   set(SYSTEM_PCRE_FOUND FALSE)
   find_package(DirectX REQUIRED)
 
@@ -171,7 +198,6 @@ if(WIN32)
   )
   get_filename_component(LIB_AVUTIL ${LIB_AVUTIL} NAME)
 elseif(MACOSX)
-  set(HAS_OGG TRUE)
   set(SYSTEM_PCRE_FOUND FALSE)
   set(WITH_CRASH_HANDLER TRUE)
   # Apple Archs needs to be 32-bit for now.
@@ -210,13 +236,6 @@ elseif(MACOSX)
     MAC_FRAME_QUICKTIME
   )
 elseif(LINUX)
-  include(ExternalProject)
-
-  if(NOT WITH_GPL_LIBS)
-    message("Disabling GPL exclusive libraries: no MP3 support.")
-    set(WITH_MP3 OFF)
-  endif()
-
   if(WITH_GTK2)
     find_package("GTK2" 2.0)
     if (${GTK2_FOUND})
@@ -266,18 +285,6 @@ elseif(LINUX)
     set(HAS_XRANDR TRUE)
   else()
     set(HAX_XRANDR FALSE)
-  endif()
-
-  if (WITH_OGG)
-    find_package(Ogg)
-    find_package(Vorbis)
-    find_package(VorbisFile)
-
-    if(NOT (OGG_FOUND AND VORBIS_FOUND AND VORBISFILE_FOUND) )
-      message(FATAL_ERROR "Not all vorbis libraries were found. If you wish to skip vorbis support, set WITH_OGG to OFF when configuring.")
-    else()
-      set(HAS_OGG TRUE)
-    endif()
   endif()
 
   find_package(PulseAudio)

--- a/src/RageSoundReader_FileReader.cpp
+++ b/src/RageSoundReader_FileReader.cpp
@@ -5,7 +5,7 @@
 #include "ActorUtil.h"
 
 #include <set>
-#ifndef NO_WAV_SUPPORT
+#if defined(HAS_WAV)
 #include "RageSoundReader_WAV.h"
 #endif
 
@@ -13,7 +13,7 @@
 #include "RageSoundReader_MP3.h"
 #endif
 
-#ifndef NO_VORBIS_SUPPORT
+#if defined(HAS_OGG)
 #include "RageSoundReader_Vorbisfile.h"
 #endif
 
@@ -21,7 +21,7 @@ RageSoundReader_FileReader *RageSoundReader_FileReader::TryOpenFile( RageFileBas
 {
 	RageSoundReader_FileReader *Sample = NULL;
 
-#ifndef NO_WAV_SUPPORT
+#if defined(HAS_WAV)
 	if( !format.CompareNoCase("wav") )
 		Sample = new RageSoundReader_WAV;
 #endif
@@ -31,7 +31,7 @@ RageSoundReader_FileReader *RageSoundReader_FileReader::TryOpenFile( RageFileBas
 		Sample = new RageSoundReader_MP3;
 #endif
 
-#ifndef NO_VORBIS_SUPPORT
+#if defined(HAS_OGG)
 	if( !format.CompareNoCase("oga") || !format.CompareNoCase("ogg") )
 		Sample = new RageSoundReader_Vorbisfile;
 #endif

--- a/src/config.in.hpp
+++ b/src/config.in.hpp
@@ -114,8 +114,14 @@ typedef long ssize_t;
 /* Defined to 1 if version information will be printed out. */
 #cmakedefine HAVE_VERSION_INFO 1
 
+/* Defined to 1 if compiling with WAV support. */
+#cmakedefine HAS_WAV 1
+
 /* Defined to 1 if compiling with MP3 support. */
 #cmakedefine HAS_MP3 1
+
+/* Defined to 1 if compiling with OGG support. */
+#cmakedefine HAS_OGG 1
 
 #if defined(__GNUC__)
 /** @brief Define a macro to tell the compiler that a function has printf()


### PR DESCRIPTION
As before, set WITH_WAV and WITH_OGG to off to limit your playing experience. Why this would be done is beyond me, but it's available.