### PR TITLE
Use _stricmp, eliminating some warning C4996.

### DIFF
--- a/src/AnnouncerManager.cpp
+++ b/src/AnnouncerManager.cpp
@@ -38,7 +38,7 @@ void AnnouncerManager::GetAnnouncerNames( vector<RString>& AddTo )
 
 	// strip out the empty announcer folder
 	for( int i=AddTo.size()-1; i>=0; i-- )
-		if( !stricmp( AddTo[i], EMPTY_ANNOUNCER_NAME ) )
+		if( !_stricmp( AddTo[i], EMPTY_ANNOUNCER_NAME ) )
 			AddTo.erase(AddTo.begin()+i, AddTo.begin()+i+1 );
 }
 
@@ -50,7 +50,7 @@ bool AnnouncerManager::DoesAnnouncerExist( RString sAnnouncerName )
 	vector<RString> asAnnouncerNames;
 	GetAnnouncerNames( asAnnouncerNames );
 	for( unsigned i=0; i<asAnnouncerNames.size(); i++ )
-		if( 0==stricmp(sAnnouncerName, asAnnouncerNames[i]) )
+		if( 0==_stricmp(sAnnouncerName, asAnnouncerNames[i]) )
 			return true;
 	return false;
 }

--- a/src/InputMapper.cpp
+++ b/src/InputMapper.cpp
@@ -1044,7 +1044,7 @@ MultiPlayer InputMapper::InputDeviceToMultiPlayer( InputDevice id )
 GameButton InputScheme::ButtonNameToIndex( const RString &sButtonName ) const
 {
 	for( GameButton gb=(GameButton) 0; gb<m_iButtonsPerController; gb=(GameButton)(gb+1) ) 
-		if( stricmp(GetGameButtonName(gb), sButtonName) == 0 )
+		if( _stricmp(GetGameButtonName(gb), sButtonName) == 0 )
 			return gb;
 
 	return GameButton_Invalid;

--- a/src/NetworkSyncManager.cpp
+++ b/src/NetworkSyncManager.cpp
@@ -927,7 +927,7 @@ unsigned long NetworkSyncManager::GetCurrentSMBuild( LoadingWindow* ld )
 							Trim( sFieldName );
 							Trim( sFieldValue );
 
-							if( 0 == stricmp(sFieldName,"X-SM-Build") )
+							if( 0 == _stricmp(sFieldName,"X-SM-Build") )
 							{
 								bSuccess = true;
 								uCurrentSMBuild = strtoul( sFieldValue, NULL, 10 );

--- a/src/NoteSkinManager.cpp
+++ b/src/NoteSkinManager.cpp
@@ -204,7 +204,7 @@ bool NoteSkinManager::NoteSkinNameInList(const RString name, vector<RString> nam
 {
 	for(size_t i= 0; i < name_list.size(); ++i)
 	{
-		if(0 == stricmp(name, name_list[i]))
+		if(0 == _stricmp(name, name_list[i]))
 		{
 			return true;
 		}

--- a/src/ScreenOptionsMasterPrefs.cpp
+++ b/src/ScreenOptionsMasterPrefs.cpp
@@ -183,7 +183,7 @@ static void GameSel( int &sel, bool ToSel, const ConfOption *pConfOption )
 
 		sel = 0;
 		for(unsigned i = 0; i < choices.size(); ++i)
-			if( !stricmp(choices[i], sCurGameName) )
+			if( !_stricmp(choices[i], sCurGameName) )
 				sel = i;
 	} else {
 		vector<const Game*> aGames;
@@ -218,12 +218,12 @@ static void Language( int &sel, bool ToSel, const ConfOption *pConfOption )
 	{
 		sel = -1;
 		for( unsigned i=0; sel == -1 && i < vs.size(); ++i )
-			if( !stricmp(vs[i], THEME->GetCurLanguage()) )
+			if( !_stricmp(vs[i], THEME->GetCurLanguage()) )
 				sel = i;
 
 		// If the current language doesn't exist, we'll show BASE_LANGUAGE, so select that.
 		for( unsigned i=0; sel == -1 && i < vs.size(); ++i )
-			if( !stricmp(vs[i], SpecialFiles::BASE_LANGUAGE) )
+			if( !_stricmp(vs[i], SpecialFiles::BASE_LANGUAGE) )
 				sel = i;
 
 		if( sel == -1 )
@@ -272,7 +272,7 @@ static void RequestedTheme( int &sel, bool ToSel, const ConfOption *pConfOption 
 	{
 		sel = 0;
 		for( unsigned i=1; i<vsThemeNames.size(); i++ )
-			if( !stricmp(vsThemeNames[i], PREFSMAN->m_sTheme.Get()) )
+			if( !_stricmp(vsThemeNames[i], PREFSMAN->m_sTheme.Get()) )
 				sel = i;
 	}
 	else
@@ -298,7 +298,7 @@ static void Announcer( int &sel, bool ToSel, const ConfOption *pConfOption )
 	{
 		sel = 0;
 		for( unsigned i=1; i<choices.size(); i++ )
-			if( !stricmp(choices[i], ANNOUNCER->GetCurAnnouncerName()) )
+			if( !_stricmp(choices[i], ANNOUNCER->GetCurAnnouncerName()) )
 				sel = i;
 	}
 	else
@@ -325,7 +325,7 @@ static void DefaultNoteSkin( int &sel, bool ToSel, const ConfOption *pConfOption
 		po.FromString( PREFSMAN->m_sDefaultModifiers );
 		sel = 0;
 		for( unsigned i=0; i < choices.size(); i++ )
-			if( !stricmp(choices[i], po.m_sNoteSkin) )
+			if( !_stricmp(choices[i], po.m_sNoteSkin) )
 				sel = i;
 	}
 	else

--- a/src/archutils/Win32/arch_setup.h
+++ b/src/archutils/Win32/arch_setup.h
@@ -20,7 +20,6 @@
 #if defined(_MSC_VER)
 
 #if _MSC_VER == 1400 // VC8 specific warnings
-#pragma warning (disable : 4996) // deprecated functions vs "ISO C++ conformant names". (stricmp vs _stricmp)
 #pragma warning (disable : 4005) // macro redefinitions (ARRAYSIZE)
 #endif
 

--- a/src/global.h
+++ b/src/global.h
@@ -148,10 +148,10 @@ template<int> struct CompileAssertDecl { };
 typedef StdString::CStdString RString;
 
 #if !defined(WIN32)
-/** @brief Define stricmp to be strcasecmp. */
-#define stricmp strcasecmp
-/** @brief Define strnicmp to be strncasecmp. */
-#define strnicmp strncasecmp
+/** @brief Define _stricmp to be strcasecmp. */
+#define _stricmp strcasecmp
+/** @brief Define _strnicmp to be strncasecmp. */
+#define _strnicmp strncasecmp
 #endif
 
 #include "RageException.h"


### PR DESCRIPTION
Since C++11 implementations requires Visual Studio 2013 and higher, it's time to get rid of deprecated `stricmp` and negate some warnings.