### PR TITLE
Remove lua.c from CMake project.

### DIFF
--- a/extern/CMakeProject-lua.cmake
+++ b/extern/CMakeProject-lua.cmake
@@ -25,7 +25,6 @@ set(LUA_SRC
   "lua-5.1/src/ltable.c"
   "lua-5.1/src/ltablib.c"
   "lua-5.1/src/ltm.c"
-  "lua-5.1/src/lua.c"
   "lua-5.1/src/lundump.c"
   "lua-5.1/src/lvm.c"
   "lua-5.1/src/lzio.c"


### PR DESCRIPTION
`lua.c` is needed for Lua interpreter, not in Lua library (see [these lines] (https://github.com/stepmania/stepmania/blob/master/extern/lua-5.1/INSTALL#L74-L82)), thus removing it.