### PR TITLE
Make sure kb7 is the appropiate steps type.

### DIFF
--- a/src/NotesLoaderBMS.cpp
+++ b/src/NotesLoaderBMS.cpp
@@ -962,8 +962,56 @@ StepsType BMSChartReader::DetermineStepsType()
 					// type, since they are more common.
 					//return StepsType_dance_solo;
 					return StepsType_beat_single5;
-				// az: Allow kb7 style charts
-				case 7:		return StepsType_kb7_single;
+					// az: Allow kb7 style charts
+				case 7:
+				{
+					// az (for nixtrix): kb7 layouts do not leave any gaps using either of these layouts.
+					// if we find a compatible layout that doesn't have gaps, we've stumbled upon a real
+					// kb7 file.
+					BmsRawChannel layoutA[] = {
+						BMS_RAW_P1_TURN,
+						BMS_RAW_P1_KEY1,
+						BMS_RAW_P1_KEY2,
+						BMS_RAW_P1_KEY3,
+						BMS_RAW_P1_KEY4,
+						BMS_RAW_P1_KEY5,
+						BMS_RAW_P1_KEY6,
+					};
+
+					BmsRawChannel layoutB[] = {
+						BMS_RAW_P1_KEY1,
+						BMS_RAW_P1_KEY2,
+						BMS_RAW_P1_KEY3,
+						BMS_RAW_P1_KEY4,
+						BMS_RAW_P1_KEY5,
+						BMS_RAW_P1_KEY6,
+						BMS_RAW_P1_KEY7,
+					};
+
+					int gaps = 0;
+					for (int i = 0; i < 7; i++)
+					{
+						if (nonEmptyTracks.find(layoutA[i]) == nonEmptyTracks.end())
+							gaps++;
+					}
+
+					if (gaps == 0) // kb7 file is a layout A file
+						return StepsType_kb7_single;
+
+					gaps = 0;
+					for (int i = 0; i < 7; i++)
+					{
+						if (nonEmptyTracks.find(layoutB[i]) == nonEmptyTracks.end())
+							gaps++;
+					}
+
+					if (gaps == 0) // kb7 file is a layout B file
+						return StepsType_kb7_single;
+
+					// neither huh, then it's a beatmania file that for some reason
+					// um, chose to not fill in a lane.
+					return StepsType_beat_single7;
+				}
 				case 8:		return StepsType_beat_single7;
 				case 9:		return StepsType_popn_nine;
 				// XXX: Some double files doesn't have #player.


### PR DESCRIPTION
As before, merely checking that a chart has 7 keys non-empty does not mean it's an actual kb7 file, as it may have a gap for whatever reason.
This PR adds checks on whether it uses all 7 channels on the only valid kb7 bms layouts before actually stating "Yes, this is a kb7 file", giving beat-single7 priority if not.