### PR TITLE
All %p calls should be casted now.

### DIFF
--- a/src/FontManager.cpp
+++ b/src/FontManager.cpp
@@ -79,7 +79,7 @@ void FontManager::UnloadFont( Font *fp )
 		return;
 	}
 
-	FAIL_M( ssprintf("Unloaded an unknown font (%p)", fp) );
+	FAIL_M( ssprintf("Unloaded an unknown font allegedly at %s", fp->path.c_str()) );
 }
 
 /*

--- a/src/Profile.cpp
+++ b/src/Profile.cpp
@@ -388,7 +388,7 @@ float Profile::GetSongsActual( StepsType st, Difficulty dc ) const
 		const SongID &id = i.first;
 		Song* pSong = id.ToSong();
 
-		CHECKPOINT_M( ssprintf("Profile::GetSongsActual: %p", pSong) );
+		CHECKPOINT_M( ssprintf("Profile::GetSongsActual: %p", static_cast<void *>(pSong)) );
 
 		// If the Song isn't loaded on the current machine, then we can't
 		// get radar values to compute dance points.
@@ -405,7 +405,7 @@ float Profile::GetSongsActual( StepsType st, Difficulty dc ) const
 		{
 			const StepsID &sid = j.first;
 			Steps* pSteps = sid.ToSteps( pSong, true );
-			CHECKPOINT_M( ssprintf("Profile::GetSongsActual: song %p, steps %p", pSong, pSteps) );
+			CHECKPOINT_M( ssprintf("Profile::GetSongsActual: song %p, steps %p", static_cast<void *>(pSong), static_cast<void *>(pSteps)) );
 
 			// If the Steps isn't loaded on the current machine, then we can't
 			// get radar values to compute dance points.
@@ -415,7 +415,7 @@ float Profile::GetSongsActual( StepsType st, Difficulty dc ) const
 			if( pSteps->m_StepsType != st )
 				continue;
 
-			CHECKPOINT_M( ssprintf("Profile::GetSongsActual: n %s = %p", sid.ToString().c_str(), pSteps) );
+			CHECKPOINT_M( ssprintf("Profile::GetSongsActual: n %s = %p", sid.ToString().c_str(), static_cast<void *>(pSteps)) );
 			if( pSteps->GetDifficulty() != dc )
 			{
 				continue;	// skip

--- a/src/RageFileBasic.cpp
+++ b/src/RageFileBasic.cpp
@@ -437,7 +437,7 @@ int RageFileObj::FillReadBuf()
 	 * the two is old data that we've read.  (Don't mangle that data; we can use it
 	 * for seeking backwards.) */
 	const int iBufAvail = BSIZE - (m_pReadBuf-m_pReadBuffer) - m_iReadBufAvail;
-	ASSERT_M( iBufAvail >= 0, ssprintf("%p, %p, %i", m_pReadBuf, m_pReadBuffer, (int) BSIZE ) );
+	ASSERT_M( iBufAvail >= 0, ssprintf("%p, %p, %i", static_cast<void *>(m_pReadBuf), static_cast<void *>(m_pReadBuffer), static_cast<int>(BSIZE) ) );
 	const int iSize = this->ReadInternal( m_pReadBuf+m_iReadBufAvail, iBufAvail );
 
 	if( iSize > 0 )

