### PR TITLE
Introduce GoogleTest and start unit testing.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "extern/ffmpeg-git"]
 	path = extern/ffmpeg-git
 	url = git://source.ffmpeg.org/ffmpeg.git
+[submodule "extern/googletest"]
+	path = extern/googletest
+	url = https://github.com/google/googletest.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,6 +65,7 @@ before_install:
     # Set up valid submodules.
     - git submodule init
     - git submodule update extern/cppformat
+    - git submodule update extern/googletest
     - if [[ "${WITH_FFMPEG}" == "ON" ]]; then git submodule update extern/ffmpeg-git; fi
 
 install:

--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -1,6 +1,7 @@
 include(CMakeProject-lua.cmake)
 include(CMakeProject-glew.cmake)
 include(CMakeProject-cppformat.cmake)
+include(CMakeProject-googletest.cmake)
 include(CMakeProject-json.cmake)
 if (APPLE OR MSVC)
   include(CMakeProject-mad.cmake)

--- a/extern/CMakeProject-googletest.cmake
+++ b/extern/CMakeProject-googletest.cmake
@@ -1,0 +1,36 @@
+if (NOT IS_DIRECTORY "${SM_EXTERN_DIR}/googletest")
+  message(ERROR "Submodule missing. Run git submodule init && git submodule update first.")
+  return()
+endif()
+
+list(APPEND GOOGLETEST_SRC
+  "${SM_EXTERN_DIR}/googletest/googletest/src/gtest-all.cc"
+)
+
+source_group("" FILES ${GOOGLETEST_SRC})
+
+add_library("googletest" ${GOOGLETEST_SRC})
+
+set_property(TARGET "googletest" PROPERTY FOLDER "External Libraries")
+
+disable_project_warnings("googletest")
+
+target_include_directories("googletest" SYSTEM PUBLIC "${SM_EXTERN_DIR}/googletest/googletest/include")
+target_include_directories("googletest" PUBLIC "${SM_EXTERN_DIR}/googletest/googletest")
+
+if (MSVC)
+
+elseif(APPLE)
+  set_target_properties("googletest" PROPERTIES
+    XCODE_ATTRIBUTE_CLANG_CXX_LANGUAGE_STANDARD "gnu++14"
+    XCODE_ATTRIBUTE_CLANG_CXX_LIBRARY "libc++"
+  )
+else()
+  sm_add_compile_flag("googletest" "-std=gnu++11")
+  if (CMAKE_CXX_COMPILER MATCHES "clang")
+    sm_add_compile_flag("googletest" "-stdlib=libc++")
+  endif()
+  if (CMAKE_CXX_COMPILER MATCHES "gcc")
+    sm_add_compile_flag("googletest" "-pthread")
+  endif()
+endif()

