### PR TITLE
Use more of std::string and fmt::sprintf.

### DIFF
--- a/src/Font.cpp
+++ b/src/Font.cpp
@@ -627,11 +627,10 @@ void Font::LoadFontPageSettings( FontPageSettings &cfg, IniFile &ini, const RStr
 
 				if(int(wdata.size()) > num_frames_wide)
 				{
-					LuaHelpers::ReportScriptErrorFmt(
-						"The font definition \"%s\" assigns %i characters to row %i"
-						"(\"%ls\"), but the font  is only %i characters wide.",
-						ini.GetPath().c_str(), (int)wdata.size(), row, wdata.c_str(),
-						num_frames_wide);
+					// wstrings don't work. Convert to RString first.
+					std::string error = fmt::format("The font definition \"{0}\" assigns {1} characters to row {2} (\"{3}\"), but the font is only {4} characters wide.",
+						ini.GetPath(), wdata.size(), row, WStringToRString(wdata), num_frames_wide);
+					LuaHelpers::ReportScriptErrorFmt(error);
 					continue;
 				}
 

--- a/src/LuaBinding.cpp
+++ b/src/LuaBinding.cpp
@@ -217,7 +217,7 @@ bool LuaBinding::Equal( lua_State *L )
  * Get a userdata, and check that it's either szType or a type
  * derived from szType, by checking the heirarchy table.
  */
-bool LuaBinding::CheckLuaObjectType( lua_State *L, int iArg, const char *szType )
+bool LuaBinding::CheckLuaObjectType( lua_State *L, int iArg, std::string const &szType )
 {
 #if defined(FAST_LUA)
 	return true;
@@ -233,7 +233,7 @@ bool LuaBinding::CheckLuaObjectType( lua_State *L, int iArg, const char *szType 
 		return false;
 	}
 
-	lua_getfield( L, -1, szType );
+	lua_getfield( L, -1, szType.c_str() );
 	bool bRet = !lua_isnil( L, -1 );
 	lua_pop( L, 2 );
 

--- a/src/LuaBinding.h
+++ b/src/LuaBinding.h
@@ -20,7 +20,7 @@ public:
 	virtual const RString &GetBaseClassName() const = 0;
 
 	static void ApplyDerivedType( Lua *L, const RString &sClassname, void *pSelf );
-	static bool CheckLuaObjectType( lua_State *L, int narg, const char *szType );
+	static bool CheckLuaObjectType( lua_State *L, int narg, std::string const &szType );
 
 protected:
 	virtual void Register( Lua *L, int iMethods, int iMetatable ) = 0;
@@ -73,7 +73,7 @@ public:
 		if( !LuaBinding::CheckLuaObjectType(L, narg, m_sClassName) )
 		{
 			if( bIsSelf )
-				luaL_typerror( L, narg, m_sClassName );
+				luaL_typerror( L, narg, m_sClassName.c_str());
 			else
 				LuaHelpers::TypeError( L, narg, m_sClassName );
 		}

--- a/src/LuaManager.cpp
+++ b/src/LuaManager.cpp
@@ -838,16 +838,6 @@ Dialog::Result LuaHelpers::ReportScriptError(RString const& Error, RString Error
 	return Dialog::ok;
 }
 
-// For convenience when replacing uses of LOG->Warn.
-void LuaHelpers::ReportScriptErrorFmt(const char *fmt, ...)
-{
-	va_list	va;
-	va_start( va, fmt );
-	RString Buff = vssprintf( fmt, va );
-	va_end( va );
-	ReportScriptError(Buff);
-}
-
 bool LuaHelpers::RunScriptOnStack( Lua *L, RString &Error, int Args, int ReturnValues, bool ReportError )
 {
 	lua_pushcfunction( L, GetLuaStack );
@@ -1003,7 +993,7 @@ void LuaHelpers::ParseCommandList( Lua *L, const RString &sCommands, const RStri
 
 /* Like luaL_typerror, but without the special case for argument 1 being "self"
  * in method calls, so we give a correct error message after we remove self. */
-int LuaHelpers::TypeError( Lua *L, int iArgNo, const char *szName )
+int LuaHelpers::TypeError( Lua *L, int iArgNo, std::string const &szName )
 {
 	RString sType;
 	luaL_pushtype( L, iArgNo );
@@ -1013,13 +1003,13 @@ int LuaHelpers::TypeError( Lua *L, int iArgNo, const char *szName )
 	if( !lua_getstack( L, 0, &debug ) )
 	{
 		return luaL_error( L, "invalid type (%s expected, got %s)",
-			szName, sType.c_str() );
+			szName.c_str(), sType.c_str() );
 	}
 	else
 	{
 		lua_getinfo( L, "n", &debug );
 		return luaL_error( L, "bad argument #%d to \"%s\" (%s expected, got %s)",
-			iArgNo, debug.name? debug.name:"(unknown)", szName, sType.c_str() );
+			iArgNo, debug.name? debug.name:"(unknown)", szName.c_str(), sType.c_str() );
 	}
 }
 

--- a/src/LuaManager.h
+++ b/src/LuaManager.h
@@ -69,8 +69,14 @@ namespace LuaHelpers
 	Dialog::Result ReportScriptError(RString const& Error, RString ErrorType= "LUA_ERROR", bool UseAbort= false);
 	// Just the broadcast message part, for things that need to do the rest differently.
 	void ScriptErrorMessage(RString const& Error);
-	// For convenience when replacing uses of LOG->Warn.
-	void ReportScriptErrorFmt(const char *fmt, ...);
+	
+	/** @brief A convenience method to use when replacing uses of LOG->Warn. */
+	template<typename... Args>
+	void ReportScriptErrorFmt(std::string const &msg, Args const & ...args)
+	{
+		std::string result = fmt::sprintf(msg, args...);
+		ReportScriptError(result);
+	}
 
 	/* Run the function with arguments at the top of the stack, with the given
 	 * number of arguments. The specified number of return values are left on
@@ -153,7 +159,7 @@ namespace LuaHelpers
 		}
 	}
 
-	int TypeError( Lua *L, int narg, const char *tname );
+	int TypeError( Lua *L, int narg, std::string const &tname );
 	inline int AbsIndex( Lua *L, int i ) { if( i > 0 || i <= LUA_REGISTRYINDEX ) return i; return lua_gettop( L ) + i + 1; }
 }
 

--- a/src/RageLog.cpp
+++ b/src/RageLog.cpp
@@ -365,7 +365,7 @@ void RageLog::UnmapLog( const RString &key )
 	UpdateMappedLog();
 }
 
-void ShowWarningOrTrace( const char *file, int line, const char *message, bool bWarning )
+void ShowWarningOrTrace( const char *file, int line, std::string const &message, bool bWarning )
 {
 	/* Ignore everything up to and including the first "src/". */
 	const char *temp = strstr( file, "src/" );
@@ -385,7 +385,7 @@ void ShowWarningOrTrace( const char *file, int line, const char *message, bool b
 	}
 	else
 	{
-		fprintf(stderr, "%s:%i: %s\n", file, line, message);
+		fprintf(stderr, "%s:%i: %s\n", file, line, message.c_str());
 	}
 }
 

--- a/src/RageSoundReader_Vorbisfile.cpp
+++ b/src/RageSoundReader_Vorbisfile.cpp
@@ -36,12 +36,10 @@ static long OggRageFile_tell_func( void *datasource )
 	return f->Tell();
 }
 