--- a/src/RageFileDriverZip.cpp
+++ b/src/RageFileDriverZip.cpp
@@ -61,8 +61,8 @@ bool RageFileDriverZip::Load( const RString &sPath )
 bool RageFileDriverZip::Load( RageFileBasic *pFile )
 {
 	ASSERT( m_pZip == nullptr ); /* don't load twice */
-	m_sPath = ssprintf("%p", pFile);
-	m_Mutex.SetName( ssprintf("RageFileDriverZip(%p)", pFile) );
+	m_sPath = ssprintf("%p", static_cast<void *>(pFile));
+	m_Mutex.SetName( ssprintf("RageFileDriverZip(%p)", static_cast<void *>(pFile)) );
 
 	m_pZip = pFile;
 

--- a/src/RageSound.cpp
+++ b/src/RageSound.cpp
@@ -267,7 +267,7 @@ int RageSound::GetDataToPlay( float *pBuffer, int iFrames, int64_t &iStreamFrame
 	/* We only update m_iStreamFrame; only take a shared lock, so we don't block the main thread. */
 //	LockMut(m_Mutex);
 
-	ASSERT_M( m_bPlaying, ssprintf("%p", this) );
+	ASSERT_M( m_bPlaying, ssprintf("%p", static_cast<void *>(this)) );
 	ASSERT( m_pSource != nullptr );
 
 	iFramesStored = 0;
@@ -333,7 +333,7 @@ void RageSound::StartPlaying()
 			GetLoadedFilePath().c_str(), m_Param.m_StartTime.Ago() );
 
 	/* Tell the sound manager to start mixing us. */
-//	LOG->Trace("set playing true for %p (StartPlaying) (%s)", this, this->GetLoadedFilePath().c_str());
+//	LOG->Trace("set playing true for %p (StartPlaying) (%s)", static_cast<void *>(this), this->GetLoadedFilePath().c_str());
 
 	m_bPlaying = true;
 
@@ -347,7 +347,7 @@ void RageSound::StartPlaying()
 
 	SOUNDMAN->StartMixing( this );
 
-//	LOG->Trace("StartPlaying %p finished (%s)", this, this->GetLoadedFilePath().c_str());
+//	LOG->Trace("StartPlaying %p finished (%s)", static_cast<void *>(this), this->GetLoadedFilePath().c_str());
 }
 
 void RageSound::StopPlaying()
@@ -383,13 +383,13 @@ void RageSound::SoundIsFinishedPlaying()
 	if( !m_HardwareToStreamMap.IsEmpty() && !m_StreamToSourceMap.IsEmpty() )
 		m_iStoppedSourceFrame = (int) GetSourceFrameFromHardwareFrame( iCurrentHardwareFrame );
 
-//	LOG->Trace("set playing false for %p (SoundIsFinishedPlaying) (%s)", this, this->GetLoadedFilePath().c_str());
+//	LOG->Trace("set playing false for %p (SoundIsFinishedPlaying) (%s)", static_cast<void *>(this), this->GetLoadedFilePath().c_str());
 	m_bPlaying = false;
 
 	m_HardwareToStreamMap.Clear();
 	m_StreamToSourceMap.Clear();
 
-//	LOG->Trace("SoundIsFinishedPlaying %p finished (%s)", this, this->GetLoadedFilePath().c_str());
+//	LOG->Trace("SoundIsFinishedPlaying %p finished (%s)", static_cast<void *>(this), this->GetLoadedFilePath().c_str());
 
 	m_Mutex.Unlock();
 }