--- a/src/Actor.cpp
+++ b/src/Actor.cpp
@@ -549,8 +549,8 @@ void Actor::PreDraw() // calculate actor properties
 			break;
 		case pulse:
 			{
-				float fMinZoom = m_vEffectMagnitude[0];
-				float fMaxZoom = m_vEffectMagnitude[1];
+				float fMinZoom = m_vEffectMagnitude.x;
+				float fMaxZoom = m_vEffectMagnitude.y;
 				float fPercentOffset = RageFastSin( fPercentThroughEffect*PI );
 				float fZoom = SCALE( fPercentOffset, 0.f, 1.f, fMinZoom, fMaxZoom );
 				tempState.scale *= fZoom;
@@ -878,7 +878,7 @@ void Actor::UpdateInternal(float delta_time)
 	switch( m_Effect )
 	{
 		case spin:
-			m_current.rotation += m_fEffectDelta*m_vEffectMagnitude;
+			m_current.rotation += ( m_vEffectMagnitude * m_fEffectDelta );
 			wrap( m_current.rotation.x, 360 );
 			wrap( m_current.rotation.y, 360 );
 			wrap( m_current.rotation.z, 360 );
@@ -1236,8 +1236,8 @@ void Actor::SetEffectPulse( float fPeriod, float fMinZoom, float fMaxZoom )
 	// todo: account for SSC_FUTURES -aj
 	m_Effect = pulse;
 	SetEffectPeriod( fPeriod );
-	m_vEffectMagnitude[0] = fMinZoom;
-	m_vEffectMagnitude[1] = fMaxZoom;
+	m_vEffectMagnitude.x = fMinZoom;
+	m_vEffectMagnitude.y = fMaxZoom;
 }
 
 
@@ -1740,7 +1740,7 @@ public:
 	static int effectoffset( T* p, lua_State *L )		{ p->SetEffectOffset(FArg(1)); COMMON_RETURN_SELF; }
 	static int effectclock( T* p, lua_State *L )		{ p->SetEffectClockString(SArg(1)); COMMON_RETURN_SELF; }
 	static int effectmagnitude( T* p, lua_State *L )	{ p->SetEffectMagnitude( RageVector3(FArg(1),FArg(2),FArg(3)) ); COMMON_RETURN_SELF; }
-	static int geteffectmagnitude( T* p, lua_State *L )	{ RageVector3 v = p->GetEffectMagnitude(); lua_pushnumber(L, v[0]); lua_pushnumber(L, v[1]); lua_pushnumber(L, v[2]); return 3; }
+	static int geteffectmagnitude( T* p, lua_State *L )	{ RageVector3 v = p->GetEffectMagnitude(); lua_pushnumber(L, v.x); lua_pushnumber(L, v.y); lua_pushnumber(L, v.z); return 3; }
 	static int scaletocover( T* p, lua_State *L )		{ p->ScaleToCover( RectF(FArg(1), FArg(2), FArg(3), FArg(4)) ); COMMON_RETURN_SELF; }
 	static int scaletofit( T* p, lua_State *L )		{ p->ScaleToFitInside( RectF(FArg(1), FArg(2), FArg(3), FArg(4)) ); COMMON_RETURN_SELF; }
 	static int animate( T* p, lua_State *L )		{ p->EnableAnimation(BIArg(1)); COMMON_RETURN_SELF; }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -64,6 +64,8 @@ include(CMakeData-screen.cmake)
 include(CMakeData-data.cmake)
 include(CMakeData-gtk.cmake)
 
+include(CMakeProject-rage.cmake)
+
 list(APPEND SMDATA_GLOBAL_SINGLETON_SRC
   "AnnouncerManager.cpp"
   "Bookkeeper.cpp"
@@ -462,6 +464,7 @@ list(APPEND SMDATA_LINK_LIB
   "png"
   "glew"
   "jpeg"
+  "rage"
 )
 
 if (HAS_MP3)
@@ -646,6 +649,7 @@ target_link_libraries("${SM_EXE_NAME}" ${SMDATA_LINK_LIB})
 list(APPEND SM_INCLUDE_DIRS
   ${CMAKE_CURRENT_SOURCE_DIR}
   "${SM_SRC_DIR}/generated"
+  "${SM_SRC_DIR}/rage"
   "${SM_EXTERN_DIR}/vorbis"
   "${SM_EXTERN_DIR}/libtommath"
   "${SM_EXTERN_DIR}/libtomcrypt/src/headers"
@@ -776,3 +780,4 @@ if(NOT APPLE)
   endif()
 endif()
 
+include(CMakeProject-rage-test.cmake)

--- a/src/CMakeProject-rage-test.cmake
+++ b/src/CMakeProject-rage-test.cmake
@@ -1,0 +1,53 @@
+list(APPEND RAGE_TEST_SRC
+  "${SM_SRC_DIR}/tests/RageVector2Fixture.cpp"
+  "${SM_SRC_DIR}/tests/RageVector2Test.cpp"
+  "${SM_SRC_DIR}/tests/RageVector3Fixture.cpp"
+  "${SM_SRC_DIR}/tests/RageVector3Test.cpp"
+  "${SM_SRC_DIR}/tests/RageVector4Fixture.cpp"
+  "${SM_SRC_DIR}/tests/RageVector4Test.cpp"
+  "${SM_SRC_DIR}/tests/rage-test-main.cpp"
+)
+
+list(APPEND RAGE_TEST_HPP
+  "${SM_SRC_DIR}/tests/RageVector2Fixture.hpp"
+  "${SM_SRC_DIR}/tests/RageVector3Fixture.hpp"
+  "${SM_SRC_DIR}/tests/RageVector4Fixture.hpp"
+)
+
+source_group("" FILES ${RAGE_TEST_SRC} ${RAGE_TEST_HPP})
+
+add_executable("rage-test" ${RAGE_TEST_SRC} ${RAGE_TEST_HPP})
+
+set_property(TARGET "rage-test" PROPERTY FOLDER "Internal Libraries")
+
+list(APPEND RAGE_TEST_LINK_LIB
+  "${CMAKE_THREAD_LIBS_INIT}"
+  "googletest"
+  "rage"
+)
+
+target_link_libraries("rage-test" ${RAGE_TEST_LINK_LIB})
+
+list(APPEND RAGE_TEST_INCLUDE_DIRS
+  "${SM_EXTERN_DIR}/googletest/googletest/include"
+  "${SM_SRC_DIR}/rage"
+)
+
+target_include_directories("rage-test" PUBLIC ${RAGE_TEST_INCLUDE_DIRS})
+
+if (MSVC)
+
+elseif(APPLE)
+  set_target_properties("rage-test" PROPERTIES
+    XCODE_ATTRIBUTE_CLANG_CXX_LANGUAGE_STANDARD "gnu++14"
+    XCODE_ATTRIBUTE_CLANG_CXX_LIBRARY "libc++"
+  )
+else()
+  sm_add_compile_flag("rage-test" "-std=gnu++11")
+  if (CMAKE_CXX_COMPILER MATCHES "clang")
+    sm_add_compile_flag("rage-test" "-stdlib=libc++")
+  endif()
+  if (CMAKE_CXX_COMPILER MATCHES "gcc")
+    sm_add_compile_flag("rage-test" "-pthread")
+  endif()
+endif()

--- a/src/CMakeProject-rage.cmake
+++ b/src/CMakeProject-rage.cmake
@@ -1,0 +1,31 @@
+list(APPEND RAGE_SRC
+  "${SM_SRC_DIR}/rage/RageVector2.cpp"
+  "${SM_SRC_DIR}/rage/RageVector3.cpp"
+  "${SM_SRC_DIR}/rage/RageVector4.cpp"
+)
+
+list(APPEND RAGE_HPP
+  "${SM_SRC_DIR}/rage/RageVector2.hpp"
+  "${SM_SRC_DIR}/rage/RageVector3.hpp"
+  "${SM_SRC_DIR}/rage/RageVector4.hpp"
+)
+
+source_group("" FILES ${RAGE_SRC} ${RAGE_HPP})
+
+add_library("rage" ${RAGE_SRC} ${RAGE_HPP})
+
+set_property(TARGET "rage" PROPERTY FOLDER "Internal Libraries")
+
+if (MSVC)
+
+elseif(APPLE)
+  set_target_properties("rage" PROPERTIES
+    XCODE_ATTRIBUTE_CLANG_CXX_LANGUAGE_STANDARD "gnu++14"
+    XCODE_ATTRIBUTE_CLANG_CXX_LIBRARY "libc++"
+  )
+else()
+  sm_add_compile_flag("rage" "-std=gnu++11")
+  if (CMAKE_CXX_COMPILER MATCHES "clang")
+    sm_add_compile_flag("rage" "-stdlib=libc++")
+  endif()
+endif()

--- a/src/Model.cpp
+++ b/src/Model.cpp
@@ -183,7 +183,7 @@ void Model::LoadMaterialsFromMilkshapeAscii( const RString &_sPath )
 				if( f.GetLine( sLine ) <= 0 )
 					THROW;
 				RageVector4 Ambient;
-				if( sscanf(sLine, "%f %f %f %f", &Ambient[0], &Ambient[1], &Ambient[2], &Ambient[3]) != 4 )
+				if( sscanf(sLine, "%f %f %f %f", &Ambient.x, &Ambient.y, &Ambient.z, &Ambient.w) != 4 )
 					THROW;
 				memcpy( &Material.Ambient, &Ambient, sizeof(Material.Ambient) );
 
@@ -191,7 +191,7 @@ void Model::LoadMaterialsFromMilkshapeAscii( const RString &_sPath )
 				if( f.GetLine( sLine ) <= 0 )
 					THROW;
 				RageVector4 Diffuse;
-				if( sscanf(sLine, "%f %f %f %f", &Diffuse[0], &Diffuse[1], &Diffuse[2], &Diffuse[3]) != 4 )
+				if( sscanf(sLine, "%f %f %f %f", &Diffuse.x, &Diffuse.y, &Diffuse.z, &Diffuse.w) != 4 )
 					THROW;
 				memcpy( &Material.Diffuse, &Diffuse, sizeof(Material.Diffuse) );
 
@@ -199,7 +199,7 @@ void Model::LoadMaterialsFromMilkshapeAscii( const RString &_sPath )
 				if( f.GetLine( sLine ) <= 0 )
 					THROW;
 				RageVector4 Specular;
-				if( sscanf(sLine, "%f %f %f %f", &Specular[0], &Specular[1], &Specular[2], &Specular[3]) != 4 )
+				if( sscanf(sLine, "%f %f %f %f", &Specular.x, &Specular.y, &Specular.z, &Specular.w) != 4 )
 					THROW;
 				memcpy( &Material.Specular, &Specular, sizeof(Material.Specular) );
 
@@ -207,7 +207,7 @@ void Model::LoadMaterialsFromMilkshapeAscii( const RString &_sPath )
 				if( f.GetLine( sLine ) <= 0 )
 					THROW;
 				RageVector4 Emissive;
-				if( sscanf (sLine, "%f %f %f %f", &Emissive[0], &Emissive[1], &Emissive[2], &Emissive[3]) != 4 )
+				if( sscanf (sLine, "%f %f %f %f", &Emissive.x, &Emissive.y, &Emissive.z, &Emissive.w) != 4 )
 					THROW;
 				memcpy( &Material.Emissive, &Emissive, sizeof(Material.Emissive) );
 
@@ -518,9 +518,9 @@ void Model::PlayAnimation( const RString &sAniName, float fPlayRate )
 
 		RageMatrixAngles( &m_vpBones[i].m_Relative, vRot );
 
-		m_vpBones[i].m_Relative.m[3][0] = pBone->Position[0];
-		m_vpBones[i].m_Relative.m[3][1] = pBone->Position[1];
-		m_vpBones[i].m_Relative.m[3][2] = pBone->Position[2];
+		m_vpBones[i].m_Relative.m[3][0] = pBone->Position.x;
+		m_vpBones[i].m_Relative.m[3][1] = pBone->Position.y;
+		m_vpBones[i].m_Relative.m[3][2] = pBone->Position.z;
 
 		int nParentBone = m_pCurAnimation->FindBoneByName( pBone->sParentName );
 		if( nParentBone != -1 )
@@ -546,9 +546,9 @@ void Model::PlayAnimation( const RString &sAniName, float fPlayRate )
 			int8_t bone = Vertices[j].bone;
 			if( bone != -1 )
 			{
-				pos[0] -= m_vpBones[bone].m_Absolute.m[3][0];
-				pos[1] -= m_vpBones[bone].m_Absolute.m[3][1];
-				pos[2] -= m_vpBones[bone].m_Absolute.m[3][2];
+				pos.x -= m_vpBones[bone].m_Absolute.m[3][0];
+				pos.y -= m_vpBones[bone].m_Absolute.m[3][1];
+				pos.z -= m_vpBones[bone].m_Absolute.m[3][2];
 
 				RageVector3 vTmp;
 
@@ -668,9 +668,9 @@ void Model::SetBones( const msAnimation* pAnimation, float fFrame, vector<myBone
 		RageMatrix m;
 		RageMatrixIdentity( &m );
 		RageMatrixFromQuat( &m, vRot );
-		m.m[3][0] = vPos[0];
-		m.m[3][1] = vPos[1];
-		m.m[3][2] = vPos[2];
+		m.m[3][0] = vPos.x;
+		m.m[3][1] = vPos.y;
+		m.m[3][2] = vPos.z;
 
 		RageMatrix RelativeFinal;
 		RageMatrixMultiply( &RelativeFinal, &vpBones[i].m_Relative, &m );

--- a/src/ModelTypes.cpp
+++ b/src/ModelTypes.cpp
@@ -276,8 +276,8 @@ bool msAnimation::LoadMilkshapeAsciiBones( RString sAniName, RString sPath )
 			int nFlags;
 			if (sscanf (sLine, "%d %f %f %f %f %f %f",
 				&nFlags,
-				&Position[0], &Position[1], &Position[2],
-				&Rotation[0], &Rotation[1], &Rotation[2]) != 7)
+				&Position.x, &Position.y, &Position.z,
+				&Rotation.x, &Rotation.y, &Rotation.z) != 7)
 			{
 				THROW;
 			}
@@ -302,12 +302,12 @@ bool msAnimation::LoadMilkshapeAsciiBones( RString sAniName, RString sPath )
 					THROW;
 
 				float fTime;
-				if (sscanf (sLine, "%f %f %f %f", &fTime, &Position[0], &Position[1], &Position[2]) != 4)
+				if (sscanf (sLine, "%f %f %f %f", &fTime, &Position.x, &Position.y, &Position.z) != 4)
 					THROW;
 
 				msPositionKey key;
 				key.fTime = fTime;
-				key.Position = RageVector3( Position[0], Position[1], Position[2] );
+				key.Position = RageVector3( Position.x, Position.y, Position.z );
 				Bone.PositionKeys[j] = key;
 			}
 
@@ -326,13 +326,13 @@ bool msAnimation::LoadMilkshapeAsciiBones( RString sAniName, RString sPath )
 					THROW;
 
 				float fTime;
-				if (sscanf (sLine, "%f %f %f %f", &fTime, &Rotation[0], &Rotation[1], &Rotation[2]) != 4)
+				if (sscanf (sLine, "%f %f %f %f", &fTime, &Rotation.x, &Rotation.y, &Rotation.z) != 4)
 					THROW;
 				Rotation = RadianToDegree(Rotation);
 
 				msRotationKey key;
 				key.fTime = fTime;
-				Rotation = RageVector3( Rotation[0], Rotation[1], Rotation[2] );
+				Rotation = RageVector3( Rotation.x, Rotation.y, Rotation.z );
 				RageQuatFromHPR( &key.Rotation, Rotation );
 				Bone.RotationKeys[j] = key;
 			}

--- a/src/RageDisplay_OGL.cpp
+++ b/src/RageDisplay_OGL.cpp
@@ -889,18 +889,18 @@ static void SetupVertices( const RageSpriteVertex v[], int iNumVerts )
 
 	for( unsigned i = 0; i < unsigned(iNumVerts); ++i )
 	{
-		Vertex[i*3+0]  = v[i].p[0];
-		Vertex[i*3+1]  = v[i].p[1];
-		Vertex[i*3+2]  = v[i].p[2];
+		Vertex[i*3+0]  = v[i].p.x;
+		Vertex[i*3+1]  = v[i].p.y;
+		Vertex[i*3+2]  = v[i].p.z;
 		Color[i*4+0]   = v[i].c.r;
 		Color[i*4+1]   = v[i].c.g;
 		Color[i*4+2]   = v[i].c.b;
 		Color[i*4+3]   = v[i].c.a;
-		Texture[i*2+0] = v[i].t[0];
-		Texture[i*2+1] = v[i].t[1];
-		Normal[i*3+0] = v[i].n[0];
-		Normal[i*3+1] = v[i].n[1];
-		Normal[i*3+2] = v[i].n[2];
+		Texture[i*2+0] = v[i].t.x;
+		Texture[i*2+1] = v[i].t.y;
+		Normal[i*3+0] = v[i].n.x;
+		Normal[i*3+1] = v[i].n.y;
+		Normal[i*3+2] = v[i].n.z;
 	}
 	glEnableClientState( GL_VERTEX_ARRAY );
 	glVertexPointer( 3, GL_FLOAT, 0, Vertex );

--- a/src/RageMath.cpp
+++ b/src/RageMath.cpp
@@ -540,22 +540,22 @@ RageMatrix RageLookAt(
 	RageVector3 Y(upx, upy, upz);
 
 	RageVector3 X(
-		 Y[1] * Z[2] - Y[2] * Z[1],
-		-Y[0] * Z[2] + Y[2] * Z[0],
-		 Y[0] * Z[1] - Y[1] * Z[0]);
+		 Y.y * Z.z - Y.z * Z.y,
+		-Y.x * Z.z + Y.z * Z.x,
+		 Y.x * Z.y - Y.y * Z.x);
 
 	Y = RageVector3(
-		 Z[1] * X[2] - Z[2] * X[1],
-		 -Z[0] * X[2] + Z[2] * X[0],
-		 Z[0] * X[1] - Z[1] * X[0] );
+		 Z.y * X.z - Z.z * X.y,
+		 -Z.x * X.z + Z.z * X.x,
+		 Z.x * X.y - Z.y * X.x );
 
 	RageVec3Normalize(&X, &X);
 	RageVec3Normalize(&Y, &Y);
 
 	RageMatrix mat(
-		X[0], Y[0], Z[0], 0,
-		X[1], Y[1], Z[1], 0,
-		X[2], Y[2], Z[2], 0,
+		X.x, Y.x, Z.x, 0,
+		X.y, Y.y, Z.y, 0,
+		X.z, Y.z, Z.z, 0,
 		0,    0,    0,    1 );
 
 	RageMatrix mat2;
