### PR TITLE
Read DirectX SDK path from environment variable.

### DIFF
--- a/CMake/Modules/FindDirectX.cmake
+++ b/CMake/Modules/FindDirectX.cmake
@@ -10,20 +10,18 @@ if(NOT WIN32)
   return()
 endif()
 
-# TODO: See if the paths listed below are enough.
+if(NOT EXISTS "$ENV{DXSDK_DIR}")
+  message(FATAL_ERROR "Could not find Microsoft DirectX SDK installation!")
+endif()
 
 set(DIRECTX_INCLUDE_SEARCH_PATHS
   # TODO: Do not be limited to x86 in the future.
-  "C:/Program Files (x86)/Microsoft DirectX SDK (June 2010)/Include"
-  "C:/DXSDK/Include"
-  "C:/Program Files (x86)/Microsoft DirectX SDK/Include"
+  "$ENV{DXSDK_DIR}/Include"
 )
 
 set(DIRECTX_LIBRARY_SEARCH_PATHS
   # TODO: Do not be limited to x86 in the future.
-  "C:/Program Files (x86)/Microsoft DirectX SDK (June 2010)/Lib/x86"
-  "C:/DXSDK/Include/Lib/x86"
-  "C:/Program Files (x86)/Microsoft DirectX SDK/Lib/x86"
+  "$ENV{DXSDK_DIR}/Lib/x86"
 )
 
 find_path(DIRECTX_INCLUDE_DIR


### PR DESCRIPTION
Every DirectX SDK installation brings in an environment variable `DXSDK_DIR`, pointing to the directory where Direct SDK is installed. We can set search paths cleanly by reading this environment variable.
If this variable does not exist, we can tell that there is no DirectX SDK.