-static RString ov_ssprintf( int err, const char *fmt, ...)
+template<typename... Args>
+static std::string ov_format( int err, std::string const &msg, Args const & ...args)
 {
-	va_list	va;
-	va_start( va, fmt );
-	RString s = vssprintf( fmt, va );
-	va_end( va );
+	std::string s = fmt::sprintf(msg, args...);
 
 	RString errstr;
 	switch( err )
@@ -79,7 +77,7 @@ RageSoundReader_FileReader::OpenResult RageSoundReader_Vorbisfile::Open( RageFil
 	int ret = ov_open_callbacks( pFile, vf, nullptr, 0, callbacks );
 	if( ret < 0 )
 	{
-		SetError( ov_ssprintf(ret, "ov_open failed") );
+		SetError( ov_format(ret, "ov_open failed") );
 		delete vf;
 		vf = nullptr;
 		switch( ret )
@@ -128,7 +126,7 @@ int RageSoundReader_Vorbisfile::SetPosition( int iFrame )
 			eof = true;
 			return 0;
 		}
-		SetError( ov_ssprintf(ret, "ogg: SetPosition failed") );
+		SetError( ov_format(ret, "ogg: SetPosition failed") );
 		return -1;
 	}
 	read_offset = (int) ov_pcm_tell(vf);

--- a/src/RageThreads.h
+++ b/src/RageThreads.h
@@ -75,7 +75,7 @@ private:
 namespace Checkpoints
 {
 	void LogCheckpoints( bool yes=true );
-	void SetCheckpoint( const char *file, int line, const char *message );
+	void SetCheckpoint( const char *file, int line, std::string const &message );
 	void GetLogs( char *pBuf, int iSize, const char *delim );
 };
 

--- a/src/arch/MovieTexture/MovieTexture_FFMpeg.cpp
+++ b/src/arch/MovieTexture/MovieTexture_FFMpeg.cpp
@@ -352,14 +352,12 @@ void MovieDecoder_FFMpeg::GetFrame( RageSurface *pSurface )
 			pict.data, pict.linesize );
 }
 