@@ -571,12 +571,12 @@ void RageMatrixAngles( RageMatrix* pOut, const RageVector3 &angles )
 {
 	const RageVector3 angles_radians( angles * 2*PI / 360 );
 
-	const float sy = RageFastSin( angles_radians[2] );
-	const float cy = RageFastCos( angles_radians[2] );
-	const float sp = RageFastSin( angles_radians[1] );
-	const float cp = RageFastCos( angles_radians[1] );
-	const float sr = RageFastSin( angles_radians[0] );
-	const float cr = RageFastCos( angles_radians[0] );
+	const float sy = RageFastSin( angles_radians.z );
+	const float cy = RageFastCos( angles_radians.z );
+	const float sp = RageFastSin( angles_radians.y );
+	const float cp = RageFastCos( angles_radians.y );
+	const float sr = RageFastSin( angles_radians.x );
+	const float cr = RageFastCos( angles_radians.x );
 
 	RageMatrixIdentity( pOut );
 

--- a/src/RageModelGeometry.cpp
+++ b/src/RageModelGeometry.cpp
@@ -174,8 +174,8 @@ void RageModelGeometry::LoadMilkshapeAscii( const RString& _sPath, bool bNeedsNo
 
 					if( sscanf(sLine, "%d %f %f %f %f %f %d",
 								&nFlags,
-								&v.p[0], &v.p[1], &v.p[2],
-								&v.t[0], &v.t[1],
+								&v.p.x, &v.p.y, &v.p.z,
+								&v.t.x, &v.t.y,
 								&nIndex
 						   ) != 7 )
 					{
@@ -189,8 +189,8 @@ void RageModelGeometry::LoadMilkshapeAscii( const RString& _sPath, bool bNeedsNo
 						v.TextureMatrixScale.y = 0;
 					if( nFlags & 4 )
 					{
-						v.t[0] = v.p[0] / v.t[0];
-						v.t[1] = v.p[1] / v.t[1];
+						v.t.x = v.p.x / v.t.x;
+						v.t.y = v.p.y / v.t.y;
 					}
 					v.bone = (uint8_t) nIndex;
 					RageVec3AddToBounds( v.p, m_vMins, m_vMaxs );
@@ -215,7 +215,7 @@ void RageModelGeometry::LoadMilkshapeAscii( const RString& _sPath, bool bNeedsNo
 						THROW;
 
 					RageVector3 Normal;
-					if( sscanf(sLine, "%f %f %f", &Normal[0], &Normal[1], &Normal[2]) != 3 )
+					if( sscanf(sLine, "%f %f %f", &Normal.x, &Normal.y, &Normal.z) != 3 )
 						THROW;
 
 					RageVec3Normalize( (RageVector3*)&Normal, (RageVector3*)&Normal );

--- a/src/RageTypes.h
+++ b/src/RageTypes.h
@@ -4,6 +4,9 @@
 #define RAGETYPES_H
 
 #include "EnumHelper.h"
+#include "RageVector2.hpp"
+#include "RageVector3.hpp"
+#include "RageVector4.hpp"
 
 enum BlendMode
 {
@@ -96,92 +99,6 @@ enum TextGlowMode
 LuaDeclareType( TextGlowMode );
 
 struct lua_State;
-
-struct RageVector2
-{
-public:
-	RageVector2(): x(0), y(0) {}
-	RageVector2( const float * f ): x(f[0]), y(f[1]) {}
-	RageVector2( float x1, float y1 ): x(x1), y(y1) {}
-	
-	// casting
-	operator float* ()			{ return &x; };
-	operator const float* () const		{ return &x; };
-	
-	// assignment operators
-	RageVector2& operator += ( const RageVector2& other )	{ x+=other.x; y+=other.y; return *this; }
-	RageVector2& operator -= ( const RageVector2& other )	{ x-=other.x; y-=other.y; return *this; }
-	RageVector2& operator *= ( float f )			{ x*=f; y*=f; return *this; }
-	RageVector2& operator /= ( float f )			{ x/=f; y/=f; return *this; }
-	
-	// binary operators
-	RageVector2 operator + ( const RageVector2& other ) const	{ return RageVector2( x+other.x, y+other.y ); }
-	RageVector2 operator - ( const RageVector2& other ) const	{ return RageVector2( x-other.x, y-other.y ); }
-	RageVector2 operator * ( float f ) const			{ return RageVector2( x*f, y*f ); }
-	RageVector2 operator / ( float f ) const			{ return RageVector2( x/f, y/f ); }
-	
-	friend RageVector2 operator * ( float f, const RageVector2& other )	{ return other*f; }
-	
-	float x, y;
-};
-
-
-struct RageVector3
-{
-public:
-	RageVector3(): x(0), y(0), z(0) {}
-	RageVector3( const float * f ):	x(f[0]), y(f[1]), z(f[2]) {}
-	RageVector3( float x1, float y1, float z1 ): x(x1), y(y1), z(z1) {}
-	
-	// casting
-	operator float* ()				{ return &x; };
-	operator const float* () const			{ return &x; };
-	
-	// assignment operators
-	RageVector3& operator += ( const RageVector3& other )	{ x+=other.x; y+=other.y; z+=other.z; return *this; }
-	RageVector3& operator -= ( const RageVector3& other )	{ x-=other.x; y-=other.y; z-=other.z; return *this; }
-	RageVector3& operator *= ( float f )			{ x*=f; y*=f; z*=f; return *this; }
-	RageVector3& operator /= ( float f )			{ x/=f; y/=f; z/=f; return *this; }
-	
-	// binary operators
-	RageVector3 operator + ( const RageVector3& other ) const	{ return RageVector3( x+other.x, y+other.y, z+other.z ); }
-	RageVector3 operator - ( const RageVector3& other ) const	{ return RageVector3( x-other.x, y-other.y, z-other.z ); }
-	RageVector3 operator * ( float f ) const			{ return RageVector3( x*f, y*f, z*f ); }
-	RageVector3 operator / ( float f ) const			{ return RageVector3( x/f, y/f, z/f ); }
-	
-	friend RageVector3 operator * ( float f, const RageVector3& other )	{ return other*f; }
-	
-	float x, y, z;
-};
-
-
-struct RageVector4
-{
-public:
-	RageVector4(): x(0), y(0), z(0), w(0) {}
-	RageVector4( const float * f ): x(f[0]), y(f[1]), z(f[2]), w(f[3]) {}
-	RageVector4( float x1, float y1, float z1, float w1 ): x(x1), y(y1), z(z1), w(w1) {}
-	
-	// casting
-	operator float* ()					{ return &x; };
-	operator const float* () const				{ return &x; };
-	
-	// assignment operators
-	RageVector4& operator += ( const RageVector4& other )	{ x+=other.x; y+=other.y; z+=other.z; w+=other.w; return *this; }
-	RageVector4& operator -= ( const RageVector4& other )	{ x-=other.x; y-=other.y; z-=other.z; w-=other.w; return *this; }
-	RageVector4& operator *= ( float f )			{ x*=f; y*=f; z*=f; w*=f; return *this; }
-	RageVector4& operator /= ( float f )			{ x/=f; y/=f; z/=f; w/=f; return *this; }
-	
-	// binary operators
-	RageVector4 operator + ( const RageVector4& other ) const	{ return RageVector4( x+other.x, y+other.y, z+other.z, w+other.w ); }
-	RageVector4 operator - ( const RageVector4& other ) const	{ return RageVector4( x-other.x, y-other.y, z-other.z, w-other.w ); }
-	RageVector4 operator * ( float f ) const			{ return RageVector4( x*f, y*f, z*f, w*f ); }
-	RageVector4 operator / ( float f ) const			{ return RageVector4( x/f, y/f, z/f, w/f ); }
-	
-	friend RageVector4 operator * ( float f, const RageVector4& other )	{ return other*f; }
-	
-	float x, y, z, w;
-};
 
 struct RageColor
 {

--- a/src/RageUtil.h
+++ b/src/RageUtil.h
@@ -40,7 +40,7 @@ T clamp( T val, T low, T high)
 template<typename T, typename U>
 inline U lerp( T x, U l, U h )
 {
-	return U(x * (h - l) + l);
+	return U((h - l) * x + l);
 }
 
 template<typename T, typename U, typename V>

--- a/src/rage/RageVector2.cpp
+++ b/src/rage/RageVector2.cpp
@@ -1,0 +1,41 @@
+#include "RageVector2.hpp"
+
+RageVector2::RageVector2() : x(0), y(0)
+{
+}
+
+RageVector2::RageVector2(float a, float b) : x(a), y(b)
+{
+}
+
+RageVector2 & RageVector2::operator+=(RageVector2 const & rhs)
+{
+	x += rhs.x;
+	y += rhs.y;
+	
+	return *this;
+}
+
+RageVector2 & RageVector2::operator-=(RageVector2 const & rhs)
+{
+	x -= rhs.x;
+	y -= rhs.y;
+	
+	return *this;
+}
+
+RageVector2 & RageVector2::operator*=(float rhs)
+{
+	x *= rhs;
+	y *= rhs;
+
+	return *this;
+}
+
+RageVector2 & RageVector2::operator/=(float rhs)
+{
+	x /= rhs;
+	y /= rhs;
+
+	return *this;
+}

--- a/src/rage/RageVector2.hpp
+++ b/src/rage/RageVector2.hpp
@@ -1,0 +1,55 @@
+#ifndef RAGE_VECTOR_2_HPP_
+#define RAGE_VECTOR_2_HPP_
+
+struct RageVector2
+{
+public:
+	RageVector2();
+	RageVector2(float x1, float y1);
+
+	// assignment operators
+	RageVector2& operator += (RageVector2 const & rhs);
+	RageVector2& operator -= (RageVector2 const & rhs);
+	RageVector2& operator *= (float rhs);
+	RageVector2& operator /= (float rhs);
+
+	float x, y;
+};
+
+inline bool operator==(RageVector2 const & lhs, RageVector2 const & rhs)
+{
+	return
+		lhs.x == rhs.x &&
+		lhs.y == rhs.y;
+}
+
+inline bool operator!=(RageVector2 const & lhs, RageVector2 const & rhs)
+{
+	return !operator==(lhs, rhs);
+}
+
+inline RageVector2 operator+(RageVector2 lhs, RageVector2 const & rhs)
+{
+	lhs += rhs;
+	return lhs;
+}
+
+inline RageVector2 operator-(RageVector2 lhs, RageVector2 const & rhs)
+{
+	lhs -= rhs;
+	return lhs;
+}
+
+inline RageVector2 operator*(RageVector2 lhs, float rhs)
+{
+	lhs *= rhs;
+	return lhs;
+}
+
+inline RageVector2 operator/(RageVector2 lhs, float rhs)
+{
+	lhs /= rhs;
+	return lhs;
+}
+
+#endif

--- a/src/rage/RageVector3.cpp
+++ b/src/rage/RageVector3.cpp
@@ -1,0 +1,41 @@
+#include "RageVector3.hpp"
+
+RageVector3::RageVector3() : x(0), y(0), z(0)
+{
+}
+
+RageVector3::RageVector3(float a, float b, float c) : x(a), y(b), z(c)
+{
+}
+
+RageVector3 & RageVector3::operator+=(const RageVector3 & rhs)
+{
+	x += rhs.x;
+	y += rhs.y;
+	z += rhs.z;
+	return *this;
+}
+
+RageVector3 & RageVector3::operator-=(const RageVector3 & rhs)
+{
+	x -= rhs.x;
+	y -= rhs.y;
+	z -= rhs.z;
+	return *this;
+}
+
+RageVector3 & RageVector3::operator*=(float rhs)
+{
+	x *= rhs;
+	y *= rhs;
+	z *= rhs;
+	return *this;
+}
+
+RageVector3 & RageVector3::operator/=(float rhs)
+{
+	x /= rhs;
+	y /= rhs;
+	z /= rhs;
+	return *this;
+}

--- a/src/rage/RageVector3.hpp
+++ b/src/rage/RageVector3.hpp
@@ -1,0 +1,56 @@
+#ifndef RAGE_VECTOR_3_HPP_
+#define RAGE_VECTOR_3_HPP_
+
+struct RageVector3
+{
+public:
+	RageVector3();
+	RageVector3(float a, float b, float c);
+		
+	// assignment operators
+	RageVector3& operator += (const RageVector3& rhs);
+	RageVector3& operator -= (const RageVector3& rhs);
+	RageVector3& operator *= (float rhs);
+	RageVector3& operator /= (float rhs);
+	
+	float x, y, z;
+};
+
+#endif
+
+inline bool operator==(RageVector3 const & lhs, RageVector3 const & rhs)
+{
+	return
+		lhs.x == rhs.x &&
+		lhs.y == rhs.y &&
+		lhs.z == rhs.z;
+}
+
+inline bool operator!=(RageVector3 const & lhs, RageVector3 const & rhs)
+{
+	return !operator==(lhs, rhs);
+}
+
+inline RageVector3 operator+(RageVector3 lhs, RageVector3 const & rhs)
+{
+	lhs += rhs;
+	return lhs;
+}
+
+inline RageVector3 operator-(RageVector3 lhs, RageVector3 const & rhs)
+{
+	lhs -= rhs;
+	return lhs;
+}
+
+inline RageVector3 operator*(RageVector3 lhs, float rhs)
+{
+	lhs *= rhs;
+	return lhs;
+}
+
+inline RageVector3 operator/(RageVector3 lhs, float rhs)
+{
+	lhs /= rhs;
+	return lhs;
+}

--- a/src/rage/RageVector4.cpp
+++ b/src/rage/RageVector4.cpp
@@ -1,0 +1,45 @@
+#include "RageVector4.hpp"
+
+RageVector4::RageVector4() : x(0), y(0), z(0), w(0)
+{
+}
+
+RageVector4::RageVector4(float a, float b, float c, float d) : x(a), y(b), z(c), w(d)
+{
+}
+
+RageVector4 & RageVector4::operator+=(const RageVector4 & rhs)
+{
+	x += rhs.x;
+	y += rhs.y;
+	z += rhs.z;
+	w += rhs.w;
+	return *this;
+}
+
+RageVector4 & RageVector4::operator-=(const RageVector4 & rhs)
+{
+	x -= rhs.x;
+	y -= rhs.y;
+	z -= rhs.z;
+	w -= rhs.w;
+	return *this;
+}
+
+RageVector4 & RageVector4::operator*=(float rhs)
+{
+	x *= rhs;
+	y *= rhs;
+	z *= rhs;
+	w *= rhs;
+	return *this;
+}
+
+RageVector4 & RageVector4::operator/=(float rhs)
+{
+	x /= rhs;
+	y /= rhs;
+	z /= rhs;
+	w /= rhs;
+	return *this;
+}

--- a/src/rage/RageVector4.hpp
+++ b/src/rage/RageVector4.hpp
@@ -1,0 +1,57 @@
+#ifndef RAGE_VECTOR_4_HPP_
+#define RAGE_VECTOR_4_HPP_
+
+struct RageVector4
+{
+public:
+	RageVector4();
+	RageVector4(float a, float b, float c, float d);
+	
+	// assignment operators
+	RageVector4& operator += (const RageVector4& rhs);
+	RageVector4& operator -= (const RageVector4& rhs);
+	RageVector4& operator *= (float rhs);
+	RageVector4& operator /= (float rhs);
+	
+	float x, y, z, w;
+};
+
+#endif
+
+inline bool operator==(RageVector4 const & lhs, RageVector4 const & rhs)
+{
+	return
+		lhs.x == rhs.x &&
+		lhs.y == rhs.y &&
+		lhs.z == rhs.z &&
+		lhs.w == rhs.w;
+}
+
+inline bool operator!=(RageVector4 const & lhs, RageVector4 const & rhs)
+{
+	return !operator==(lhs, rhs);
+}
+
+inline RageVector4 operator+(RageVector4 lhs, RageVector4 const & rhs)
+{
+	lhs += rhs;
+	return lhs;
+}
+
+inline RageVector4 operator-(RageVector4 lhs, RageVector4 const & rhs)
+{
+	lhs -= rhs;
+	return lhs;
+}
+
+inline RageVector4 operator*(RageVector4 lhs, float rhs)
+{
+	lhs *= rhs;
+	return lhs;
+}
+
+inline RageVector4 operator/(RageVector4 lhs, float rhs)
+{
+	lhs /= rhs;
+	return lhs;
+}

--- a/src/tests/RageVector2Fixture.cpp
+++ b/src/tests/RageVector2Fixture.cpp
@@ -1,0 +1,15 @@
+#include "RageVector2Fixture.hpp"
+
+void RageVector2Fixture::SetUp()
+{
+	a1 = { 1, 2 };
+	b1 = { 3, 4 };
+
+	sum1 = { 4, 6 };
+
+	difference1 = { -2, -2 };
+
+	product1 = { 2.5f, 5 };
+
+	quotient1 = { 1.5f, 2 };
+}

--- a/src/tests/RageVector2Fixture.hpp
+++ b/src/tests/RageVector2Fixture.hpp
@@ -1,0 +1,20 @@
+#ifndef RAGE_VECTOR_2_FIXTURE_HPP_
+#define RAGE_VECTOR_2_FIXTURE_HPP_
+
+#include "gtest/gtest.h"
+#include "RageVector2.hpp"
+
+class RageVector2Fixture : public ::testing::Test
+{
+protected:
+	virtual void SetUp();
+
+	RageVector2 a1;
+	RageVector2 b1;
+	RageVector2 sum1;
+	RageVector2 difference1;
+	RageVector2 product1;
+	RageVector2 quotient1;
+};
+
+#endif

--- a/src/tests/RageVector2Test.cpp
+++ b/src/tests/RageVector2Test.cpp
@@ -1,0 +1,37 @@
+#include "RageVector2Fixture.hpp"
+
+TEST_F(RageVector2Fixture, addition)
+{
+	RageVector2 c = a1 + b1;
+
+	EXPECT_EQ(sum1.x, c.x);
+	EXPECT_EQ(sum1.y, c.y);
+	EXPECT_EQ(sum1, c);
+}
+
+TEST_F(RageVector2Fixture, subtraction)
+{
+	RageVector2 c = a1 - b1;
+
+	EXPECT_EQ(difference1.x, c.x);
+	EXPECT_EQ(difference1.y, c.y);
+	EXPECT_EQ(difference1, c);
+}
+
+TEST_F(RageVector2Fixture, multiplication)
+{
+	RageVector2 c = a1 * 2.5f;
+
+	EXPECT_EQ(product1.x, c.x);
+	EXPECT_EQ(product1.y, c.y);
+	EXPECT_EQ(product1, c);
+}
+
+TEST_F(RageVector2Fixture, division)
+{
+	RageVector2 c = b1 / 2;
+
+	EXPECT_EQ(quotient1.x, c.x);
+	EXPECT_EQ(quotient1.y, c.y);
+	EXPECT_EQ(quotient1, c);
+}

--- a/src/tests/RageVector3Fixture.cpp
+++ b/src/tests/RageVector3Fixture.cpp
@@ -1,0 +1,12 @@
+#include "RageVector3Fixture.hpp"
+
+void RageVector3Fixture::SetUp()
+{
+	a = { 1, 2, 3 };
+	b = { 4, 6, 8 };
+
+	sum = { 5, 8, 11 };
+	difference = { -3, -4, -5 };
+	product = { 2.5, 5, 7.5 };
+	quotient = { 1, 1.5, 2 };
+}

--- a/src/tests/RageVector3Fixture.hpp
+++ b/src/tests/RageVector3Fixture.hpp
@@ -1,0 +1,20 @@
+#ifndef RAGE_VECTOR_3_FIXTURE_HPP_
+#define RAGE_VECTOR_3_FIXTURE_HPP_
+
+#include "gtest/gtest.h"
+#include "RageVector3.hpp"
+
+class RageVector3Fixture : public ::testing::Test
+{
+protected:
+	virtual void SetUp();
+
+	RageVector3 a;
+	RageVector3 b;
+	RageVector3 sum;
+	RageVector3 difference;
+	RageVector3 product;
+	RageVector3 quotient;
+};
+
+#endif

--- a/src/tests/RageVector3Test.cpp
+++ b/src/tests/RageVector3Test.cpp
@@ -1,0 +1,41 @@
+#include "RageVector3Fixture.hpp"
+
+TEST_F(RageVector3Fixture, addition)
+{
+	RageVector3 c = a + b;
+
+	EXPECT_EQ(sum.x, c.x);
+	EXPECT_EQ(sum.y, c.y);
+	EXPECT_EQ(sum.z, c.z);
+	EXPECT_EQ(sum, c);
+}
+
+TEST_F(RageVector3Fixture, subtraction)
+{
+	RageVector3 c = a - b;
+
+	EXPECT_EQ(difference.x, c.x);
+	EXPECT_EQ(difference.y, c.y);
+	EXPECT_EQ(difference.z, c.z);
+	EXPECT_EQ(difference, c);
+}
+
+TEST_F(RageVector3Fixture, multiplication)
+{
+	RageVector3 c = a * 2.5;
+
+	EXPECT_EQ(product.x, c.x);
+	EXPECT_EQ(product.y, c.y);
+	EXPECT_EQ(product.z, c.z);
+	EXPECT_EQ(product, c);
+}
+
+TEST_F(RageVector3Fixture, division)
+{
+	RageVector3 c = b / 4.f;
+
+	EXPECT_EQ(quotient.x, c.x);
+	EXPECT_EQ(quotient.y, c.y);
+	EXPECT_EQ(quotient.z, c.z);
+	EXPECT_EQ(quotient, c);
+}

--- a/src/tests/RageVector4Fixture.cpp
+++ b/src/tests/RageVector4Fixture.cpp
@@ -1,0 +1,12 @@
+#include "RageVector4Fixture.hpp"
+
+void RageVector4Fixture::SetUp()
+{
+	a = { 1, 2, 3, 4 };
+	b = { 4, 6, 8, 16 };
+
+	sum = { 5, 8, 11, 20 };
+	difference = { -3, -4, -5, -12 };
+	product = { 2.5, 5, 7.5, 10 };
+	quotient = { 1, 1.5, 2, 4 };
+}

--- a/src/tests/RageVector4Fixture.hpp
+++ b/src/tests/RageVector4Fixture.hpp
@@ -1,0 +1,20 @@
+#ifndef RAGE_VECTOR_4_FIXTURE_HPP_
+#define RAGE_VECTOR_4_FIXTURE_HPP_
+
+#include "gtest/gtest.h"
+#include "RageVector4.hpp"
+
+class RageVector4Fixture : public ::testing::Test
+{
+protected:
+	virtual void SetUp();
+
+	RageVector4 a;
+	RageVector4 b;
+	RageVector4 sum;
+	RageVector4 difference;
+	RageVector4 product;
+	RageVector4 quotient;
+};
+
+#endif

--- a/src/tests/RageVector4Test.cpp
+++ b/src/tests/RageVector4Test.cpp
@@ -1,0 +1,45 @@
+#include "RageVector4Fixture.hpp"
+
+TEST_F(RageVector4Fixture, addition)
+{
+	RageVector4 c = a + b;
+
+	EXPECT_EQ(sum.x, c.x);
+	EXPECT_EQ(sum.y, c.y);
+	EXPECT_EQ(sum.z, c.z);
+	EXPECT_EQ(sum.w, c.w);
+	EXPECT_EQ(sum, c);
+}
+
+TEST_F(RageVector4Fixture, subtraction)
+{
+	RageVector4 c = a - b;
+
+	EXPECT_EQ(difference.x, c.x);
+	EXPECT_EQ(difference.y, c.y);
+	EXPECT_EQ(difference.z, c.z);
+	EXPECT_EQ(difference.w, c.w);
+	EXPECT_EQ(difference, c);
+}
+
+TEST_F(RageVector4Fixture, multiplication)
+{
+	RageVector4 c = a * 2.5;
+
+	EXPECT_EQ(product.x, c.x);
+	EXPECT_EQ(product.y, c.y);
+	EXPECT_EQ(product.z, c.z);
+	EXPECT_EQ(product.w, c.w);
+	EXPECT_EQ(product, c);
+}
+
+TEST_F(RageVector4Fixture, division)
+{
+	RageVector4 c = b / 4.f;
+
+	EXPECT_EQ(quotient.x, c.x);
+	EXPECT_EQ(quotient.y, c.y);
+	EXPECT_EQ(quotient.z, c.z);
+	EXPECT_EQ(quotient.w, c.w);
+	EXPECT_EQ(quotient, c);
+}

--- a/src/tests/rage-test-main.cpp
+++ b/src/tests/rage-test-main.cpp
@@ -1,0 +1,8 @@
+#include "gtest/gtest.h"
+
+int main(int argc, char **argv)
+{
+	::testing::InitGoogleTest(&argc, argv);
+	int ret = RUN_ALL_TESTS();
+	return ret;
+}


### PR DESCRIPTION
The RageVectors were moved to a new project for easier testing.

Accessing/writing to the fields is now consistently done in one way.

Operating overloading is in proper effect. RageVectors can now be compared against one another.

The friend functions were removed: they are unneeded. Chain the operators the correct way.

More work will be done on this pending travis's successful build. There should be a way to make travis run the unit tests now that I think about it.