### PR TITLE
Fix GCC warnings on Linux.

### DIFF
--- a/src/RageBitmapTexture.cpp
+++ b/src/RageBitmapTexture.cpp
@@ -87,7 +87,7 @@ void RageBitmapTexture::Create()
 	{
 		RString warning = ssprintf("RageBitmapTexture: Couldn't load %s: %s",
 			actualID.filename.c_str(), error.c_str());
-		LOG->Warn(warning);
+		LOG->Warn("%s", warning.c_str());
 		Dialog::OK(warning, "missing_texture");
 		pImg = RageSurfaceUtils::MakeDummySurface( 64, 64 );
 		ASSERT( pImg != NULL );

--- a/src/RageFileManager.cpp
+++ b/src/RageFileManager.cpp
@@ -280,16 +280,20 @@ static void ChangeToDirOfExecutable( const RString &argv0 )
 	/* Set the CWD.  Any effects of this is platform-specific; most files are read and
 	 * written through RageFile.  See also RageFileManager::RageFileManager. */
 #if defined(_WINDOWS)
-	chdir( RageFileManagerUtil::sDirOfExecutable + "/.." );
+	if( _chdir( RageFileManagerUtil::sDirOfExecutable + "/.." ) )
 #elif defined(UNIX)
-	chdir( RageFileManagerUtil::sDirOfExecutable + "/" );
+	if( chdir( RageFileManagerUtil::sDirOfExecutable + "/" ) )
 #elif defined(MACOSX)
 	/* If the basename is not MacOS, then we've likely been launched via the command line
 	 * through a symlink. Assume this is the case and change to the dir of the symlink. */
 	if( Basename(RageFileManagerUtil::sDirOfExecutable) == "MacOS" )
 		CollapsePath( RageFileManagerUtil::sDirOfExecutable += "/../../../" );
-	chdir( RageFileManagerUtil::sDirOfExecutable );
+	if( chdir( RageFileManagerUtil::sDirOfExecutable ) )
 #endif
+	{
+		LOG->Warn("Can't set current working directory to %s", RageFileManagerUtil::sDirOfExecutable.c_str());
+		return;
+	}
 }
 
 RageFileManager::RageFileManager( const RString &argv0 )

--- a/src/RageSoundPosMap.cpp
+++ b/src/RageSoundPosMap.cpp
@@ -180,17 +180,17 @@ int64_t pos_map_queue::Search( int64_t iSourceFrame, bool *bApproximate ) const
 	 * 3. Underflow; we'll be given a larger frame number than we know about.
 	 */
 #if defined(WIN32)
-#define LI "%I64i"
-#elif defined(PRIi64)
-#define LI "%" PRIi64
+#define I64F "%I64i"
+#elif defined(__x86_64__)
+#define I64F "%li"
 #else
-#define LI "%lli"
+#define I64F "%lli"
 #endif
 	static RageTimer last;
 	if( last.PeekDeltaTime() >= 1.0f )
 	{
 		last.GetDeltaTime();
-		LOG->Trace( "Approximate sound time: driver frame " LI ", m_pImpl->m_Queue frame " LI ".." LI " (dist " LI "), closest position is " LI,
+		LOG->Trace( "Approximate sound time: driver frame " I64F ", m_pImpl->m_Queue frame " I64F ".." I64F " (dist " I64F "), closest position is " I64F,
 			iSourceFrame, pClosestBlock->m_iDestFrame, pClosestBlock->m_iDestFrame+pClosestBlock->m_iFrames,
 			iClosestPositionDist, iClosestPosition );
 	}

--- a/src/ScreenEvaluation.cpp
+++ b/src/ScreenEvaluation.cpp
@@ -265,13 +265,13 @@ void ScreenEvaluation::Init()
 
 				m_SmallBanner[i].LoadFromSong( pSong );
 				m_SmallBanner[i].ScaleToClipped( BANNER_WIDTH, BANNER_HEIGHT );
-				m_SmallBanner[i].SetName( ssprintf("SmallBanner%d",i+1) );
+				m_SmallBanner[i].SetName( ssprintf("SmallBanner%zu",i+1) );
 				ActorUtil::LoadAllCommands( m_SmallBanner[i], m_sName );
 				SET_XY( m_SmallBanner[i] );
 				this->AddChild( &m_SmallBanner[i] );
 
 				m_sprSmallBannerFrame[i].Load( THEME->GetPathG(m_sName,"BannerFrame") );
-				m_sprSmallBannerFrame[i]->SetName( ssprintf("SmallBanner%d",i+1) );
+				m_sprSmallBannerFrame[i]->SetName( ssprintf("SmallBanner%zu",i+1) );
 				ActorUtil::LoadAllCommands( *m_sprSmallBannerFrame[i], m_sName );
 				SET_XY( m_sprSmallBannerFrame[i] );
 				this->AddChild( m_sprSmallBannerFrame[i] );

--- a/src/TimingData.cpp
+++ b/src/TimingData.cpp
@@ -143,7 +143,7 @@ void TimingData::DumpOneTable(const beat_start_lookup_t& lookup, const RString& 
 			SegInfoStr(stops, starts.stop, "stop").c_str(),
 			SegInfoStr(delays, starts.delay, "delay").c_str(),
 			starts.last_row, starts.last_time, starts.warp_destination, starts.is_warping);
-		LOG->Trace(str.c_str());
+		LOG->Trace("%s", str.c_str());
 	}
 }
 

--- a/src/arch/Lights/LightsDriver_Linux_PIUIO.cpp
+++ b/src/arch/Lights/LightsDriver_Linux_PIUIO.cpp
@@ -24,7 +24,7 @@ LightsDriver_Linux_PIUIO::LightsDriver_Linux_PIUIO()
 	fd = open("/dev/piuio0", O_WRONLY);
 	if( fd < 0 )
 	{
-		LOG->Warn( "Error opening serial port for lights. Error:: %d %s", errno, strerror(errno) );
+		LOG->Warn( "Error opening serial port for lights. Error: %d %s", errno, strerror(errno) );
 		return;
 	}
 	LOG->Info("Opened PIUIO device for lights");
@@ -75,7 +75,11 @@ void LightsDriver_Linux_PIUIO::Set( const LightsState *ls )
 		return;
 	memcpy(oldbuf, buf, 8);
 
-	write(fd, buf, 8);
+	if (write(fd, buf, 8) != 8)
+	{
+		LOG->Warn( "Error setting lights state. Error: %d %s", errno, strerror(errno) );
+		return;
+	}
 }
 
 /*


### PR DESCRIPTION
This commit attempts to eliminate GCC 5 warnings on Linux (as tested by Travis CI), leaving an only warning to be resolved:
```
/home/travis/build/Prcuvu/stepmania/src/archutils/Unix/BacktraceNames.cpp:455:2: warning: #warning Undefined BACKTRACE_LOOKUP_METHOD_* [-Wcpp]
 #warning Undefined BACKTRACE_LOOKUP_METHOD_*
  ^
```
Which macro should we actually use to kill this warning?