### PR TITLE
Fix interaction between global offset and music rate.

### DIFF
--- a/src/TimingData.cpp
+++ b/src/TimingData.cpp
@@ -1,6 +1,7 @@
 #include "global.h"
 #include "TimingData.h"
 #include "PrefsManager.h"
+#include "GameState.h"
 #include "RageUtil.h"
 #include "RageLog.h"
 #include "ThemeManager.h"
@@ -704,7 +705,7 @@ bool TimingData::DoesLabelExist( const RString& sLabel ) const
 
 void TimingData::GetBeatAndBPSFromElapsedTime(GetBeatArgs& args) const
 {
-	args.elapsed_time += PREFSMAN->m_fGlobalOffsetSeconds;
+	args.elapsed_time += GAMESTATE->m_SongOptions.GetCurrent().m_fMusicRate * PREFSMAN->m_fGlobalOffsetSeconds;
 	GetBeatAndBPSFromElapsedTimeNoOffset(args);
 }
 
@@ -945,7 +946,8 @@ float TimingData::GetElapsedTimeInternal(GetBeatStarts& start, float beat,
 
 float TimingData::GetElapsedTimeFromBeat( float fBeat ) const
 {
-	return TimingData::GetElapsedTimeFromBeatNoOffset( fBeat ) - PREFSMAN->m_fGlobalOffsetSeconds;
+	return TimingData::GetElapsedTimeFromBeatNoOffset( fBeat )
+		- GAMESTATE->m_SongOptions.GetCurrent().m_fMusicRate * PREFSMAN->m_fGlobalOffsetSeconds;
 }
 
 float TimingData::GetElapsedTimeFromBeatNoOffset( float fBeat ) const


### PR DESCRIPTION
The global offset is a correction for audio latency, which is measured
in wall-clock time, but TimingData elapsed time values represent offsets
into the sound file.  To get the offset in the sound file that
corresponds to the wall-clock time of the global offset, we have to
multiply by the music rate.