-static RString averr_ssprintf( int err, const char *fmt, ... )
+template<typename... Args>
+static std::string averr_format( int err, std::string const &msg, Args const & ...args)
 {
 	ASSERT( err < 0 );
-
-	va_list     va;
-	va_start(va, fmt);
-	RString s = vssprintf( fmt, va );
-	va_end(va); 
+	
+	std::string s = fmt::sprintf(msg, args...);
 
 	size_t errbuf_size = 512;
 	char* errbuf = new char[errbuf_size];
@@ -425,11 +423,11 @@ RString MovieDecoder_FFMpeg::Open( RString sFile )
 	m_fctx->pb = m_avioContext;
 	int ret = avcodec::avformat_open_input( &m_fctx, sFile.c_str(), nullptr, nullptr );
 	if( ret < 0 )
-		return RString( averr_ssprintf(ret, "AVCodec: Couldn't open \"%s\"", sFile.c_str()) );
+		return RString( averr_format(ret, "AVCodec: Couldn't open \"%s\"", sFile.c_str()) );
 
 	ret = avcodec::avformat_find_stream_info( m_fctx, nullptr );
 	if( ret < 0 )
-		return RString( averr_ssprintf(ret, "AVCodec (%s): Couldn't find codec parameters", sFile.c_str()) );
+		return RString( averr_format(ret, "AVCodec (%s): Couldn't find codec parameters", sFile.c_str()) );
 
 	int stream_idx = avcodec::av_find_best_stream( m_fctx, avcodec::AVMEDIA_TYPE_VIDEO, -1, -1, nullptr, 0 );
 	if ( stream_idx < 0 ||
@@ -474,7 +472,7 @@ RString MovieDecoder_FFMpeg::OpenCodec()
 
 	int ret = avcodec::avcodec_open2( m_pStream->codec, pCodec, nullptr );
 	if( ret < 0 )
-		return RString( averr_ssprintf(ret, "Couldn't open codec \"%s\"", pCodec->name) );
+		return RString( averr_format(ret, "Couldn't open codec \"%s\"", pCodec->name) );
 	ASSERT( m_pStream->codec->codec != nullptr );
 
 	return RString();

--- a/src/global.h
+++ b/src/global.h
@@ -55,7 +55,7 @@
 /** @brief RageThreads defines (don't pull in all of RageThreads.h here) */
 namespace Checkpoints
 {
-	void SetCheckpoint( const char *file, int line, const char *message );
+	void SetCheckpoint( const char *file, int line, std::string const &message );
 }
 /** @brief Set a checkpoint with no message. */
 #define CHECKPOINT (Checkpoints::SetCheckpoint(__FILE__, __LINE__, nullptr))
@@ -106,7 +106,7 @@ void NORETURN sm_crash( std::string const &reason );
 /** @brief Use this to catch switching on invalid values */
 #define DEFAULT_FAIL(i) 	default: FAIL_M( ssprintf("%s = %i", #i, (i)) )
 
-void ShowWarningOrTrace( const char *file, int line, const char *message, bool bWarning ); // don't pull in LOG here
+void ShowWarningOrTrace( const char *file, int line, std::string const &message, bool bWarning ); // don't pull in LOG here
 #define WARN(MESSAGE) (ShowWarningOrTrace(__FILE__, __LINE__, MESSAGE, true))
 #if !defined(CO_EXIST_WITH_MFC)
 #define TRACE(MESSAGE) (ShowWarningOrTrace(__FILE__, __LINE__, MESSAGE, false))


### PR DESCRIPTION
Also, investigated the `%p` issue. Explicit casts to `(void *)` can still work. Unsure if it's a good idea all the time, but one step at a time perhaps.

The only usages of `vssprintf` now are tied to our custom `ssprintf` function. I do not trust that just replacing the functionality with `cppformat` will work here. That is for later tonight I guess.