### PR TITLE
Reference bzip2 and iconv on Mac OS X properly.

### DIFF
--- a/CMake/Modules/FindIconv.cmake
+++ b/CMake/Modules/FindIconv.cmake
@@ -6,8 +6,6 @@
 # ICONV_INCLUDE_DIR - The Iconv include directory.
 # ICONV_LIBRARIES - The library file to link to.
 
-include(CheckCxxSourceCompiles)
-
 if (ICONV_INCLUDE_DIR AND ICONV_LIBRARIES)
   # Already in cache, so don't repeat the finding procedures.
   set(ICONV_FIND_QUIETLY TRUE)

--- a/CMake/Modules/FindIconv.cmake
+++ b/CMake/Modules/FindIconv.cmake
@@ -1,0 +1,24 @@
+# Borrowed from https://github.com/onyx-intl/cmake_modules/blob/master/FindIconv.cmake
+
+# Find Iconv on the system. When this is done, the following are defined:
+
+# ICONV_FOUND - The system has Iconv.
+# ICONV_INCLUDE_DIR - The Iconv include directory.
+# ICONV_LIBRARIES - The library file to link to.
+
+include(CheckCxxSourceCompiles)
+
+if (ICONV_INCLUDE_DIR AND ICONV_LIBRARIES)
+  # Already in cache, so don't repeat the finding procedures.
+  set(ICONV_FIND_QUIETLY TRUE)
+endif()
+
+find_path(ICONV_INCLUDE_DIR iconv.h)
+set(ICONV_NAMES ${ICONV_NAMES} iconv libiconv libiconv-2 c)
+find_library(ICONV_LIBRARIES NAMES ${ICONV_NAMES})
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(ICONV DEFAULT_MSG ICONV_LIBRARIES ICONV_INCLUDE_DIR)
+
+mark_as_advanced(ICONV_INCLUDE_DIR ICONV_LIBRARIES)
+

--- a/StepmaniaCore.cmake
+++ b/StepmaniaCore.cmake
@@ -1,5 +1,5 @@
-
 # Include the macros and functions.
+
 include(${CMAKE_CURRENT_LIST_DIR}/CMake/CMakeMacros.cmake)
 
 # Set up helper variables for future configuring.
@@ -221,6 +221,13 @@ endif()
 find_package(nasm)
 find_package(yasm)
 
+find_package(BZip2)
+if (NOT ${BZIP2_FOUND} AND NOT MSVC)
+  message(FATAL_ERROR "Bzip2 support required.")
+endif()
+
+find_package(Iconv)
+
 find_package(Threads)
 if (${Threads_FOUND})
   set(HAS_PTHREAD TRUE)
@@ -317,11 +324,6 @@ elseif(LINUX)
 
   find_package(Pcre)
   set(SYSTEM_PCRE_FOUND ${PCRE_FOUND})
-
-  find_package("BZip2")
-  if (NOT(${BZIP2_FOUND}))
-    message(FATAL_ERROR "Bzip2 support required.")
-  endif()
 
   find_package("ZLIB")
   if (NOT(${ZLIB_FOUND}))

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -204,7 +204,6 @@ elseif(APPLE)
     XCODE_ATTRIBUTE_GCC_PREFIX_HEADER "${CMAKE_CURRENT_SOURCE_DIR}/archutils/Darwin/StepMania.pch"
     XCODE_ATTRIBUTE_GCC_ENABLE_CPP_EXCEPTIONS "NO"
     XCODE_ATTRIBUTE_LIBRARY_SEARCH_PATHS "${SM_XCODE_DIR}/ffmpeg/lib ${SM_XCODE_DIR}/Libraries"
-    XCODE_ATTRIBUTE_OTHER_LDFLAGS "-lbz2"
   )
 
   sm_add_compile_definition("${SM_EXE_NAME}" _XOPEN_SOURCE)
@@ -403,6 +402,8 @@ elseif(APPLE)
     "vorbis"
   )
   list(APPEND SMDATA_LINK_LIB
+    "${BZIP2_LIBRARY_RELEASE}"
+    "${ICONV_LIBRARIES}"
     "pcre"
     "avcodec"
     "avdevice"


### PR DESCRIPTION
This removes the need for the arbitrary other linker flags.

This is required to allow for proper building of ffmpeg (the next goal).