--- a/src/RageSurface_Load_PNG.cpp
+++ b/src/RageSurface_Load_PNG.cpp
@@ -229,7 +229,7 @@ static RageSurface *RageSurface_Load_PNG( RageFile *f, const char *fn, char erro
 
 	/* alloca to prevent memleaks if libpng longjmps us */
 	png_byte **row_pointers = (png_byte **) alloca( sizeof(png_byte*) * height );
-	CHECKPOINT_M( ssprintf("%p",row_pointers) );
+	CHECKPOINT_M( ssprintf("%p", static_cast<void *>(row_pointers) ) );
 
 	for( unsigned y = 0; y < height; ++y )
 	{

--- a/src/RageUtil_BackgroundLoader.cpp
+++ b/src/RageUtil_BackgroundLoader.cpp
@@ -24,7 +24,7 @@ BackgroundLoader::BackgroundLoader():
 	if( !g_bEnableBackgroundLoading )
 		return;
 
-	m_sCachePathPrefix = ssprintf( "@mem/%p", this );
+	m_sCachePathPrefix = ssprintf( "@mem/%p", static_cast<void *>(this) );
 
 	m_bShutdownThread = false;
 	m_sThreadIsActive = m_sThreadShouldAbort = false;

--- a/src/SongManager.cpp
+++ b/src/SongManager.cpp
@@ -1272,7 +1272,7 @@ void SongManager::GetExtraStageInfo( bool bExtra2, const Style *sd, Song*& pSong
 	}
 
 	ASSERT_M( sGroup != "", ssprintf("%p '%s' '%s'",
-		GAMESTATE->m_pCurSong.Get(),
+		static_cast<void *>(GAMESTATE->m_pCurSong.Get()),
 		GAMESTATE->m_pCurSong? GAMESTATE->m_pCurSong->GetSongDir().c_str():"",
 		GAMESTATE->m_pCurSong? GAMESTATE->m_pCurSong->m_sGroupName.c_str():"") );
 

--- a/src/arch/InputHandler/InputHandler_MacOSX_HID.cpp
+++ b/src/arch/InputHandler/InputHandler_MacOSX_HID.cpp
@@ -36,7 +36,7 @@ void InputHandler_MacOSX_HID::QueueCallback( void *target, int result, void *ref
 			free( event.longValue );
 			continue;
 		}
-		//LOG->Trace( "Got event with cookie %p, value %d", event.elementCookie, int(event.value) );
+		//LOG->Trace( "Got event with cookie %p, value %d", static_cast<void *>(event.elementCookie), int(event.value) );
 		dev->GetButtonPresses( vPresses, event.elementCookie, event.value, now );
 	}
 	for (auto &i: vPresses)

--- a/src/arch/Sound/RageSoundDriver_Generic_Software.cpp
+++ b/src/arch/Sound/RageSoundDriver_Generic_Software.cpp
@@ -70,7 +70,7 @@ RageSoundMixBuffer &RageSoundDriver::MixIntoBuffer( int iFrames, int64_t iFrameN
 			s.m_bPaused = false;
 			s.m_State = Sound::STOPPED;
 
-//			LOG->Trace("set %p from HALTING to STOPPED", m_Sounds[i].m_pSound);
+//			LOG->Trace("set %p from HALTING to STOPPED", static_cast<void *>(m_Sounds[i].m_pSound));
 			continue;
 		}
 
@@ -144,7 +144,7 @@ RageSoundMixBuffer &RageSoundDriver::MixIntoBuffer( int iFrames, int64_t iFrameN
 			p[0]->m_iPosition += frames_to_read;
 
 //			LOG->Trace( "incr fr rd += %i (state %i) (%p)",
-//				(int) frames_to_read, s.m_State, s.m_pSound );
+//				static_cast<int>(frames_to_read), s.m_State, static_cast<void *>(s.m_pSound) );
 
 			iGotFrames += frames_to_read;
 			iFramesLeft -= frames_to_read;
@@ -239,7 +239,7 @@ int RageSoundDriver::GetDataForSound( Sound &s )
 	}
 
 //	LOG->Trace( "incr fr wr %i (state %i) (%p)",
-//		(int) pBlock->m_FramesInBuffer, s.m_State, s.m_pSound );
+//		static_cast<int>(pBlock->m_FramesInBuffer), s.m_State, static_cast<void *>(s.m_pSound) );
 
 	return iRet;
 }
@@ -337,12 +337,12 @@ void RageSoundDriver::StartMixing( RageSoundBase *pSound )
 
 	s.Allocate( BufferSize );
 
-//	LOG->Trace("StartMixing(%s) (%p)", s.m_pSound->GetLoadedFilePath().c_str(), s.m_pSound );
+//	LOG->Trace("StartMixing(%s) (%p)", s.m_pSound->GetLoadedFilePath().c_str(), static_cast<void *>(s.m_pSound) );
 
 	/* Prebuffer some frames before changing the sound to PLAYING. */
 	while( s.m_Buffer.num_writable() )
 	{
-//		LOG->Trace("StartMixing: (#%i) buffering %i (%i writable) (%p)", i, (int) frames_to_buffer, s.buffer.num_writable(), s.m_pSound );
+//		LOG->Trace("StartMixing: (#%i) buffering %i (%i writable) (%p)", i, static_cast<int>(frames_to_buffer), s.buffer.num_writable(), static_cast<void *>(s.m_pSound) );
 		int iWrote = GetDataForSound( s );
 		if( iWrote < 0 )
 			break;
@@ -350,7 +350,7 @@ void RageSoundDriver::StartMixing( RageSoundBase *pSound )
 
 	s.m_State = Sound::PLAYING;
 
-//	LOG->Trace("StartMixing: (#%i) finished prebuffering(%s) (%p)", i, s.m_pSound->GetLoadedFilePath().c_str(), s.m_pSound );
+//	LOG->Trace("StartMixing: (#%i) finished prebuffering(%s) (%p)", i, s.m_pSound->GetLoadedFilePath().c_str(), static_cast<void *>(s.m_pSound) );
 }
 
 void RageSoundDriver::StopMixing( RageSoundBase *pSound )
@@ -378,7 +378,7 @@ void RageSoundDriver::StopMixing( RageSoundBase *pSound )
 		return;
 	}
 
