### PR TITLE
Re-enable precompiled headers for Windows.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -196,8 +196,20 @@ configure_file("${SM_XCODE_DIR}/plistHelper.in.hpp" "${SM_XCODE_DIR}/plistHelper
 if(APPLE)
   set(MACOSX_BUNDLE_BUNDLE_NAME ${SM_EXE_NAME})
   add_executable("${SM_EXE_NAME}" MACOSX_BUNDLE ${SMDATA_ALL_FILES_SRC} ${SMDATA_ALL_FILES_HPP})
-  set_target_properties("${SM_EXE_NAME}" PROPERTIES MACOSX_BUNDLE TRUE)
+  set_target_properties("${SM_EXE_NAME}" PROPERTIES
+    MACOSX_BUNDLE TRUE
+  )
 else()
+  if (MSVC)
+    foreach ( sm_src_file ${SMDATA_ALL_FILES_SRC} )
+      get_filename_component(sm_src_raw "${sm_src_file}" NAME_WE)
+      if( ${sm_src_raw} MATCHES "global" )
+        set_source_files_properties("${sm_src_raw}.cpp" PROPERTIES COMPILE_FLAGS "/Ycglobal.h")
+      elseif(NOT (${sm_src_raw} MATCHES "verstub"))
+        set_source_files_properties("${sm_src_raw}.cpp" PROPERTIES COMPILE_FLAGS "/Yuglobal.h")
+      endif()
+    endforeach()
+  endif()
   add_executable("${SM_EXE_NAME}" ${SMDATA_ALL_FILES_SRC} ${SMDATA_ALL_FILES_HPP})
 endif()
 


### PR DESCRIPTION
The speed is brought back up to reasonable limits considering I work with a VM primarily.