### PR TITLE
Revert "Rewrote Sprite::ScaleToClipped and CropTo to actually work."

### DIFF
--- a/Docs/Luadoc/LuaDocumentation.xml
+++ b/Docs/Luadoc/LuaDocumentation.xml
@@ -4982,7 +4982,7 @@ save yourself some time, copy this for undocumented things:
 		[02 Sprite.lua] Call <Link class='RageTexture' function='rate'><code>RageTexture:rate</code></Link><code>( fRate )</code> on the texture.
 	</Function>
 	<Function name='scaletoclipped' return='void' arguments='float fWidth, float fHeight'>
-		Scale the Sprite to width <code>fWidth</code> and height <code>fHeight</code> clipping dimension that would stick out.
+		Scale the Sprite to width <code>fWidth</code> and height <code>fHeight</code> clipping if the dimensions do not match.
 	</Function>
 	<Function name='setstate' return='void' arguments='int iNewState'>
 		Set the Sprite's state to <code>iNewState</code>.

--- a/src/Sprite.h
+++ b/src/Sprite.h
@@ -82,10 +82,10 @@ public:
 	 * @brief Scale the Sprite while maintaining the aspect ratio.
 	 *
 	 * It has to fit within and become clipped to the given parameters.
-	 * @param width the new width.
-	 * @param height the new height. */
-	void ScaleToClipped( float width, float height );
-	void CropTo( float width, float height );
+	 * @param fWidth the new width.
+	 * @param fHeight the new height. */
+	void ScaleToClipped( float fWidth, float fHeight );
+	void CropTo( float fWidth, float fHeight );
 
 	// Commands
 	virtual void PushSelf( lua_State *L );
@@ -137,7 +137,6 @@ private:
 	// Remembered clipped dimensions are applied on Load().
 	// -1 means no remembered dimensions;
 	float	m_fRememberedClipWidth, m_fRememberedClipHeight;
-	float	m_fRememberedCropWidth, m_fRememberedCropHeight;
 
 	float m_fTexCoordVelocityX;
 	float m_fTexCoordVelocityY;


### PR DESCRIPTION
ScaleToClipped needs to use custom tex coords to prevent the scale effect from tweening on.
Reverts stepmania/stepmania#203