### PR TITLE
[Windows] Build using platform toolset "v140_xp" on AppVeyor.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -35,7 +35,7 @@ before_build:
 - cmd: >-
     cd Build
 
-    cmake -G "Visual Studio 14 2015" -DWITH_IRC_POST_HOOK=ON ..
+    cmake -G "Visual Studio 14 2015" -T "v140_xp" -DWITH_IRC_POST_HOOK=ON ..
 build:
   project: C:\Repos\wolfmania\Build\StepMania.sln
   verbosity: normal

--- a/Build/README.md
+++ b/Build/README.md
@@ -51,6 +51,8 @@ For the first setup, you will want to run this command:
 
 Replace {YourGeneratorHere} with one of the generator choices from `cmake --help`. As an example, Mac OS X users that want to have Xcode used would run `cmake -G Xcode .. && cmake ..` on their Terminal program.
 
+If you are building on Windows and expecting your final executable to be able to run on Windows XP, append an additional parameter `-T "v140_xp"` (or `-T "v120_xp"`, depending on which version of Visual Studio you have installed) to your command line.
+
 If any cmake project file changes, you can just run `cmake .. && cmake ..` to get up to date.
 If this by itself doesn't work, you may have to clean the cmake cache.
 Use `rm -rf CMakeCache.txt CMakeScripts/ CMakeFiles/ cmake_install.txt` to do that, and then run the generator command again as specified above.


### PR DESCRIPTION
With no NT6-specific functions implemented, Windows XP can still be supported.
Hopefully 5.0.10 and 5.1.0 Alpha installers can be updated to support Windows XP.