### PR TITLE
Enforce submodule and compiler safety with builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,13 +61,37 @@ matrix:
                         - libxrandr-dev
                         - libglew-dev
 
+        -
+            env: CXX_COMPILER=g++-4.9 CC_COMPILER=gcc-4.9 BUILD_TYPE=Release WITH_FFMPEG=OFF
+            compiler: gcc
+            addons: &gcc49
+                apt:
+                    sources:
+                        - ubuntu-toolchain-r-test
+                    packages:
+                        - nasm
+                        - gcc-4.9
+                        - g++-4.9
+                        - libmad0-dev
+                        - libgtk2.0-dev
+                        - binutils-dev
+                        - libasound-dev
+                        - libpulse-dev
+                        - libjack-dev
+                        - libc6-dev
+                        - libogg-dev
+                        - libvorbis-dev
+                        - libxtst-dev
+                        - libxrandr-dev
+                        - libglew-dev
+
 before_install:
     # Set up valid submodules.
     - git submodule init
     - git submodule update extern/cppformat
     - git submodule update extern/tommath
     - git submodule update extern/tomcrypt
-    - git submodule update extern/googletest
+    - if [[ "${CXX_COMPILER}" != "g++-4.9" ]]; then git submodule update extern/googletest; fi
     - if [[ "${WITH_FFMPEG}" == "ON" ]]; then git submodule update extern/ffmpeg-git; fi
 
 install:

--- a/CMake/SetupFfmpeg.cmake
+++ b/CMake/SetupFfmpeg.cmake
@@ -48,6 +48,6 @@ if (IS_DIRECTORY "${SM_FFMPEG_SRC_DIR}")
     TEST_COMMAND ""
   )
 else()
-  message(ERROR "Submodule missing. Run git submodule init && git submodule update first.")
+  message(ERROR "Submodule for ffmpeg missing. Run git submodule init && git submodule update first.")
 endif()
 

--- a/StepmaniaCore.cmake
+++ b/StepmaniaCore.cmake
@@ -45,6 +45,18 @@ include("${SM_CMAKE_DIR}/SMDefs.cmake")
 # Put the predefined targets in separate groups.
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
+# Determine which projects can be compiled in.
+if (${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU")
+  message(STATUS "Using GNU compiler.")
+  if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5.0)
+    set(CAN_COMPILE_TESTS OFF)
+  else()
+    set(CAN_COMPILE_TESTS ON)
+  endif()
+else()
+  set(CAN_COMPILE_TESTS ON)
+endif()
+
 # Checks the standard include directories for c-style headers.
 # We may use C++ in this project, but the check works better with plain C headers.
 include(CheckIncludeFiles)
@@ -256,7 +268,7 @@ elseif(MACOSX)
   set(CMAKE_OSX_ARCHITECTURES "i386")
   set(CMAKE_OSX_DEPLOYMENT_TARGET "10.7")
   set(CMAKE_OSX_DEPLOYMENT_TARGET_FULL "10.7.0")
-  
+
   find_library(MAC_FRAME_ACCELERATE Accelerate ${CMAKE_SYSTEM_FRAMEWORK_PATH})
   find_library(MAC_FRAME_APPKIT AppKit ${CMAKE_SYSTEM_FRAMEWORK_PATH})
   find_library(MAC_FRAME_AUDIOTOOLBOX AudioToolbox ${CMAKE_SYSTEM_FRAMEWORK_PATH})

--- a/extern/CMakeProject-cppformat.cmake
+++ b/extern/CMakeProject-cppformat.cmake
@@ -1,3 +1,8 @@
+if (NOT IS_DIRECTORY "${SM_EXTERN_DIR}/cppformat")
+  message(ERROR "Submodule for cppformat missing. Run git submodule init && git submodule update first.")
+  return()
+endif()
+
 list(APPEND CPPFORMAT_SRC
   "cppformat/format.cc"
 )

--- a/extern/CMakeProject-googletest.cmake
+++ b/extern/CMakeProject-googletest.cmake
@@ -1,5 +1,10 @@
+if (NOT CAN_COMPILE_TESTS)
+  message(STATUS "Unit test support disabled. If you wish to compile and run the unit tests, please update your compiler.")
+  return()
+endif()
+
 if (NOT IS_DIRECTORY "${SM_EXTERN_DIR}/googletest")
-  message(ERROR "Submodule missing. Run git submodule init && git submodule update first.")
+  message(ERROR "Submodule for googletest missing. Run git submodule init && git submodule update first.")
   return()
 endif()
 

--- a/extern/CMakeProject-tomcrypt.cmake
+++ b/extern/CMakeProject-tomcrypt.cmake
@@ -1,5 +1,10 @@
 set(TOMDIR "${SM_EXTERN_DIR}/tomcrypt")
 
+if (NOT IS_DIRECTORY "${TOMDIR}")
+  message(ERROR "Submodule for tomcrypt missing. Run git submodule init && git submodule update first.")
+  return()
+endif()
+
 list(APPEND TOMCRYPT_MISC_CRYPT
   "${TOMDIR}/src/misc/crypt/crypt.c"
   "${TOMDIR}/src/misc/crypt/crypt_argchk.c"

--- a/extern/CMakeProject-tommath.cmake
+++ b/extern/CMakeProject-tommath.cmake
@@ -1,5 +1,9 @@
 set(TOMDIR "${SM_EXTERN_DIR}/tommath")
 
+if (NOT IS_DIRECTORY "${TOMDIR}")
+  message(ERROR "Submodule for tommath missing. Run git submodule init && git submodule update first.")
+endif()
+
 list(APPEND TOMMATH_SRC
   "${TOMDIR}/bn_error.c"
   "${TOMDIR}/bn_fast_mp_invmod.c"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,7 +9,9 @@ endif()
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR})
 
 include(CMakeProject-rage.cmake)
-include(CMakeProject-rage-test.cmake)
+if (CAN_COMPILE_TESTS)
+  include(CMakeProject-rage-test.cmake)
+endif()
 
 # Main project is below.
 


### PR DESCRIPTION
Eventually, there will be options to disable building the unit test portions explicitly. That will come later.