### PR TITLE
fix logic for attacks in gameplay disqualifying

### DIFF
--- a/src/PlayerOptions.cpp
+++ b/src/PlayerOptions.cpp
@@ -881,7 +881,7 @@ bool PlayerOptions::IsEasierForSongAndSteps( Song* pSong, Steps* pSteps, PlayerN
 	if( m_bTransforms[TRANSFORM_ECHO] )	return true;
 	
 	// Removing attacks is easier in general.
-	if (m_fNoAttack || (!m_fRandAttack && pSteps->HasAttacks()))
+	if ((m_fNoAttack && pSteps->HasAttacks()) || m_fRandAttack)
 		return true;
 	
 	if( m_fCover )	return true;


### PR DESCRIPTION
When disqualification was turned on via Preferences, the old logic exhibited two problems:

1. charts with attacks were always disqualified from ranking
2. charts without attacks could be disqualified from ranking if the attack modifier was set to "Off"

So, this commit fixes those problems.  If a chart has attacks, and the attack modifier is used to turn them "Off", then disqualification is enforced.

Additionally, disqualification is enforced if the attack modifier is set to "Random Attacks."  This part might not be necessary, but I acted on the assumption that random attacks could theoretically make a chart easier.