-//	LOG->Trace("StopMixing: set %p (%s) to HALTING", m_Sounds[i].m_pSound, m_Sounds[i].m_pSound->GetLoadedFilePath().c_str());
+//	LOG->Trace("StopMixing: set %p (%s) to HALTING", static_cast<void *>(m_Sounds[i].m_pSound), m_Sounds[i].m_pSound->GetLoadedFilePath().c_str());
 
 	/* Tell the mixing thread to flush the buffer.  We don't have to worry about
 	 * the decoding thread, since we've locked m_Mutex. */

--- a/src/archutils/Darwin/HIDDevice.h
+++ b/src/archutils/Darwin/HIDDevice.h
@@ -83,7 +83,7 @@ protected:
 	{
 		IOReturn ret = CALL( m_Queue, addElement, cookie, 0 );
 		if( ret != KERN_SUCCESS )
-			LOG->Warn( "Failed to add HID element with cookie %p to queue: %u", cookie, ret );
+			LOG->Warn( "Failed to add HID element with cookie %p to queue: %u", static_cast<void *>(cookie), ret );
 	}
 
 	// Perform a synchronous set report on the HID interface.

--- a/src/archutils/Darwin/KeyboardDevice.cpp
+++ b/src/archutils/Darwin/KeyboardDevice.cpp
@@ -160,10 +160,10 @@ void KeyboardDevice::AddElement( int usagePage, int usage, IOHIDElementCookie co
 
 void KeyboardDevice::Open()
 {
-	for( auto i = m_Mapping.cbegin(); i != m_Mapping.cend(); ++i )
+	for (auto &mapping : m_Mapping)
 	{
-		//LOG->Trace( "Adding %s to queue, cookie %p", DeviceButtonToString(i->second).c_str(), i->first );
-		AddElementToQueue( i->first );
+		//LOG->Trace( "Adding %s to queue, cookie %p", DeviceButtonToString(i->second).c_str(), static_cast<void *>(mapping.first) );
+		AddElementToQueue(mapping.first);
 	}
 }
 

--- a/src/archutils/Win32/GraphicsWindow.cpp
+++ b/src/archutils/Win32/GraphicsWindow.cpp
@@ -53,7 +53,7 @@ static RString GetNewWindow()
 
 static LRESULT CALLBACK GraphicsWindow_WndProc( HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam )
 {
-	CHECKPOINT_M( ssprintf("%p, %u, %08x, %08x", hWnd, msg, wParam, lParam) );
+	CHECKPOINT_M( ssprintf("%p, %u, %08x, %08x", static_cast<void *>(hWnd), msg, wParam, lParam) );
 
 	// Suppress autorun.
 	if( msg == g_iQueryCancelAutoPlayMessage )
@@ -178,7 +178,7 @@ static LRESULT CALLBACK GraphicsWindow_WndProc( HWND hWnd, UINT msg, WPARAM wPar
 		}
 	}
 
-	CHECKPOINT_M( ssprintf("%p, %u, %08x, %08x", hWnd, msg, wParam, lParam) );
+	CHECKPOINT_M( ssprintf("%p, %u, %08x, %08x", static_cast<void *>(hWnd), msg, wParam, lParam) );
 
 	if( m_bWideWindowClass )
 		return DefWindowProcW( hWnd, msg, wParam, lParam );

--- a/src/archutils/Win32/RegistryAccess.cpp
+++ b/src/archutils/Win32/RegistryAccess.cpp
@@ -134,7 +134,7 @@ bool RegistryAccess::GetRegSubKeys( const RString &sKey, vector<RString> &lst, c
 
 		if( iRet != ERROR_SUCCESS )
 		{
-			LOG->Warn( werr_ssprintf(iRet, "GetRegSubKeys(%p,%i) error", hKey, index) );
+			LOG->Warn( werr_ssprintf(iRet, "GetRegSubKeys(%p,%i) error", static_cast<void *>(hKey), index) );
 			bError = true;
 			break;
 		}

--- a/src/archutils/Win32/USB.cpp
+++ b/src/archutils/Win32/USB.cpp
@@ -159,6 +159,7 @@ void WindowsFileIO::queue_read()
 
 int WindowsFileIO::finish_read( void *p )
 {
+	LOG->Trace("this is %p, p is %p", static_cast<void *>(this), static_cast<void *>(p));
 	/* We do; get the result.  It'll go into the original m_pBuffer
 	 * we supplied on the original call; that's why m_pBuffer is a
 	 * member instead of a local. */


### PR DESCRIPTION
This will help with `fmt::sprintf` and `fmt::format`.