### PR TITLE
reinstate MaxRegenComboAfterMiss Preference

### DIFF
--- a/src/LifeMeterBar.cpp
+++ b/src/LifeMeterBar.cpp
@@ -211,7 +211,13 @@ void LifeMeterBar::ChangeLife( float fDeltaLife )
 		fDeltaLife *= 1 + (float)m_iProgressiveLifebar/8 * m_iMissCombo;
 		// do this after; only successive W5/miss will increase the amount of life lost.
 		m_iMissCombo++;
-		m_iComboToRegainLife = PREFSMAN->m_iRegenComboAfterMiss;
+		/* Increase by m_iRegenComboAfterMiss; never push it beyond m_iMaxRegenComboAfterMiss
+		 * but don't reduce it if it's already past. */
+		const int NewComboToRegainLife = min(
+			 (int)PREFSMAN->m_iMaxRegenComboAfterMiss,
+			 m_iComboToRegainLife + PREFSMAN->m_iRegenComboAfterMiss );
+
+		m_iComboToRegainLife = max( m_iComboToRegainLife, NewComboToRegainLife );
 	}
 
 	// If we've already failed, there's no point in letting them fill up the bar again.

--- a/src/PrefsManager.cpp
+++ b/src/PrefsManager.cpp
@@ -202,6 +202,7 @@ PrefsManager::PrefsManager() :
 
 
 	m_iRegenComboAfterMiss		( "RegenComboAfterMiss",	5 ),
+	m_iMaxRegenComboAfterMiss	( "MaxRegenComboAfterMiss",	5 ), // this was 10 by default in SM3.95 -dguzek
 	m_bMercifulDrain		( "MercifulDrain",		false ),	// negative life deltas are scaled by the players life percentage
 	m_HarshHotLifePenalty		( "HarshHotLifePenalty",	true ),
 	m_bMinimum1FullSongInCourses	( "Minimum1FullSongInCourses",	false ),	// FEoS for 1st song, FailImmediate thereafter

--- a/src/PrefsManager.h
+++ b/src/PrefsManager.h
@@ -193,9 +193,10 @@ public:
 	Preference<float>	m_fLifeDifficultyScale;
 
 	// Whoever added these: Please add a comment saying what they do. -Chris
-	Preference<int>	m_iRegenComboAfterMiss;
+	Preference<int>		m_iRegenComboAfterMiss; // combo that must be met after a Miss to regen life
+	Preference<int>		m_iMaxRegenComboAfterMiss; // caps RegenComboAfterMiss if multiple Misses occur in rapid succession
 	Preference<bool>	m_bMercifulDrain; // negative life deltas are scaled by the players life percentage
-	Preference<bool> m_HarshHotLifePenalty; // See LifeMeterBar.cpp -Kyz
+	Preference<bool>	m_HarshHotLifePenalty; // See LifeMeterBar.cpp -Kyz
 	Preference<bool>	m_bMinimum1FullSongInCourses; // FEoS for 1st song, FailImmediate thereafter
 	Preference<bool>	m_bFailOffInBeginner;
 	Preference<bool>	m_bFailOffForFirstStageEasy;


### PR DESCRIPTION
This preference existed in previous versions of StepMania (3.95, at least) and is needed to properly emulate certain games (namely, In The Groove).

This PR brings back the code as seen here: https://github.com/sigatrev/Stepmania-3.95/blob/4af304c51aeeedacd07f612d7f0e5ecaa81cce19/LifeMeterBar.cpp#L228-L233

Unlike in SM3.95, however, I've now set the default value to be 5, the same as the `RegenComboAfterMiss`.  If players don't change the value, they won't see any difference in behavior in SM5.

If players want, they can manually set the preference to 10 (or a value of their choosing) to emulate the game of their choice.