### PR TITLE
Restore VS2013 compilation.

### DIFF
--- a/src/AdjustSync.cpp
+++ b/src/AdjustSync.cpp
@@ -47,7 +47,7 @@ using std::vector;
 vector<TimingData> AdjustSync::s_vpTimingDataOriginal;
 float AdjustSync::s_fGlobalOffsetSecondsOriginal = 0.0f;
 int AdjustSync::s_iAutosyncOffsetSample = 0;
-int constexpr AdjustSync::OFFSET_SAMPLE_COUNT;
+int CONSTEXPR_VARIABLE AdjustSync::OFFSET_SAMPLE_COUNT;
 float AdjustSync::s_fAutosyncOffset[AdjustSync::OFFSET_SAMPLE_COUNT];
 float AdjustSync::s_fStandardDeviation = 0.0f;
 vector< std::pair<float, float> > AdjustSync::s_vAutosyncTempoData;

--- a/src/AdjustSync.h
+++ b/src/AdjustSync.h
@@ -39,7 +39,7 @@ public:
 	static void GetSyncChangeTextSong( std::vector<RString> &vsAddTo );
 
 	/** @brief The minimum number of steps to hit for syncing purposes. */
-	static int constexpr OFFSET_SAMPLE_COUNT = 24;
+	static int CONSTEXPR_VARIABLE OFFSET_SAMPLE_COUNT = 24;
 
 	static float s_fAutosyncOffset[OFFSET_SAMPLE_COUNT];
 	static int s_iAutosyncOffsetSample;

--- a/src/CMakeProject-rage.cmake
+++ b/src/CMakeProject-rage.cmake
@@ -14,6 +14,7 @@ list(APPEND RAGE_SRC
 
 list(APPEND RAGE_HPP
   "${SM_SRC_DIR}/rage/RageColor.hpp"
+  "${SM_SRC_DIR}/rage/RageConfig.hpp"
   "${SM_SRC_DIR}/rage/RageMath.hpp"
   "${SM_SRC_DIR}/rage/RageMatrix.hpp"
   "${SM_SRC_DIR}/rage/RageModelVertex.hpp"

--- a/src/ModValue.h
+++ b/src/ModValue.h
@@ -19,7 +19,7 @@ struct ModifiableValue;
 
 // invalid_modfunction_time exists so that the loading code can tell when a
 // start or end time was provided.
-static constexpr double invalid_modfunction_time= -1000.0;
+static CONSTEXPR_VARIABLE double invalid_modfunction_time= -1000.0;
 
 struct ModManager
 {

--- a/src/NoteDisplay.cpp
+++ b/src/NoteDisplay.cpp
@@ -17,8 +17,8 @@
 #include "LuaBinding.h"
 #include "RageMath.h"
 
-static double constexpr PI_180= Rage::PI / 180.0;
-static double constexpr PI_180R= 180.0 / Rage::PI;
+static double CONSTEXPR_VARIABLE PI_180= Rage::PI / 180.0;
+static double CONSTEXPR_VARIABLE PI_180R= 180.0 / Rage::PI;
 
 const RString& NoteNotePartToString( NotePart i );
 /** @brief A foreach loop going through the different NoteParts. */

--- a/src/config.in.hpp
+++ b/src/config.in.hpp
@@ -3,6 +3,9 @@
 
 /* Auto-generated config.h file powered by cmake. */
 
+/* Include necessary items from the rage project. */
+#include "RageConfig.hpp"
+
 /* Defined to 1 if <alloca.h> is found. */
 #cmakedefine HAVE_ALLOCA_H 1
 

--- a/src/rage/RageConfig.hpp
+++ b/src/rage/RageConfig.hpp
@@ -1,0 +1,16 @@
+#ifndef RAGE_CONFIG_HPP_
+#define RAGE_CONFIG_HPP_
+
+#if defined(_MSC_VER) && _MSC_VER <= 1800
+/** @brief A cross platform way of indicating a constant expression variable if the compiler was intelligent enough. */
+#define CONSTEXPR_VARIABLE const
+/** @brief A cross platform way of indicating a constant expression function if the compiler was intelligent enough. */
+#define CONSTEXPR_FUNCTION
+#else
+/** @brief A cross platform way of indiciating a constant expression variable. */
+#define CONSTEXPR_VARIABLE constexpr
+/** @brief A cross platform way of indicating a constant expression function. */
+#define CONSTEXPR_FUNCTION constexpr
+#endif
+
+#endif

--- a/src/rage/RageMath.hpp
+++ b/src/rage/RageMath.hpp
@@ -1,25 +1,26 @@
 #ifndef RAGE_MATH_HPP_
 #define RAGE_MATH_HPP_
 
+#include "RageConfig.hpp"
 #include <algorithm>
 
 namespace Rage
 {
 	/** @brief Have PI be defined cleanly. */
-	float constexpr PI = 3.141592653589793f;
-	double constexpr D_PI = 3.1415926535897932384626433832795;
-	double constexpr D_PI_REC = 1.0 / D_PI;
+	float CONSTEXPR_VARIABLE PI = 3.141592653589793f;
+	double CONSTEXPR_VARIABLE D_PI = 3.1415926535897932384626433832795;
+	double CONSTEXPR_VARIABLE D_PI_REC = 1.0 / D_PI;
 
 	/** @brief Convert from radians to degrees. */
 	template<typename T>
-	T constexpr RadiansToDegrees(T radians)
+	T CONSTEXPR_FUNCTION RadiansToDegrees(T radians)
 	{
 		return radians * (180.f / PI);
 	}
 
 	/** @brief Convert from degrees to radians. */
 	template<typename T>
-	T constexpr DegreesToRadians(T degrees)
+	T CONSTEXPR_FUNCTION DegreesToRadians(T degrees)
 	{
 		return degrees * (PI / 180.f);
 	}
@@ -32,14 +33,14 @@ namespace Rage
 
 	/** @brief Bring a value within range. */
 	template<typename T>
-	T constexpr clamp( T const & val, T const & low, T const & high )
+	T CONSTEXPR_FUNCTION clamp( T const & val, T const & low, T const & high )
 	{
 		return std::max(low, std::min(val, high));
 	}
 
 	/** @brief Interpolate within the ranges and interlopant. */
 	template<typename T, typename U>
-	U constexpr lerp( T x, U l, U h )
+	U CONSTEXPR_FUNCTION lerp( T x, U l, U h )
 	{
 		return static_cast<U>( (h - l) * x + l );
 	}
@@ -52,7 +53,7 @@ namespace Rage
 	 * One such example: scale(x, 0, 1, L, H); interpolate between L and H.
 	 */
 	template<typename T>
-	T constexpr scale(T x, T l1, T h1, T l2, T h2)
+	T CONSTEXPR_FUNCTION scale(T x, T l1, T h1, T l2, T h2)
 	{
 		return
 			( l1 == 0 && h1 == 1 ) ?

--- a/src/tests/RageMathTest.cpp
+++ b/src/tests/RageMathTest.cpp
@@ -53,7 +53,7 @@ GTEST_TEST(lerp, vectors_too)
 	Rage::Vector2 a { 0, 0 };
 	Rage::Vector2 b { 10, 20 };
 	
-	Rage::Vector2 actual = lerp(0.6, a, b);
+	Rage::Vector2 actual = lerp(0.6f, a, b);
 	EXPECT_EQ( (Rage::Vector2{6, 12}), actual);
 	
 }


### PR DESCRIPTION
Once SM6 hits, no more VS2013. Consider yourselves warned.