### PR TITLE
Use an alternative hex calculation for wchar_t.

### DIFF
--- a/src/RageUtil.cpp
+++ b/src/RageUtil.cpp
@@ -1,6 +1,7 @@
 #include "global.h"
 #include "RageUtil.h"
 #include "RageMath.hpp"
+#include "RageString.hpp"
 
 #include <array>
 
@@ -2116,11 +2117,20 @@ void Replace_Unicode_Markers( RString &sText )
 // Form a string to identify a wchar_t with ASCII.
 RString WcharDisplayText( wchar_t c )
 {
-	RString sChr;
-	sChr = ssprintf( "U+%4.4x", c );
-	if( c < 128 )
-		sChr += ssprintf( " ('%c')", char(c) );
-	return sChr;
+	char ascii = '\0';
+	if (c < 128)
+	{
+		ascii = static_cast<char>(c);
+	}
+
+	std::string hex = Rage::hexify(c, 4);
+
+	if (ascii != '\0')
+	{
+		hex = fmt::format("U+{0} ('{1}')", hex, ascii);
+	}
+
+	return hex;
 }
 
 /* Return the last named component of dir:

--- a/src/rage/RageString.cpp
+++ b/src/rage/RageString.cpp
@@ -1,5 +1,6 @@
 #include "RageString.hpp"
 #include <cstdlib>
+#include <sstream>
 
 using namespace Rage;
 
@@ -27,4 +28,29 @@ std::string Rage::tail(std::string const &source, int32_t const length)
 		return source.substr(-length);
 	}
 	return source.substr(source.size() - length);
+}
+
+std::string Rage::hexify(wchar_t const src, unsigned int dstlen)
+{
+	static char const alphabet[] = "0123456789abcdef";
+
+	std::stringstream builder;
+	
+	unsigned int i = 0;
+	wchar_t const *ptr = &src;
+	
+	while (*ptr && ( 2 * i ) + 1 < dstlen)
+	{
+		builder << alphabet[*ptr / 16];
+		builder << alphabet[*ptr % 16];
+		++ptr;
+		++i;
+	}
+	
+	std::string setup{builder.str()};
+	while (setup.size() < dstlen)
+	{
+		setup = '0' + setup;
+	}
+	return setup;
 }

--- a/src/rage/RageString.hpp
+++ b/src/rage/RageString.hpp
@@ -16,6 +16,11 @@ namespace Rage
      * This comes from http://stackoverflow.com/a/7597469/445373
      */
     std::string tail(std::string const &source, int32_t const length);
+
+	/** @brief Offer a clean way of hexify-ing a wide character. Primarily used for fonts.
+	 *
+	 * See http://stackoverflow.com/a/8024386 */
+	std::string hexify(wchar_t const src, unsigned int dstlen);
 }
 
 #endif

--- a/src/tests/RageStringTest.cpp
+++ b/src/tests/RageStringTest.cpp
@@ -63,3 +63,12 @@ GTEST_TEST(RageString, tail_song_group_name_check)
 	
 	EXPECT_EQ("StepMix 5", target);
 }
+
+GTEST_TEST(RageString, hexify_ascii)
+{
+	wchar_t test = 'a';
+
+	std::string target = Rage::hexify(test, 4);
+
+	EXPECT_EQ("0061", target);
+}


### PR DESCRIPTION
This is being done to prepare for valid `cppformat` combinations.