### PR TITLE
Have sm_crash use std::string now.

### DIFF
--- a/src/global.cpp
+++ b/src/global.cpp
@@ -21,25 +21,25 @@ using CrashHandler::DebugBreak;
 #include "archutils/Unix/CrashHandler.h"
 #endif
 
-void NORETURN sm_crash( const char *reason )
+void NORETURN sm_crash( std::string const &reason )
 {
 #if ( defined(_WINDOWS) && defined(CRASH_HANDLER) ) || defined(MACOSX) || defined(_XDBG)
 	/* If we're being debugged, throw a debug break so it'll suspend the process. */
 	if( IsDebuggerPresent() )
 	{
 		DebugBreak();
-		while(1); /* don't return */
+		for(;;); /* don't return */
 	}
 #endif
 
 #if defined(CRASH_HANDLER)
-	CrashHandler::ForceCrash( reason );
+	CrashHandler::ForceCrash( reason.c_str() );
 #else
 	*(char*)0=0;
 
 	/* This isn't actually reached.  We just do this to convince the compiler that the
 	 * function really doesn't return. */
-	while(1);
+	for(;;)
 #endif
 
 #if defined(_WINDOWS)

--- a/src/global.h
+++ b/src/global.h
@@ -86,7 +86,7 @@ namespace Checkpoints
  * @param reason the crash reason as determined by prior function calls.
  * @return nothing: there is no escape without quitting the program.
  */
-void NORETURN sm_crash( const char *reason = "Internal error" );
+void NORETURN sm_crash( std::string const &reason );
 
 /**
  * @brief Assertion that sets an optional message and brings up the crash


### PR DESCRIPTION
This one is relatively safe to modify: all calls are handled through defined macros.

The macros themselves will be looked at another day.

This commit may potentially be cherry-picked into master with no issues.