### PR TITLE
Move the split calls to Rage::split.

### DIFF
--- a/src/Attack.cpp
+++ b/src/Attack.cpp
@@ -86,9 +86,7 @@ RString Attack::GetTextDescription() const
 
 int Attack::GetNumAttacks() const
 {
-	vector<RString> tmp;
-	split(this->sModifiers, ",", tmp);
-	return tmp.size();
+	return Rage::split(this->sModifiers, ",").size();
 }
 
 bool AttackArray::ContainsTransformOrTurn() const

--- a/src/BitmapText.cpp
+++ b/src/BitmapText.cpp
@@ -482,7 +482,7 @@ void BitmapText::SetTextInternal()
 
 	if( m_iWrapWidthPixels == -1 )
 	{
-		split( RStringToWstring(m_sText), L"\n", m_wTextLines, false );
+		m_wTextLines = Rage::split( RStringToWstring(m_sText), L"\n", Rage::EmptyEntries::include );
 	}
 	else
 	{
@@ -493,18 +493,16 @@ void BitmapText::SetTextInternal()
 		/* "...I can add Japanese wrapping, at least. We could handle hyphens
 		 * and soft hyphens and pretty easily, too." -glenn */
 		// TODO: Move this wrapping logic into Font.
-		vector<RString> asLines;
-		split( m_sText, "\n", asLines, false );
+		auto lines = Rage::split(m_sText, "\n", Rage::EmptyEntries::include);
 		
-		for (auto &singleLine: asLines)
+		for (auto &singleLine: lines)
 		{
-			vector<RString> asWords;
-			split( singleLine, " ", asWords );
+			auto words = Rage::split(singleLine, " ");
 
 			RString sCurLine;
 			int iCurLineWidth = 0;
 
-			for (auto const &sWord: asWords)
+			for (auto const &sWord: words)
 			{
 				int iWidthWord = m_pFont->GetLineWidthInSourcePixels( RStringToWstring(sWord) );
 

--- a/src/Character.cpp
+++ b/src/Character.cpp
@@ -24,8 +24,7 @@ bool Character::Load( RString sCharDir )
 
 	// save ID
 	{
-		vector<RString> as;
-		split( sCharDir, "/", as );
+		auto as = Rage::split(sCharDir, "/");
 		m_sCharacterID = as.back();
 	}
 

--- a/src/CodeSet.cpp
+++ b/src/CodeSet.cpp
@@ -6,20 +6,18 @@
 
 using std::vector;
 
-#define CODE_NAMES		THEME->GetMetric (sType,"CodeNames")
 #define CODE( s )		THEME->GetMetric (sType,fmt::sprintf("Code%s",s.c_str()))
 void InputQueueCodeSet::Load( const RString &sType )
 {
-	//
-	// Load codes
-	//
-	split( CODE_NAMES, ",", m_asCodeNames, true );
+	// Load the codes here. There is no guarantee that m_asCodeNames is not empty,
+	// so make a temporary to move it.
+	auto toDump = Rage::split(THEME->GetMetric(sType, "CodeNames"), ",", Rage::EmptyEntries::skip);
+	m_asCodeNames.insert(m_asCodeNames.end(), std::make_move_iterator(toDump.begin()), std::make_move_iterator(toDump.end()));
 
 	for (auto &name: m_asCodeNames)
 	{
-		vector<RString> asBits;
-		split( name, "=", asBits, true );
-		RString sCodeName = asBits[0];
+		auto asBits = Rage::split(name, "=", Rage::EmptyEntries::skip);
+		auto sCodeName = asBits[0];
 		if( asBits.size() > 1 )
 		{
 			name = asBits[1];

--- a/src/CommandLineActions.h
+++ b/src/CommandLineActions.h
@@ -16,7 +16,7 @@ namespace CommandLineActions
 	{
 	public:
 		/** @brief the arguments in question. */
-		std::vector<RString> argv;
+		std::vector<std::string> argv;
 	};
 	/**
 	 * @brief A list of command line arguemnts to process while the game is running.

--- a/src/CommonMetrics.cpp
+++ b/src/CommonMetrics.cpp
@@ -37,8 +37,7 @@ void ThemeMetricDifficultiesToShow::Read()
 
 	m_v.clear();
 
-	vector<RString> v;
-	split( ThemeMetric<std::string>::GetValue(), ",", v );
+	auto v = Rage::split( ThemeMetric<std::string>::GetValue(), "," );
 	if(v.empty())
 	{
 		LuaHelpers::ReportScriptError("DifficultiesToShow must have at least one entry.");
@@ -76,8 +75,7 @@ void ThemeMetricCourseDifficultiesToShow::Read()
 
 	m_v.clear();
 
-	vector<RString> v;
-	split( ThemeMetric<std::string>::GetValue(), ",", v );
+	auto v = Rage::split( ThemeMetric<std::string>::GetValue(), "," );
 	if(v.empty())
 	{
 		LuaHelpers::ReportScriptError("CourseDifficultiesToShow must have at least one entry.");
@@ -101,8 +99,7 @@ const vector<CourseDifficulty>& ThemeMetricCourseDifficultiesToShow::GetValue() 
 
 static void RemoveStepsTypes( vector<StepsType>& inout, RString sStepsTypesToRemove )
 {
-	vector<RString> v;
-	split( sStepsTypesToRemove, ",", v );
+	auto v = Rage::split(sStepsTypesToRemove, ",");
 	if( v.size() == 0 ) return; // Nothing to do!
 
 	// subtract StepsTypes

--- a/src/Course.cpp
+++ b/src/Course.cpp
@@ -742,7 +742,7 @@ const Style *Course::GetCourseStyle( const Game *pGame, int iNumPlayers ) const
 
 	for (auto const *pStyle: vpStyles)
 	{
-		Rage::ci_ascii_string styleName{ pStyle->m_szName };
+		Rage::ci_ascii_string styleName{ pStyle->m_szName.c_str() };
 		for (auto const &style: m_setStyles)
 		{
 			if (styleName == style)
@@ -939,18 +939,14 @@ void Course::UpdateCourseStats( StepsType st )
 
 bool Course::IsRanking() const
 {
-	vector<RString> rankingsongs;
-
-	split(THEME->GetMetric("ScreenRanking", "CoursesToShow"), ",", rankingsongs);
+	auto rankingSongs = Rage::split(THEME->GetMetric("ScreenRanking", "CoursesToShow"), ",");
 	Rage::ci_ascii_string path{ m_sPath.c_str() };
-	for (unsigned i = 0; i < rankingsongs.size(); i++)
-	{
-		if (path == rankingsongs[i])
-		{
-			return true;
-		}
-	}
-	return false;
+
+	auto doesRank = [&path](std::string const &song) {
+		return path == song;
+	};
+
+	return std::any_of(rankingSongs.cbegin(), rankingSongs.cend(), doesRank);
 }
 
 const CourseEntry *Course::FindFixedSong( const Song *pSong ) const
@@ -1021,8 +1017,7 @@ bool Course::Matches( RString sGroup, RString sCourse ) const
 	if (!sFile.empty())
 	{
 		Rage::replace(sFile, '\\', '/');
-		vector<RString> bits;
-		split(sFile, "/", bits);
+		auto bits = Rage::split(sFile, "/");
 		const RString &sLastBit = bits[bits.size() - 1];
 		if (course == sLastBit)
 		{

--- a/src/CourseLoaderCRS.cpp
+++ b/src/CourseLoaderCRS.cpp
@@ -125,8 +125,7 @@ bool CourseLoaderCRS::LoadFromMsd( const RString &sPath, const MsdFile &msd, Cou
 			float end = -9999;
 			for( unsigned j = 1; j < sParams.params.size(); ++j )
 			{
-				vector<RString> sBits;
-				split( sParams[j], "=", sBits, false );
+				auto sBits = Rage::split(sParams[j], "=", Rage::EmptyEntries::include);
 				if( sBits.size() < 2 )
 				{
 					continue;
@@ -134,11 +133,17 @@ bool CourseLoaderCRS::LoadFromMsd( const RString &sPath, const MsdFile &msd, Cou
 
 				Rage::ci_ascii_string tagName{ Rage::trim(sBits[0]).c_str() };
 				if( tagName == "TIME" )
+				{
 					attack.fStartSecond = max( StringToFloat(sBits[1]), 0.0f );
+				}
 				else if( tagName == "LEN" )
+				{
 					attack.fSecsRemaining = StringToFloat( sBits[1] );
+				}
 				else if( tagName == "END" )
+				{
 					end = StringToFloat( sBits[1] );
+				}
 				else if( tagName == "MODS" )
 				{
 					attack.sModifiers = sBits[1];
@@ -233,8 +238,7 @@ bool CourseLoaderCRS::LoadFromMsd( const RString &sPath, const MsdFile &msd, Cou
 				//new_entry.bSecret = true;
 				RString sSong = sParams[1];
 				Rage::replace(sSong, '\\', '/' );
-				vector<RString> bits;
-				split( sSong, "/", bits );
+				auto bits = Rage::split(sSong, "/");
 				if( bits.size() == 2 )
 				{
 					new_entry.songCriteria.m_sGroupName = bits[0];
@@ -257,8 +261,7 @@ bool CourseLoaderCRS::LoadFromMsd( const RString &sPath, const MsdFile &msd, Cou
 			{
 				RString sSong = sParams[1];
 				Rage::replace(sSong, '\\', '/' );
-				vector<RString> bits;
-				split( sSong, "/", bits );
+				auto bits = Rage::split(sSong, "/");
 
 				Song *pSong = nullptr;
 				if( bits.size() == 2 )
@@ -356,8 +359,7 @@ bool CourseLoaderCRS::LoadFromMsd( const RString &sPath, const MsdFile &msd, Cou
 		else if(tagName == "STYLE" )
 		{
 			RString sStyles = sParams[1];
-			vector<RString> asStyles;
-			split( sStyles, ",", asStyles );
+			auto asStyles = Rage::split(sStyles, ",");
 			for (auto &s: asStyles)
 			{
 				out.m_setStyles.insert( s );
@@ -419,8 +421,7 @@ bool CourseLoaderCRS::LoadFromCRSFile( const RString &_sPath, Course &out )
 
 	// save group name
 	{
-		vector<RString> parts;
-		split( sPath, "/", parts, false );
+		auto parts = Rage::split(sPath, "/", Rage::EmptyEntries::include);
 		if( parts.size() >= 4 ) // e.g. "/Courses/blah/fun.crs"
 			out.m_sGroupName = parts[parts.size()-2];
 	}

--- a/src/CourseUtil.cpp
+++ b/src/CourseUtil.cpp
@@ -336,8 +336,7 @@ void CourseUtil::WarnOnInvalidMods( RString sMods )
 {
 	PlayerOptions po;
 	SongOptions so;
-	vector<RString> vs;
-	split( sMods, ",", vs, true );
+	auto vs = Rage::split( sMods, ",", Rage::EmptyEntries::skip );
 	for (auto &s: vs)
 	{
 		bool bValid = false;

--- a/src/Difficulty.cpp
+++ b/src/Difficulty.cpp
@@ -118,8 +118,7 @@ RString GetCustomDifficulty( StepsType st, Difficulty dc, CourseType ct )
 		return "Edit";
 	}
 	// OPTIMIZATION OPPORTUNITY: cache these metrics and cache the splitting
-	vector<RString> vsNames;
-	split( NAMES.GetValue(), ",", vsNames );
+	auto vsNames = Rage::split(NAMES.GetValue(), ",");
 	for (auto &sName: vsNames)
 	{
 		ThemeMetric<StepsType> STEPS_TYPE("CustomDifficulty",sName+"StepsType");

--- a/src/Font.cpp
+++ b/src/Font.cpp
@@ -808,14 +808,16 @@ void Font::Load( const RString &sIniPath, RString sChars )
 
 		// If this is a top-level font (not a subfont), load the default font first.
 		if( bIsTopLevelFont )
+		{
 			ImportList.push_back("Common default");
-
+		}
 		/* Check to see if we need to import any other fonts.  Do this
 		 * before loading this font, so any characters in this font
 		 * override imported characters. */
 		RString imports;
 		ini.GetValue( "main", "import", imports );
-		split(imports, ",", ImportList, true);
+		auto toDump = Rage::split(imports, ",", Rage::EmptyEntries::skip);
+		ImportList.insert(ImportList.end(), std::make_move_iterator(toDump.begin()), std::make_move_iterator(toDump.end()));
 
 		if( bIsTopLevelFont  &&  imports.empty()  &&  asTexturePaths.empty() )
 		{

--- a/src/GameState.cpp
+++ b/src/GameState.cpp
@@ -3108,7 +3108,7 @@ public:
 			}
 		}
 		luaL_error( L, "Style %s is incompatible with PlayMode %s",
-			style->m_szName, PlayModeToString( pm ).c_str() );
+			style->m_szName.c_str(), PlayModeToString( pm ).c_str() );
 		return false;
 	}
 
@@ -3149,12 +3149,12 @@ public:
 		if( p->GetNumSidesJoined() == 2 &&
 			( st == StyleType_OnePlayerOneSide || st == StyleType_OnePlayerTwoSides ) )
 		{
-			luaL_error( L, "Too many sides joined for style %s", pStyle->m_szName );
+			luaL_error( L, "Too many sides joined for style %s", pStyle->m_szName.c_str() );
 		}
 		else if( p->GetNumSidesJoined() == 1 &&
 			( st == StyleType_TwoPlayersTwoSides || st == StyleType_TwoPlayersSharedSides ) )
 		{
-			luaL_error( L, "Too few sides joined for style %s", pStyle->m_szName );
+			luaL_error( L, "Too few sides joined for style %s", pStyle->m_szName.c_str() );
 		}
 
 		if( !AreStyleAndPlayModeCompatible( p, L, pStyle, p->m_PlayMode ) )

--- a/src/HelpDisplay.cpp
+++ b/src/HelpDisplay.cpp
@@ -23,7 +23,7 @@ void HelpDisplay::Load( const RString &sType )
 	m_fSecsBetweenSwitches = THEME->GetMetricF(sType,"TipSwitchTime");
 }
 
-void HelpDisplay::SetTips( const vector<RString> &arrayTips, const vector<RString> &arrayTipsAlt )
+void HelpDisplay::SetTips( vector<std::string> const &arrayTips, vector<std::string> const &arrayTipsAlt )
 {
 	ASSERT( arrayTips.size() == arrayTipsAlt.size() );
 
@@ -74,7 +74,7 @@ public:
 	{
 		luaL_checktype( L, 1, LUA_TTABLE );
 		lua_pushvalue( L, 1 );
-		vector<RString> arrayTips;
+		vector<std::string> arrayTips;
 		LuaHelpers::ReadArrayFromTable( arrayTips, L );
 		lua_pop( L, 1 );
 		for (auto &tip: arrayTips)
@@ -83,7 +83,7 @@ public:
 		}
 		if( lua_gettop(L) > 1 && !lua_isnil( L, 2 ) )
 		{
-			vector<RString> arrayTipsAlt;
+			vector<std::string> arrayTipsAlt;
 			luaL_checktype( L, 2, LUA_TTABLE );
 			lua_pushvalue( L, 2 );
 			LuaHelpers::ReadArrayFromTable( arrayTipsAlt, L );
@@ -101,15 +101,14 @@ public:
 	}
 	static int SetTipsColonSeparated( T* p, lua_State *L )
 	{
-		vector<RString> vs;
-		split( SArg(1), "::", vs );
+		auto vs = Rage::split(luaL_checkstring(L,1), "::");
 		p->SetTips( vs );
 		COMMON_RETURN_SELF;
 	}
 
 	static int gettips( T* p, lua_State *L )
 	{
-		vector<RString> arrayTips, arrayTipsAlt;
+		vector<std::string> arrayTips, arrayTipsAlt;
 		p->GetTips( arrayTips, arrayTipsAlt );
 
 		LuaHelpers::CreateTableFromArray( arrayTips, L );

--- a/src/HelpDisplay.h
+++ b/src/HelpDisplay.h
@@ -13,9 +13,13 @@ public:
 
 	virtual HelpDisplay *Copy() const;
 
-	void SetTips( const std::vector<RString> &arrayTips ) { SetTips( arrayTips, arrayTips ); }
-	void SetTips( const std::vector<RString> &arrayTips, const std::vector<RString> &arrayTipsAlt );
-	void GetTips( std::vector<RString> &arrayTipsOut, std::vector<RString> &arrayTipsAltOut ) const { arrayTipsOut = m_arrayTips; arrayTipsAltOut = m_arrayTipsAlt; }
+	void SetTips( std::vector<std::string> const &arrayTips ) { SetTips( arrayTips, arrayTips ); }
+	void SetTips( std::vector<std::string> const &arrayTips, std::vector<std::string> const &arrayTipsAlt );
+	void GetTips( std::vector<std::string> &arrayTipsOut, std::vector<std::string> &arrayTipsAltOut ) const
+	{
+		arrayTipsOut = m_arrayTips;
+		arrayTipsAltOut = m_arrayTipsAlt;
+	}
 	void SetSecsBetweenSwitches( float fSeconds ) { m_fSecsBetweenSwitches = m_fSecsUntilSwitch = fSeconds; }
 
 	virtual void Update( float fDeltaTime );
@@ -24,7 +28,7 @@ public:
 	virtual void PushSelf( lua_State *L );
 
 protected:
-	std::vector<RString> m_arrayTips, m_arrayTipsAlt;
+	std::vector<std::string> m_arrayTips, m_arrayTipsAlt;
 	int m_iCurTipIndex;
 
 	float m_fSecsBetweenSwitches;

--- a/src/InputQueue.cpp
+++ b/src/InputQueue.cpp
@@ -169,14 +169,10 @@ bool InputQueueCode::Load( RString sButtonsNames )
 {
 	m_aPresses.clear();
 
-	vector<RString> asPresses;
-	split( sButtonsNames, ",", asPresses, false );
+	auto asPresses = Rage::split( sButtonsNames, ",", Rage::EmptyEntries::include );
 	for (auto &sPress: asPresses)
 	{
-		vector<RString> asButtonNames;
-
-		split( sPress, "-", asButtonNames, false );
-
+		auto asButtonNames = Rage::split(sPress, "-", Rage::EmptyEntries::include);
 		if( asButtonNames.size() < 1 )
 		{
 			if( sButtonsNames != "" )

--- a/src/LightsManager.cpp
+++ b/src/LightsManager.cpp
@@ -54,8 +54,7 @@ static void GetUsedGameInputs( vector<GameInput> &vGameInputsOut )
 {
 	vGameInputsOut.clear();
 
-	vector<RString> asGameButtons;
-	split( GAME_BUTTONS_TO_SHOW.GetValue(), ",", asGameButtons );
+	auto asGameButtons = Rage::split(GAME_BUTTONS_TO_SHOW, ",");
 	FOREACH_ENUM( GameController,  gc )
 	{
 		for (auto const &button: asGameButtons)

--- a/src/ModIcon.cpp
+++ b/src/ModIcon.cpp
@@ -45,8 +45,7 @@ void ModIcon::Load( RString sMetricsGroup )
 
 	// stop words
 	STOP_WORDS.Load( sMetricsGroup, "StopWords" );
-	m_vStopWords.empty();
-	split(STOP_WORDS.GetValue(), ",", m_vStopWords);
+	m_vStopWords = Rage::split(STOP_WORDS.GetValue(), ",");
 
 	Set("");
 }

--- a/src/ModIcon.h
+++ b/src/ModIcon.h
@@ -22,7 +22,7 @@ protected:
 
 	ThemeMetric<int> CROP_TEXT_TO_WIDTH;
 	ThemeMetric<std::string> STOP_WORDS;
-	std::vector<RString> m_vStopWords;
+	std::vector<std::string> m_vStopWords;
 };
 
 #endif

--- a/src/ModIconRow.cpp
+++ b/src/ModIconRow.cpp
@@ -154,8 +154,7 @@ void ModIconRow::SetFromGameState()
 	PlayerNumber pn = m_pn;
 
 	RString sOptions = GAMESTATE->m_pPlayerState[pn]->m_PlayerOptions.GetStage().GetString();
-	vector<RString> vsOptions;
-	split( sOptions, ", ", vsOptions, true );
+	auto vsOptions = Rage::split(sOptions, ", ", Rage::EmptyEntries::skip);
 
 	vector<RString> vsText;	// fill these with what will be displayed on the tabs
 	vsText.resize( m_vpModIcon.size() );
@@ -164,7 +163,7 @@ void ModIconRow::SetFromGameState()
 	for (auto sOption: vsOptions)
 	{
 		int iPerferredCol = OptionToPreferredColumn( sOption );
-		Rage::clamp( iPerferredCol, 0, (int)m_vpModIcon.size()-1 );
+		Rage::clamp( iPerferredCol, 0, static_cast<int>(m_vpModIcon.size()) - 1 );
 
 		if( iPerferredCol == -1 )
 			continue;	// skip

--- a/src/MusicWheel.cpp
+++ b/src/MusicWheel.cpp
@@ -32,9 +32,9 @@ static Preference<bool> g_bPrecacheAllSorts( "PreCacheAllWheelSorts", false);
 #define CUSTOM_ITEM_WHEEL_TEXT(s)		THEME->GetString( "MusicWheel", fmt::sprintf("CustomItem%sText",s.c_str()) );
 
 static std::string SECTION_COLORS_NAME( size_t i )	{ return fmt::sprintf("SectionColor%d",int(i+1)); }
-static std::string CHOICE_NAME( RString s )		{ return fmt::sprintf("Choice%s",s.c_str()); }
-static std::string CUSTOM_WHEEL_ITEM_NAME( RString s )		{ return fmt::sprintf("CustomWheelItem%s",s.c_str()); }
-static std::string CUSTOM_WHEEL_ITEM_COLOR( RString s )		{ return fmt::sprintf("%sColor",s.c_str()); }
+static std::string CHOICE_NAME( std::string s )		{ return fmt::sprintf("Choice%s",s.c_str()); }
+static std::string CUSTOM_WHEEL_ITEM_NAME( std::string s )		{ return fmt::sprintf("CustomWheelItem%s",s.c_str()); }
+static std::string CUSTOM_WHEEL_ITEM_COLOR( std::string s )		{ return fmt::sprintf("%sColor",s.c_str()); }
 
 static LocalizedString EMPTY_STRING	( "MusicWheel", "Empty" );
 
@@ -90,14 +90,12 @@ void MusicWheel::Load( RString sType )
 	HIDE_INACTIVE_SECTIONS		.Load(sType,"OnlyShowActiveSection");
 	HIDE_ACTIVE_SECTION_TITLE		.Load(sType,"HideActiveSectionTitle");
 	REMIND_WHEEL_POSITIONS		.Load(sType,"RemindWheelPositions");
-	vector<RString> vsModeChoiceNames;
-	split( MODE_MENU_CHOICE_NAMES.GetValue(), ",", vsModeChoiceNames );
+  auto vsModeChoiceNames = Rage::split(MODE_MENU_CHOICE_NAMES.GetValue(), ",");
 	CHOICE				.Load(sType,CHOICE_NAME,vsModeChoiceNames);
 	SECTION_COLORS			.Load(sType,SECTION_COLORS_NAME,NUM_SECTION_COLORS);
 
 	CUSTOM_WHEEL_ITEM_NAMES		.Load(sType,"CustomWheelItemNames");
-	vector<RString> vsCustomItemNames;
-	split( CUSTOM_WHEEL_ITEM_NAMES.GetValue(), ",", vsCustomItemNames );
+  auto vsCustomItemNames = Rage::split(CUSTOM_WHEEL_ITEM_NAMES.GetValue(), ",");
 	CUSTOM_CHOICES.Load(sType,CUSTOM_WHEEL_ITEM_NAME,vsCustomItemNames);
 	CUSTOM_CHOICE_COLORS.Load(sType,CUSTOM_WHEEL_ITEM_COLOR,vsCustomItemNames);
 
@@ -516,8 +514,7 @@ void MusicWheel::BuildWheelItemDatas( vector<MusicWheelItemData *> &arrayWheelIt
 		case SORT_MODE_MENU:
 		{
 			arrayWheelItemDatas.clear();	// clear out the previous wheel items
-			vector<RString> vsNames;
-			split( MODE_MENU_CHOICE_NAMES.GetValue(), ",", vsNames );
+			auto vsNames = Rage::split(MODE_MENU_CHOICE_NAMES.GetValue(), ",");
 			for( unsigned i=0; i<vsNames.size(); ++i )
 			{
 				MusicWheelItemData wid( WheelItemDataType_Sort, nullptr, "", nullptr, SORT_MENU_COLOR, 0 );
@@ -722,8 +719,7 @@ void MusicWheel::BuildWheelItemDatas( vector<MusicWheelItemData *> &arrayWheelIt
 					arrayWheelItemDatas.push_back( new MusicWheelItemData(WheelItemDataType_Portal, nullptr, "", nullptr, PORTAL_COLOR, 0) );
 
 				// add custom wheel items
-				vector<RString> vsNames;
-				split( CUSTOM_WHEEL_ITEM_NAMES.GetValue(), ",", vsNames );
+				auto vsNames = Rage::split(CUSTOM_WHEEL_ITEM_NAMES.GetValue(), ",");
 				for( unsigned i=0; i<vsNames.size(); ++i )
 				{
 					MusicWheelItemData wid( WheelItemDataType_Custom, nullptr, "", nullptr, CUSTOM_CHOICE_COLORS.GetValue(vsNames[i]), 0 );
@@ -733,8 +729,9 @@ void MusicWheel::BuildWheelItemDatas( vector<MusicWheelItemData *> &arrayWheelIt
 					wid.m_sLabel = CUSTOM_ITEM_WHEEL_TEXT( vsNames[i] );
 
 					if( !wid.m_pAction->IsPlayable() )
+					{
 						continue;
-
+					}
 					arrayWheelItemDatas.push_back( new MusicWheelItemData(wid) );
 				}
 			}

--- a/src/NewSkin.cpp
+++ b/src/NewSkin.cpp
@@ -774,8 +774,7 @@ bool NewSkinLoader::load_from_file(std::string const& path)
 		LUA->Release(L);
 		return false;
 	}
-	vector<RString> path_parts;
-	split(path, "/", path_parts);
+	auto path_parts = Rage::split(path, "/");
 	size_t name_index= 0;
 	if(path_parts.size() > 1)
 	{

--- a/src/NoteDataUtil.cpp
+++ b/src/NoteDataUtil.cpp
@@ -71,7 +71,7 @@ static void LoadFromSMNoteDataStringWithPlayer( NoteData& out, const RString &sS
 		/* XXX Ignoring empty seems wrong for measures. It means that ",,," is treated as
 		 * "," where I would expect most people would want 2 empty measures. ",\n,\n,"
 		 * would do as I would expect. */
-		split( sSMNoteData, ",", start, size, end, true ); // Ignore empty is important.
+		Rage::split_in_place( sSMNoteData, ",", start, size, end, Rage::EmptyEntries::skip ); // Ignore empty is important.
 		if( start == end )
 			break;
 
@@ -83,7 +83,7 @@ static void LoadFromSMNoteDataStringWithPlayer( NoteData& out, const RString &sS
 		while( true )
 		{
 			// Ignore empty is clearly important here.
-			split( sSMNoteData, "\n", measureLineStart, measureLineSize, measureEnd, true );
+			Rage::split_in_place( sSMNoteData, "\n", measureLineStart, measureLineSize, measureEnd, Rage::EmptyEntries::skip );
 			if( measureLineStart == measureEnd )
 				break;
 			//RString &line = sSMNoteData.substr( measureLineStart, measureLineSize );
@@ -304,8 +304,7 @@ void NoteDataUtil::LoadFromSMNoteDataString( NoteData &out, const RString &sSMNo
 	vector<NoteData> vParts;
 	FOREACH_PlayerNumber( pn )
 	{
-		// Split in place.
-		split( sSMNoteData, "&", start, size, false );
+		Rage::split_in_place( sSMNoteData, "&", start, size, Rage::EmptyEntries::include );
 		if( unsigned(start) == sSMNoteData.size() )
 			break;
 		vParts.push_back( NoteData() );

--- a/src/NotesLoaderDWI.cpp
+++ b/src/NotesLoaderDWI.cpp
@@ -644,13 +644,10 @@ bool DWILoader::LoadFromDir( const RString &sPath_, Song &out, std::set<RString>
 
 		else if(tagName == "FREEZE" )
 		{
-			vector<RString> arrayFreezeExpressions;
-			split( sParams[1], ",", arrayFreezeExpressions );
-
+			auto arrayFreezeExpressions = Rage::split( sParams[1], "," );
 			for (auto &freeze: arrayFreezeExpressions)
 			{
-				vector<RString> arrayFreezeValues;
-				split( freeze, "=", arrayFreezeValues );
+				auto arrayFreezeValues = Rage::split(freeze, "=");
 				if( arrayFreezeValues.size() != 2 )
 				{
 					LOG->UserLog( "Song file", sPath, "has an invalid FREEZE: '%s'.", freeze.c_str() );
@@ -666,13 +663,11 @@ bool DWILoader::LoadFromDir( const RString &sPath_, Song &out, std::set<RString>
 
 		else if(tagName == "CHANGEBPM" || tagName == "BPMCHANGE" )
 		{
-			vector<RString> arrayBPMChangeExpressions;
-			split( sParams[1], ",", arrayBPMChangeExpressions );
+			auto arrayBPMChangeExpressions = Rage::split(sParams[1], ",");
 
 			for (auto &change: arrayBPMChangeExpressions)
 			{
-				vector<RString> arrayBPMChangeValues;
-				split( change, "=", arrayBPMChangeValues );
+				auto arrayBPMChangeValues = Rage::split(change, "=");
 				if( arrayBPMChangeValues.size() != 2 )
 				{
 					LOG->UserLog( "Song file", sPath, "has an invalid CHANGEBPM: '%s'.", change.c_str() );

--- a/src/NotesLoaderSM.cpp
+++ b/src/NotesLoaderSM.cpp
@@ -185,8 +185,7 @@ void SMSetBGChanges(SMSongTagInfo& info)
 }
 void SMSetFGChanges(SMSongTagInfo& info)
 {
-	vector<RString> aFGChangeExpressions;
-	split((*info.params)[1], ",", aFGChangeExpressions);
+	auto aFGChangeExpressions = Rage::split((*info.params)[1], ",");
 
 	for (auto &expression: aFGChangeExpressions)
 	{
@@ -197,7 +196,10 @@ void SMSetFGChanges(SMSongTagInfo& info)
 }
 void SMSetKeysounds(SMSongTagInfo& info)
 {
-	split((*info.params)[1], ",", info.song->m_vsKeysoundFile);
+	// Do not assume it's empty.
+	auto toDump = Rage::split((*info.params)[1], ",");
+	auto &soundFiles = info.song->m_vsKeysoundFile;
+	soundFiles.insert(soundFiles.end(), std::make_move_iterator(toDump.begin()), std::make_move_iterator(toDump.end()));
 }
 void SMSetAttacks(SMSongTagInfo& info)
 {
@@ -373,8 +375,7 @@ void SMLoader::ProcessBGChanges( Song &out, const RString &sValueName, const RSt
 	}
 	else
 	{
-		vector<RString> aBGChangeExpressions;
-		split( sParam, ",", aBGChangeExpressions );
+		auto aBGChangeExpressions = Rage::split(sParam, ",");
 
 		for (auto &expression: aBGChangeExpressions)
 		{
@@ -406,8 +407,7 @@ void SMLoader::ProcessAttacks( AttackArray &attacks, MsdFile::value_t params )
 
 	for( unsigned j=1; j < params.params.size(); ++j )
 	{
-		vector<RString> sBits;
-		split( params[j], "=", sBits, false );
+		auto sBits = Rage::split(params[j], "=", Rage::EmptyEntries::include);
 
 		// Need an identifer and a value for this to work
 		if( sBits.size() < 2 )
@@ -416,11 +416,17 @@ void SMLoader::ProcessAttacks( AttackArray &attacks, MsdFile::value_t params )
 		}
 		Rage::ci_ascii_string tagName{ Rage::trim(sBits[0]).c_str() };
 		if( tagName == "TIME" )
-			attack.fStartSecond = strtof( sBits[1], nullptr );
+		{
+			attack.fStartSecond = strtof( sBits[1].c_str(), nullptr );
+		}
 		else if( tagName == "LEN" )
-			attack.fSecsRemaining = strtof( sBits[1], nullptr );
+		{
+			attack.fSecsRemaining = strtof( sBits[1].c_str(), nullptr );
+		}
 		else if( tagName == "END" )
-			end = strtof( sBits[1], nullptr );
+		{
+			end = strtof( sBits[1].c_str(), nullptr );
+		}
 		else if( tagName == "MODS" )
 		{
 			attack.sModifiers = Rage::trim(sBits[1]);
@@ -440,30 +446,28 @@ void SMLoader::ProcessAttacks( AttackArray &attacks, MsdFile::value_t params )
 
 void SMLoader::ProcessInstrumentTracks( Song &out, const RString &sParam )
 {
-	vector<RString> vs1;
-	split( sParam, ",", vs1 );
+	auto vs1 = Rage::split(sParam, ",");
 	for (auto const &s: vs1)
 	{
-		vector<RString> vs2;
-		split( s, "=", vs2 );
+		auto vs2 = Rage::split(s, "=");
 		if( vs2.size() >= 2 )
 		{
 			InstrumentTrack it = StringToInstrumentTrack( vs2[0] );
 			if( it != InstrumentTrack_Invalid )
+			{
 				out.m_sInstrumentTrackFile[it] = vs2[1];
+			}
 		}
 	}
 }
 
 void SMLoader::ParseBPMs( vector< std::pair<float, float> > &out, const RString line, const int rowsPerBeat )
 {
-	vector<RString> arrayBPMChangeExpressions;
-	split( line, ",", arrayBPMChangeExpressions );
+	auto arrayBPMChangeExpressions = Rage::split(line, ",");
 
 	for (auto const &expression: arrayBPMChangeExpressions)
 	{
-		vector<RString> arrayBPMChangeValues;
-		split( expression, "=", arrayBPMChangeValues );
+		auto arrayBPMChangeValues = Rage::split(expression, "=");
 		if( arrayBPMChangeValues.size() != 2 )
 		{
 			LOG->UserLog("Song file",
@@ -487,13 +491,11 @@ void SMLoader::ParseBPMs( vector< std::pair<float, float> > &out, const RString 
 
 void SMLoader::ParseStops( vector< std::pair<float, float> > &out, const RString line, const int rowsPerBeat )
 {
-	vector<RString> arrayFreezeExpressions;
-	split( line, ",", arrayFreezeExpressions );
+	auto arrayFreezeExpressions = Rage::split(line, ",");
 
 	for (auto const &expression: arrayFreezeExpressions)
 	{
-		vector<RString> arrayFreezeValues;
-		split( expression, "=", arrayFreezeValues );
+		auto arrayFreezeValues = Rage::split(expression, "=");
 		if( arrayFreezeValues.size() != 2 )
 		{
 			LOG->UserLog("Song file",
@@ -753,13 +755,11 @@ void SMLoader::ProcessBPMsAndStops(TimingData &out,
 
 void SMLoader::ProcessDelays( TimingData &out, const RString line, const int rowsPerBeat )
 {
-	vector<RString> arrayDelayExpressions;
-	split( line, ",", arrayDelayExpressions );
+	auto arrayDelayExpressions = Rage::split(line, ",");
 
 	for (auto const &expression: arrayDelayExpressions)
 	{
-		vector<RString> arrayDelayValues;
-		split( expression, "=", arrayDelayValues );
+		auto arrayDelayValues = Rage::split(expression, "=");
 		if( arrayDelayValues.size() != 2 )
 		{
 			LOG->UserLog("Song file",
@@ -785,13 +785,11 @@ void SMLoader::ProcessDelays( TimingData &out, const RString line, const int row
 
 void SMLoader::ProcessTimeSignatures( TimingData &out, const RString line, const int rowsPerBeat )
 {
-	vector<RString> vs1;
-	split( line, ",", vs1 );
+	auto vs1 = Rage::split(line, ",");
 
 	for (auto const &s1: vs1)
 	{
-		vector<RString> vs2;
-		split( s1, "=", vs2 );
+		auto vs2 = Rage::split(s1, "=");
 
 		if( vs2.size() < 3 )
 		{
@@ -839,13 +837,11 @@ void SMLoader::ProcessTimeSignatures( TimingData &out, const RString line, const
 
 void SMLoader::ProcessTickcounts( TimingData &out, const RString line, const int rowsPerBeat )
 {
-	vector<RString> arrayTickcountExpressions;
-	split( line, ",", arrayTickcountExpressions );
+	auto arrayTickcountExpressions = Rage::split(line, ",");
 
 	for (auto const &expression: arrayTickcountExpressions)
 	{
-		vector<RString> arrayTickcountValues;
-		split( expression, "=", arrayTickcountValues );
+		auto arrayTickcountValues = Rage::split(expression, "=");
 		if( arrayTickcountValues.size() != 2 )
 		{
 			LOG->UserLog("Song file",
@@ -856,7 +852,7 @@ void SMLoader::ProcessTickcounts( TimingData &out, const RString line, const int
 		}
 
 		const float fTickcountBeat = RowToBeat( arrayTickcountValues[0], rowsPerBeat );
-		int iTicks = Rage::clamp(atoi( arrayTickcountValues[1] ), 0, ROWS_PER_BEAT);
+		int iTicks = Rage::clamp(std::stoi( arrayTickcountValues[1] ), 0, ROWS_PER_BEAT);
 
 		out.AddSegment( TickcountSegment(BeatToNoteRow(fTickcountBeat), iTicks) );
 	}
@@ -864,17 +860,19 @@ void SMLoader::ProcessTickcounts( TimingData &out, const RString line, const int
 
 void SMLoader::ProcessSpeeds( TimingData &out, const RString line, const int rowsPerBeat )
 {
-	vector<RString> vs1;
-	split( line, ",", vs1 );
+	auto vs1 = Rage::split(line, ",");
 
-	for (auto s1 = vs1.begin(); s1 != vs1.end(); ++s1)
+	for (auto s1: vs1)
 	{
-		vector<RString> vs2;
-		split( *s1, "=", vs2 );
+		auto vs2 = Rage::split(s1, "=");
 
-		if( vs2[0] == 0 && vs2.size() == 2 ) // First one always seems to have 2.
+		if (vs2.size() == 2)
 		{
-			vs2.push_back("0");
+			// Make sure we don't cast all the dang time. Also, first one almost always has 2.
+			if (StringToFloat(vs2[0]) == 0.f)
+			{
+				vs2.push_back("0");
+			}
 		}
 
 		if( vs2.size() == 3 ) // use beats by default.
@@ -924,13 +922,11 @@ void SMLoader::ProcessSpeeds( TimingData &out, const RString line, const int row
 
 void SMLoader::ProcessFakes( TimingData &out, const RString line, const int rowsPerBeat )
 {
-	vector<RString> arrayFakeExpressions;
-	split( line, ",", arrayFakeExpressions );
+	auto arrayFakeExpressions = Rage::split(line, ",");
 
 	for (auto const &expression: arrayFakeExpressions)
 	{
-		vector<RString> arrayFakeValues;
-		split( expression, "=", arrayFakeValues );
+		auto arrayFakeValues = Rage::split(expression, "=");
 		if( arrayFakeValues.size() != 2 )
 		{
 			LOG->UserLog("Song file",
@@ -944,7 +940,9 @@ void SMLoader::ProcessFakes( TimingData &out, const RString line, const int rows
 		const float fSkippedBeats = StringToFloat( arrayFakeValues[1] );
 
 		if(fSkippedBeats > 0)
+		{
 			out.AddSegment( FakeSegment(BeatToNoteRow(fBeat), fSkippedBeats) );
+		}
 		else
 		{
 			LOG->UserLog("Song file",
@@ -958,8 +956,7 @@ void SMLoader::ProcessFakes( TimingData &out, const RString line, const int rows
 bool SMLoader::LoadFromBGChangesString( BackgroundChange &change, const RString &sBGChangeExpression )
 {
 	using std::min;
-	vector<RString> aBGChangeValues;
-	split( sBGChangeExpression, "=", aBGChangeValues, false );
+	auto aBGChangeValues = Rage::split(sBGChangeExpression, "=", Rage::EmptyEntries::include);
 
 	aBGChangeValues.resize( min((int)aBGChangeValues.size(),11) );
 

--- a/src/NotesLoaderSMA.cpp
+++ b/src/NotesLoaderSMA.cpp
@@ -18,13 +18,11 @@ using std::vector;
 
 void SMALoader::ProcessMultipliers( TimingData &out, const int iRowsPerBeat, const RString sParam )
 {
-	vector<RString> arrayMultiplierExpressions;
-	split( sParam, ",", arrayMultiplierExpressions );
+	auto arrayMultiplierExpressions = Rage::split(sParam, ",");
 
 	for (auto &expression: arrayMultiplierExpressions)
 	{
-		vector<RString> arrayMultiplierValues;
-		split( expression, "=", arrayMultiplierValues );
+		auto arrayMultiplierValues = Rage::split(expression, "=");
 		unsigned size = arrayMultiplierValues.size();
 		if( size < 2 )
 		{
@@ -46,13 +44,11 @@ void SMALoader::ProcessMultipliers( TimingData &out, const int iRowsPerBeat, con
 
 void SMALoader::ProcessBeatsPerMeasure( TimingData &out, const RString sParam )
 {
-	vector<RString> vs1;
-	split( sParam, ",", vs1 );
+	auto vs1 = Rage::split(sParam, ",");
 
 	for (auto const &s1: vs1)
 	{
-		vector<RString> vs2;
-		split( s1, "=", vs2 );
+		auto vs2 = Rage::split(s1, "=");
 
 		if( vs2.size() < 2 )
 		{
@@ -88,15 +84,12 @@ void SMALoader::ProcessBeatsPerMeasure( TimingData &out, const RString sParam )
 
 void SMALoader::ProcessSpeeds( TimingData &out, const RString line, const int rowsPerBeat )
 {
-	vector<RString> vs1;
-	split( line, ",", vs1 );
+	auto vs1 = Rage::split(line, ",");
 
 	for (auto s1 = vs1.begin(); s1 != vs1.end(); ++s1)
 	{
-		vector<RString> vs2;
-		vs2.clear(); // trying something.
 		RString loopTmp = Rage::trim(*s1);
-		split( loopTmp, "=", vs2 );
+		auto vs2 = Rage::split(loopTmp, "=");
 
 		if( vs2.size() == 2 ) // First one always seems to have 2.
 		{
@@ -291,11 +284,9 @@ bool SMALoader::LoadFromSimfile( const RString &sPath, Song &out, bool bFromCach
 			 * becomes so, make adjustments to this code. */
 			if( iRowsPerBeat < 0 )
 			{
-				vector<RString> arrayBeatChangeExpressions;
-				split( sParams[1], ",", arrayBeatChangeExpressions );
+				auto arrayBeatChangeExpressions = Rage::split(sParams[1], ",");
 
-				vector<RString> arrayBeatChangeValues;
-				split( arrayBeatChangeExpressions[0], "=", arrayBeatChangeValues );
+				auto arrayBeatChangeValues = Rage::split(arrayBeatChangeExpressions[0], "=");
 				iRowsPerBeat = StringToInt(arrayBeatChangeValues[1]);
 			}
 			else
@@ -353,8 +344,7 @@ bool SMALoader::LoadFromSimfile( const RString &sPath, Song &out, bool bFromCach
 
 		else if( sValueName=="FGCHANGES" )
 		{
-			vector<RString> aFGChangeExpressions;
-			split( sParams[1], ",", aFGChangeExpressions );
+			auto aFGChangeExpressions = Rage::split(sParams[1], ",");
 
 			for (auto &expression: aFGChangeExpressions)
 			{
@@ -422,7 +412,9 @@ bool SMALoader::LoadFromSimfile( const RString &sPath, Song &out, bool bFromCach
 
 		else if( sValueName=="KEYSOUNDS" )
 		{
-			split( sParams[1], ",", out.m_vsKeysoundFile );
+			// Do not assume this is empty.
+			auto toDump = Rage::split(sParams[1], ",");
+			out.m_vsKeysoundFile.insert(out.m_vsKeysoundFile.end(), std::make_move_iterator(toDump.begin()), std::make_move_iterator(toDump.end()));
 		}
 
 		// Attacks loaded from file

--- a/src/NotesLoaderSSC.cpp
+++ b/src/NotesLoaderSSC.cpp
@@ -227,8 +227,7 @@ void SetBGChanges(SongTagInfo& info)
 }
 void SetFGChanges(SongTagInfo& info)
 {
-	vector<RString> aFGChangeExpressions;
-	split((*info.params)[1], ",", aFGChangeExpressions);
+	auto aFGChangeExpressions = Rage::split((*info.params)[1], ",");
 
 	for (auto const &expression: aFGChangeExpressions)
 	{
@@ -241,8 +240,12 @@ void SetKeysounds(SongTagInfo& info)
 {
 	RString keysounds = (*info.params)[1];
 	if(keysounds.length() >= 2 && keysounds.substr(0, 2) == "\\#")
-	{ keysounds = keysounds.substr(1); }
-	split(keysounds, ",", info.song->m_vsKeysoundFile);
+	{
+		keysounds = keysounds.substr(1);
+	}
+	auto toDump = Rage::split(keysounds, ",");
+	auto &soundFiles = info.song->m_vsKeysoundFile;
+	soundFiles.insert(soundFiles.end(), std::make_move_iterator(toDump.begin()), std::make_move_iterator(toDump.end()));
 }
 void SetAttacks(SongTagInfo& info)
 {
@@ -370,8 +373,7 @@ void SetRadarValues(StepsTagInfo& info)
 {
 	if(info.from_cache || info.for_load_edit)
 	{
-		vector<RString> values;
-		split((*info.params)[1], ",", values, true);
+		auto values = Rage::split((*info.params)[1], ",", Rage::EmptyEntries::skip);
 		// Instead of trying to use the version to figure out how many
 		// categories to expect, look at the number of values and split them
 		// evenly. -Kyz
@@ -656,13 +658,11 @@ ssc_parser_helper_t parser_helper;
 
 void SSCLoader::ProcessBPMs( TimingData &out, const RString sParam )
 {
-	vector<RString> arrayBPMExpressions;
-	split( sParam, ",", arrayBPMExpressions );
+	auto arrayBPMExpressions = Rage::split( sParam, "," );
 
 	for (auto const &expression: arrayBPMExpressions)
 	{
-		vector<RString> arrayBPMValues;
-		split( expression, "=", arrayBPMValues );
+		auto arrayBPMValues = Rage::split(expression, "=");
 		if( arrayBPMValues.size() != 2 )
 		{
 			LOG->UserLog("Song file",
@@ -690,13 +690,11 @@ void SSCLoader::ProcessBPMs( TimingData &out, const RString sParam )
 
 void SSCLoader::ProcessStops( TimingData &out, const RString sParam )
 {
-	vector<RString> arrayStopExpressions;
-	split( sParam, ",", arrayStopExpressions );
+	auto arrayStopExpressions = Rage::split( sParam, "," );
 
 	for (auto const &expression: arrayStopExpressions)
 	{
-		vector<RString> arrayStopValues;
-		split( expression, "=", arrayStopValues );
+		auto arrayStopValues = Rage::split(expression, "=");
 		if( arrayStopValues.size() != 2 )
 		{
 			LOG->UserLog("Song file",
@@ -722,13 +720,11 @@ void SSCLoader::ProcessStops( TimingData &out, const RString sParam )
 
 void SSCLoader::ProcessWarps( TimingData &out, const RString sParam, const float fVersion )
 {
-	vector<RString> arrayWarpExpressions;
-	split( sParam, ",", arrayWarpExpressions );
+	auto arrayWarpExpressions = Rage::split( sParam, "," );
 
 	for (auto const &expression: arrayWarpExpressions)
 	{
-		vector<RString> arrayWarpValues;
-		split( expression, "=", arrayWarpValues );
+		auto arrayWarpValues = Rage::split(expression, "=");
 		if( arrayWarpValues.size() != 2 )
 		{
 			LOG->UserLog("Song file",
@@ -759,13 +755,11 @@ void SSCLoader::ProcessWarps( TimingData &out, const RString sParam, const float
 
 void SSCLoader::ProcessLabels( TimingData &out, const RString sParam )
 {
-	vector<RString> arrayLabelExpressions;
-	split( sParam, ",", arrayLabelExpressions );
+	auto arrayLabelExpressions = Rage::split( sParam, "," );
 
 	for (auto const &expression: arrayLabelExpressions)
 	{
-		vector<RString> arrayLabelValues;
-		split( expression, "=", arrayLabelValues );
+		auto arrayLabelValues = Rage::split(expression, "=");
 		if( arrayLabelValues.size() != 2 )
 		{
 			LOG->UserLog("Song file",
@@ -794,13 +788,11 @@ void SSCLoader::ProcessLabels( TimingData &out, const RString sParam )
 
 void SSCLoader::ProcessCombos( TimingData &out, const RString line, const int rowsPerBeat )
 {
-	vector<RString> arrayComboExpressions;
-	split( line, ",", arrayComboExpressions );
+	auto arrayComboExpressions = Rage::split( line, "," );
 
 	for (auto const &expression: arrayComboExpressions)
 	{
-		vector<RString> arrayComboValues;
-		split( expression, "=", arrayComboValues );
+		auto arrayComboValues = Rage::split(expression, "=");
 		unsigned size = arrayComboValues.size();
 		if( size < 2 )
 		{
@@ -819,13 +811,11 @@ void SSCLoader::ProcessCombos( TimingData &out, const RString line, const int ro
 
 void SSCLoader::ProcessScrolls( TimingData &out, const RString sParam )
 {
-	vector<RString> vs1;
-	split( sParam, ",", vs1 );
+	auto vs1 = Rage::split(sParam, ",");
 
 	for (auto const &s1: vs1)
 	{
-		vector<RString> vs2;
-		split( s1, "=", vs2 );
+		auto vs2 = Rage::split(s1, "=");
 
 		if( vs2.size() < 2 )
 		{

--- a/src/NotesWriterSM.cpp
+++ b/src/NotesWriterSM.cpp
@@ -296,10 +296,10 @@ void NotesWriterSM::GetEditFileContents( const Song *pSong, const Steps *pSteps,
 	RString sDir = pSong->GetSongDir();
 
 	// "Songs/foo/bar"; strip off "Songs/".
-	auto asParts = Rage::split(sDir, "/");
-	if( asParts.size() )
+	auto parts = Rage::split(sDir, "/");
+	if( parts.size() )
 	{
-		sDir = Rage::join( "/", asParts.begin()+1, asParts.end() );
+		sDir = Rage::join( "/", parts.begin()+1, parts.end() );
 	}
 	sOut += fmt::sprintf( "#SONG:%s;\r\n", sDir.c_str() );
 	sOut += GetSMNotesTag( *pSong, *pSteps );

--- a/src/OptionRowHandler.cpp
+++ b/src/OptionRowHandler.cpp
@@ -374,8 +374,7 @@ static void SortNoteSkins( vector<std::string> &asSkinNames )
 	std::set<RString> setSkinNames;
 	setSkinNames.insert( asSkinNames.begin(), asSkinNames.end() );
 
-	vector<RString> asSorted;
-	split( NOTE_SKIN_SORT_ORDER, ",", asSorted );
+	auto asSorted = Rage::split( NOTE_SKIN_SORT_ORDER, "," );
 
 	std::set<RString> setUnusedSkinNames( setSkinNames );
 	asSkinNames.clear();
@@ -383,7 +382,9 @@ static void SortNoteSkins( vector<std::string> &asSkinNames )
 	for (auto &sSkin: asSorted)
 	{
 		if( setSkinNames.find(sSkin) == setSkinNames.end() )
+		{
 			continue;
+		}
 		asSkinNames.push_back( sSkin );
 		setUnusedSkinNames.erase( sSkin );
 	}

--- a/src/OptionsList.cpp
+++ b/src/OptionsList.cpp
@@ -202,14 +202,12 @@ void OptionsList::Load( RString sType, PlayerNumber pn )
 	ActorUtil::LoadAllCommands( *m_Cursor, sType );
 	this->AddChild( m_Cursor );
 
-	vector<RString> asDirectLines;
-	split( DIRECT_LINES, ",", asDirectLines, true );
+	auto asDirectLines = Rage::split(DIRECT_LINES, ",", Rage::EmptyEntries::skip);
 	for (auto const &s: asDirectLines)
 	{
 		m_setDirectRows.insert( s );
 	}
-	vector<RString> setToLoad;
-	split( TOP_MENUS, ",", setToLoad );
+	auto setToLoad = Rage::split(TOP_MENUS, ",");
 	m_setTopMenus.insert( setToLoad.begin(), setToLoad.end() );
 
 	while( !setToLoad.empty() )
@@ -218,8 +216,9 @@ void OptionsList::Load( RString sType, PlayerNumber pn )
 		setToLoad.erase( setToLoad.begin() );
 
 		if( m_Rows.find(sLineName) != m_Rows.end() )
+		{
 			continue;
-
+		}
 		RString sRowCommands = LINE(sLineName);
 		Commands cmds;
 		ParseCommands( sRowCommands, cmds, false );

--- a/src/PlayerOptions.cpp
+++ b/src/PlayerOptions.cpp
@@ -334,8 +334,7 @@ void PlayerOptions::GetMods( vector<std::string> &AddTo, bool bForceNoteSkin ) c
 void PlayerOptions::FromString( std::string const &sMultipleMods )
 {
 	RString sTemp = sMultipleMods;
-	vector<RString> vs;
-	split( sTemp, ",", vs, true );
+	auto vs = Rage::split(sTemp, ",", Rage::EmptyEntries::skip);
 	RString sThrowAway;
 	for (auto &s: vs)
 	{
@@ -358,8 +357,7 @@ bool PlayerOptions::FromOneModString( std::string const &sOneMod, std::string &s
 
 	float level = 1;
 	float speed = 1;
-	vector<RString> asParts;
-	split( sBit, " ", asParts, true );
+	auto asParts = Rage::split(sBit, " ", Rage::EmptyEntries::skip);
 
 	for (auto const &s: asParts)
 	{
@@ -385,7 +383,7 @@ bool PlayerOptions::FromOneModString( std::string const &sOneMod, std::string &s
 		}
 		else if( s[0]=='*' )
 		{
-			sscanf( s, "*%f", &speed );
+			std::sscanf( s.c_str(), "*%f", &speed );
 			if( !std::isfinite(speed) )
 			{
 				speed = 1.0f;

--- a/src/Profile.cpp
+++ b/src/Profile.cpp
@@ -1701,21 +1701,19 @@ void Profile::LoadGeneralDataFromNode( const XNode* pNode )
 	{
 		RString pref_noteskins;
 		pNode->GetChildValue("PreferredNoteskins", pref_noteskins);
-		vector<RString> split_by_stype;
-		split(pref_noteskins, ";", split_by_stype);
+		auto split_by_stype = Rage::split(pref_noteskins, ";");
 		for(auto&& entry : split_by_stype)
 		{
-			vector<RString> parts;
-			split(entry, ",", parts);
+			auto parts = Rage::split(entry, ",");
 			if(parts.size() != 2)
 			{
 				continue;
 			}
+			std::string lowerParts = Rage::make_lower(parts[0]);
+			Rage::replace(lowerParts, '_', '-');
 			// I hate that StepsTypeToString and StringToStepsType don't used the
 			// same formatting. -Kyz
-			parts[0].MakeLower();
-			parts[0].Replace('_', '-');
-			StepsType stype= GAMEMAN->StringToStepsType(parts[0]);
+			StepsType stype= GAMEMAN->StringToStepsType(lowerParts);
 			if(stype == StepsType_Invalid)
 			{
 				continue;

--- a/src/ProfileManager.cpp
+++ b/src/ProfileManager.cpp
@@ -225,7 +225,8 @@ void ProfileManager::GetMemoryCardProfileDirectoriesToTry( vector<RString> &asDi
 	asDirsToTry.push_back( PREFSMAN->m_sMemoryCardProfileSubdir.ToString() );
 
 	/* If that failed, try loading from all fallback directories. */
-	split( g_sMemoryCardProfileImportSubdirs.Get(), ";", asDirsToTry, true );
+	auto toDump = Rage::split(g_sMemoryCardProfileImportSubdirs.Get(), ";", Rage::EmptyEntries::skip);
+	asDirsToTry.insert(asDirsToTry.end(), std::make_move_iterator(toDump.begin()), std::make_move_iterator(toDump.end()));
 }
 
 bool ProfileManager::LoadProfileFromMemoryCard( PlayerNumber pn, bool bLoadEdits )

--- a/src/RadarValues.cpp
+++ b/src/RadarValues.cpp
@@ -91,8 +91,7 @@ RString RadarValues::ToString( int iMaxValues ) const
 
 void RadarValues::FromString( RString sRadarValues )
 {
-	vector<RString> saValues;
-	split( sRadarValues, ",", saValues, true );
+	auto saValues = Rage::split(sRadarValues, ",", Rage::EmptyEntries::skip);
 
 	if( saValues.size() != NUM_RadarCategory )
 	{

--- a/src/RageDisplay_GLES2.cpp
+++ b/src/RageDisplay_GLES2.cpp
@@ -306,8 +306,7 @@ RageDisplay_GLES2::Init( const VideoModeParams &p, bool bAllowUnacceleratedRende
 		}
 #else
 		const char *szExtensionString = (const char *) glGetString(GL_EXTENSIONS);
-		vector<RString> asExtensions;
-		split( szExtensionString, " ", asExtensions );
+		auto asExtensions = Rage::split(szExtensionString, " ");
 		sort( asExtensions.begin(), asExtensions.end() );
 		size_t iNextToPrint = 0;
 		while( iNextToPrint < asExtensions.size() )

--- a/src/RageDisplay_OGL.cpp
+++ b/src/RageDisplay_OGL.cpp
@@ -487,8 +487,7 @@ RString RageDisplay_Legacy::Init( const VideoModeParams &p, bool bAllowUnacceler
 	LOG->Info( "OGL Extensions:" );
 	{
 		const char *szExtensionString = (const char *) glGetString(GL_EXTENSIONS);
-		vector<RString> asExtensions;
-		split( szExtensionString, " ", asExtensions );
+		auto asExtensions = Rage::split(szExtensionString, " ");
 		sort( asExtensions.begin(), asExtensions.end() );
 		size_t iNextToPrint = 0;
 		while( iNextToPrint < asExtensions.size() )
@@ -503,11 +502,11 @@ RString RageDisplay_Legacy::Init( const VideoModeParams &p, bool bAllowUnacceler
 				{
 					sThisType = Rage::join( "_", asBits.begin(), asBits.begin()+2 );
 				}
-                if (i > iNextToPrint && sThisType != sType)
+				if (i > iNextToPrint && sThisType != sType)
 				{
 					break;
 				}
-                sType = sThisType;
+				sType = sThisType;
 				iLastToPrint = i;
 			}
 
@@ -525,7 +524,9 @@ RString RageDisplay_Legacy::Init( const VideoModeParams &p, bool bAllowUnacceler
 				auto sShortExt = Rage::join( "_", asBits.begin()+2, asBits.end() );
 				sList += sShortExt;
 				if (iNextToPrint < iLastToPrint)
+				{
 					sList += ", ";
+				}
 				if (iNextToPrint == iLastToPrint || sList.size() + asExtensions[iNextToPrint+1].size() > 120)
 				{
 					LOG->Info( "%s", sList.c_str() );

--- a/src/RageFileDriver.cpp
+++ b/src/RageFileDriver.cpp
@@ -13,8 +13,7 @@ RageFileDriver::~RageFileDriver()
 
 int RageFileDriver::GetPathValue( const RString &sPath )
 {
-	vector<RString> asParts;
-	split( sPath, "/", asParts, true );
+	auto asParts = Rage::split(sPath, "/", Rage::EmptyEntries::skip);
 
 	RString sPartialPath;
 

--- a/src/RageFileDriverDirectHelpers.cpp
+++ b/src/RageFileDriverDirectHelpers.cpp
@@ -80,7 +80,6 @@ bool WinMoveFile( RString sOldPath, RString sNewPath )
 bool CreateDirectories( RString Path )
 {
 	// XXX: handle "//foo/bar" paths in Windows
-	vector<RString> parts;
 	RString curpath;
 
 	// If Path is absolute, add the initial slash ("ignore empty" will remove it).
@@ -89,12 +88,14 @@ bool CreateDirectories( RString Path )
 		curpath = "/";
 	}
 	// Ignore empty, so eg. "/foo/bar//baz" doesn't try to create "/foo/bar" twice.
-	split( Path, "/", parts, true );
+	auto parts = Rage::split(Path, "/", Rage::EmptyEntries::skip);
 
 	for(unsigned i = 0; i < parts.size(); ++i)
 	{
 		if( i )
+		{
 			curpath += "/";
+		}
 		curpath += parts[i];
 
 #if defined(WIN32)

--- a/src/RageFileManager.cpp
+++ b/src/RageFileManager.cpp
@@ -262,20 +262,24 @@ static RString GetDirOfExecutable( RString argv0 )
 			if( !path )
 				path = _PATH_DEFPATH;
 
-			vector<RString> vPath;
-			split( path, ":", vPath );
+			auto vPath = Rage::split(path, ":");
 			for (auto &i: vPath)
 			{
-				if( access(i + "/" + argv0, X_OK|R_OK) )
+				if( access((i + "/" + argv0).c_str(), X_OK|R_OK) )
+				{
 					continue;
+				}
 				sPath = ExtractDirectory(ReadlinkRecursive(i + "/" + argv0));
 				break;
 			}
 			if( sPath.empty() )
+			{
 				sPath = GetCwd(); // What?
+			}
 			else if( sPath[0] != '/' ) // For example, if . is in $PATH.
+			{
 				sPath = GetCwd() + "/" + sPath;
-
+			}
 		}
 		else
 		{

--- a/src/RageLog.cpp
+++ b/src/RageLog.cpp
@@ -88,8 +88,7 @@ RageLog::~RageLog()
 {
 	/* Add the mapped log data to info.txt. */
 	const RString AdditionalLog = GetAdditionalLog();
-	vector<RString> AdditionalLogLines;
-	split( AdditionalLog, "\n", AdditionalLogLines );
+	auto AdditionalLogLines = Rage::split(AdditionalLog, "\n");
 	for (auto &line: AdditionalLogLines)
 	{
 		this->Info( Rage::trim(line) );
@@ -191,8 +190,7 @@ void RageLog::Write( WriteDest where, std::string const &line )
 	LockMut( *g_Mutex );
 
 	const char *const sWarningSeparator = "/////////////////////////////////////////";
-	vector<RString> lines;
-	split( line, "\n", lines, false );
+	auto lines = Rage::split(line, "\n", Rage::EmptyEntries::include);
 	bool containsLoud = flags(where & WriteDest::Loud);
 	bool containsInfo = flags(where & WriteDest::Info);
 	if( containsLoud )
@@ -214,14 +212,21 @@ void RageLog::Write( WriteDest where, std::string const &line )
 			str = sWarning + str;
 		}
 		if( m_bShowLogOutput || containsInfo )
-			puts(str); //fputws( (const wchar_t *)str.c_str(), stdout );
+		{
+			puts(str.c_str());
+		}
 		if( containsInfo )
+		{
 			AddToInfo( str );
+		}
 		if( m_bLogToDisk && containsInfo && g_fileInfo->IsOpen() )
+		{
 			g_fileInfo->PutLine( str );
+		}
 		if( m_bUserLogToDisk && (flags(where & WriteDest::UserLog)) && g_fileUserLog->IsOpen() )
+		{
 			g_fileUserLog->PutLine( str );
-
+		}
 		/* Add a timestamp to log.txt and RecentLogs, but not the rest of info.txt
 		 * and stdout. */
 		str = sTimestamp + str;
@@ -233,9 +238,10 @@ void RageLog::Write( WriteDest where, std::string const &line )
 		AddToRecentLogs( str );
 
 		if( m_bLogToDisk && g_fileLog->IsOpen() )
+		{
 			g_fileLog->PutLine( str );
+		}
 	}
-
 	if( containsLoud )
 	{
 		if( m_bLogToDisk && g_fileLog->IsOpen() )

--- a/src/RageUtil.cpp
+++ b/src/RageUtil.cpp
@@ -277,12 +277,12 @@ bool HexToBinary( const RString &s, RString &sOut )
 
 float HHMMSSToSeconds( const RString &sHHMMSS )
 {
-	vector<RString> arrayBits;
-	split( sHHMMSS, ":", arrayBits, false );
+	auto arrayBits = Rage::split(sHHMMSS, ":", Rage::EmptyEntries::include);
 
 	while( arrayBits.size() < 3 )
+	{
 		arrayBits.insert(arrayBits.begin(), "0" );	// pad missing bits
-
+	}
 	float fSeconds = 0;
 	fSeconds += StringToInt( arrayBits[0] ) * 60 * 60;
 	fSeconds += StringToInt( arrayBits[1] ) * 60;
@@ -675,127 +675,6 @@ static int DelimitorLength( const S &Delimitor )
 static int DelimitorLength( char Delimitor )
 {
 	return 1;
-}
-
-static int DelimitorLength( wchar_t Delimitor )
-{
-	return 1;
-}
-
-template <class S, class C>
-void do_split( const S &Source, const C Delimitor, vector<S> &AddIt, const bool bIgnoreEmpty )
-{
-	/* Short-circuit if the source is empty; we want to return an empty vector if
-	 * the string is empty, even if bIgnoreEmpty is true. */
-	if( Source.empty() )
-		return;
-
-	size_t startpos = 0;
-
-	do {
-		size_t pos;
-		pos = Source.find( Delimitor, startpos );
-		if( pos == Source.npos )
-			pos = Source.size();
-
-		if( pos-startpos > 0 || !bIgnoreEmpty )
-		{
-			/* Optimization: if we're copying the whole string, avoid substr; this
-			 * allows this copy to be refcounted, which is much faster. */
-			if( startpos == 0 && pos-startpos == Source.size() )
-				AddIt.push_back(Source);
-			else
-			{
-				const S AddRString = Source.substr(startpos, pos-startpos);
-				AddIt.push_back(AddRString);
-			}
-		}
-
-		startpos = pos+DelimitorLength(Delimitor);
-	} while ( startpos <= Source.size() );
-}
-
-void split( const RString &sSource, const RString &sDelimitor, vector<RString> &asAddIt, const bool bIgnoreEmpty )
-{
-	if( sDelimitor.size() == 1 )
-		do_split( sSource, sDelimitor[0], asAddIt, bIgnoreEmpty );
-	else
-		do_split( sSource, sDelimitor, asAddIt, bIgnoreEmpty );
-}
-
-void split( const wstring &sSource, const wstring &sDelimitor, vector<wstring> &asAddIt, const bool bIgnoreEmpty )
-{
-	if( sDelimitor.size() == 1 )
-		do_split( sSource, sDelimitor[0], asAddIt, bIgnoreEmpty );
-	else
-		do_split( sSource, sDelimitor, asAddIt, bIgnoreEmpty );
-}
-
-/* Use:
-
-RString str="a,b,c";
-int start = 0, size = -1;
-while( 1 )
-{
-	do_split( str, ",", start, size );
-	if( start == str.size() )
-		break;
-	str[start] = 'Q';
-}
-
-*/
-
-template <class S>
-void do_split( const S &Source, const S &Delimitor, int &begin, int &size, int len, const bool bIgnoreEmpty )
-{
-	using std::min;
-	if( size != -1 )
-	{
-		// Start points to the beginning of the last delimiter. Move it up.
-		begin += size+Delimitor.size();
-		begin = min( begin, len );
-	}
-
-	size = 0;
-
-	if( bIgnoreEmpty )
-	{
-		// Skip delims.
-		while( begin + Delimitor.size() < Source.size() &&
-			!Source.compare( begin, Delimitor.size(), Delimitor ) )
-			++begin;
-	}
-
-	/* Where's the string function to find within a substring?
-	 * C++ strings apparently are missing that ... */
-	size_t pos;
-	if( Delimitor.size() == 1 )
-		pos = Source.find( Delimitor[0], begin );
-	else
-		pos = Source.find( Delimitor, begin );
-	if( pos == Source.npos || (int) pos > len )
-		pos = len;
-	size = pos - begin;
-}
-
-void split( const RString &Source, const RString &Delimitor, int &begin, int &size, int len, const bool bIgnoreEmpty )
-{
-	do_split( Source, Delimitor, begin, size, len, bIgnoreEmpty );
-}
-
-void split( const wstring &Source, const wstring &Delimitor, int &begin, int &size, int len, const bool bIgnoreEmpty )
-{
-	do_split( Source, Delimitor, begin, size, len, bIgnoreEmpty );
-}
-
-void split( const RString &Source, const RString &Delimitor, int &begin, int &size, const bool bIgnoreEmpty )
-{
-	do_split( Source, Delimitor, begin, size, Source.size(), bIgnoreEmpty );
-}
-
-void split( const wstring &Source, const wstring &Delimitor, int &begin, int &size, const bool bIgnoreEmpty )
-{
-	do_split( Source, Delimitor, begin, size, Source.size(), bIgnoreEmpty );
 }
 
 /*

--- a/src/RageUtil.h
+++ b/src/RageUtil.h
@@ -393,18 +393,6 @@ void GetLanguageInfos( std::vector<const LanguageInfo*> &vAddTo );
 const LanguageInfo *GetLanguageInfo( const RString &sIsoCode );
 RString GetLanguageNameFromISO639Code( RString sName );
 
-// Splits a RString into an std::vector<RString> according the Delimitor.
-void split( const RString &sSource, const RString &sDelimitor, std::vector<RString>& asAddIt, const bool bIgnoreEmpty = true );
-void split( const std::wstring &sSource, const std::wstring &sDelimitor, std::vector<std::wstring> &asAddIt, const bool bIgnoreEmpty = true );
-
-/* In-place split. */
-void split( const RString &sSource, const RString &sDelimitor, int &iBegin, int &iSize, const bool bIgnoreEmpty = true );
-void split( const std::wstring &sSource, const std::wstring &sDelimitor, int &iBegin, int &iSize, const bool bIgnoreEmpty = true );
-
-/* In-place split of partial string. */
-void split( const RString &sSource, const RString &sDelimitor, int &iBegin, int &iSize, int iLen, const bool bIgnoreEmpty ); /* no default to avoid ambiguity */
-void split( const std::wstring &sSource, const std::wstring &sDelimitor, int &iBegin, int &iSize, int iLen, const bool bIgnoreEmpty );
-
 // These methods escapes a string for saving in a .sm or .crs file
 RString SmEscape( const RString &sUnescaped );
 RString SmEscape( const char *cUnescaped, int len );

--- a/src/RageUtil_CharConversions.cpp
+++ b/src/RageUtil_CharConversions.cpp
@@ -2,6 +2,7 @@
 #include "RageUtil_CharConversions.h"
 #include "RageUtil.h"
 #include "RageLog.h"
+#include "RageString.hpp"
 #include "RageUnicode.hpp"
 
 using std::vector;
@@ -131,8 +132,7 @@ bool ConvertString( RString &str, const RString &encodings )
 	if( str.empty() )
 		return true;
 
-	vector<RString> lst;
-	split( encodings, ",", lst );
+	auto lst = Rage::split( encodings, "," );
 
 	for(unsigned i = 0; i < lst.size(); ++i)
 	{

--- a/src/RageUtil_FileDB.cpp
+++ b/src/RageUtil_FileDB.cpp
@@ -192,7 +192,7 @@ bool FilenameDB::ResolvePath( RString &sPath )
 	static const RString slash("/");
 	for(;;)
 	{
-		split( sPath, slash, iBegin, iSize, true );
+        Rage::split_in_place( sPath, slash, iBegin, iSize, Rage::EmptyEntries::skip );
 		if( iBegin == (int) sPath.size() )
 			break;
 

--- a/src/Screen.cpp
+++ b/src/Screen.cpp
@@ -63,22 +63,19 @@ void Screen::Init()
 
 	PlayCommandNoRecurse( Message("Init") );
 
-	vector<RString> asList;
-	split( PREPARE_SCREENS, ",", asList );
+	auto asList = Rage::split(PREPARE_SCREENS, ",");
 	for (auto &item: asList)
 	{
 		LOG->Trace( "Screen \"%s\" preparing \"%s\"", m_sName.c_str(), item.c_str() );
 		SCREENMAN->PrepareScreen( item );
 	}
 
-	asList.clear();
-	split( GROUPED_SCREENS, ",", asList );
+	asList = Rage::split(GROUPED_SCREENS, ",");
 	for (auto &item: asList)
 	{
 		SCREENMAN->GroupScreen( item );
 	}
-	asList.clear();
-	split( PERSIST_SCREENS, ",", asList );
+	asList = Rage::split(PERSIST_SCREENS, ",");
 	for (auto &item: asList)
 	{
 		SCREENMAN->PersistantScreen( item );

--- a/src/ScreenDemonstration.cpp
+++ b/src/ScreenDemonstration.cpp
@@ -31,8 +31,7 @@ void ScreenDemonstration::Init()
 
 	// Choose a Style
 	{
-		vector<RString> v;
-		split( ALLOW_STYLE_TYPES, ",", v );
+		auto v = Rage::split(ALLOW_STYLE_TYPES, ",");
 		vector<StyleType> vStyleTypeAllow;
 		for (auto &s: v)
 		{

--- a/src/ScreenEdit.cpp
+++ b/src/ScreenEdit.cpp
@@ -545,8 +545,7 @@ void ScreenEdit::LoadKeymapSectionIntoMappingsMember(XNode const* section, MapEd
 		{
 			RString joined_names;
 			attr->second->GetValue(joined_names);
-			vector<RString> key_names;
-			split(joined_names, DEVICE_INPUT_SEPARATOR, key_names, false);
+			auto key_names = Rage::split(joined_names, DEVICE_INPUT_SEPARATOR, Rage::EmptyEntries::include);
 			for(size_t k= 0; k < key_names.size() && k < NUM_EDIT_TO_DEVICE_SLOTS; ++k)
 			{
 				DeviceInput devi;
@@ -4023,7 +4022,7 @@ void ScreenEdit::HandleScreenMessage( const ScreenMessage SM )
 		(GAMESTATE->m_bIsUsingStepTiming ? m_pSteps->m_Attacks : m_pSong->m_Attacks);
 		Attack &attack = attacks[attackInProcess];
 		auto mods = Rage::split(attack.sModifiers, ",");
-		RString mod = Rage::trim(ScreenTextEntry::s_sLastAnswer);
+		auto mod = Rage::trim(ScreenTextEntry::s_sLastAnswer);
 		if (mod.length() > 0)
 		{
 			mods[modInProcess - 2] = mod;
@@ -4048,8 +4047,7 @@ void ScreenEdit::HandleScreenMessage( const ScreenMessage SM )
 		AttackArray &attacks =
 		(GAMESTATE->m_bIsUsingStepTiming ? m_pSteps->m_Attacks : m_pSong->m_Attacks);
 		Attack &attack = attacks[attackInProcess];
-		vector<RString> mods;
-		split(attack.sModifiers, ",", mods);
+        auto mods = Rage::split(attack.sModifiers, ",");
 		modInProcess = option;
 		if (option == 0) // adjusting the starting time
 		{
@@ -4143,8 +4141,7 @@ void ScreenEdit::HandleScreenMessage( const ScreenMessage SM )
 															 0,
 															 nullptr));
 				g_IndividualAttack.rows[1].SetOneUnthemedChoice(FloatToString(attack.fSecsRemaining));
-				vector<RString> mods;
-				split(attack.sModifiers, ",", mods);
+				auto mods = Rage::split(attack.sModifiers, ",");
 				for (unsigned i = 0; i < mods.size(); ++i)
 				{
 					unsigned col = i + 2;
@@ -5016,8 +5013,7 @@ static LocalizedString CONFIRM_CLEAR("ScreenEdit", "Are you sure you want to cle
 
 static bool ConvertMappingInputToMapping(RString const& mapstr, int* mapping, RString& error)
 {
-	vector<RString> mapping_input;
-	split(mapstr, ",", mapping_input);
+    auto mapping_input = Rage::split(mapstr, ",");
 	size_t tracks_for_type= GAMEMAN->GetStepsTypeInfo(GAMESTATE->m_pCurSteps[0]->m_StepsType).iNumTracks;
 	if(mapping_input.size() > tracks_for_type)
 	{

--- a/src/ScreenGameplay.cpp
+++ b/src/ScreenGameplay.cpp
@@ -1426,9 +1426,8 @@ void ScreenGameplay::LoadLights()
 	}
 
 	// No explicit lights.  Create autogen lights.
-	RString sDifficulty = PREFSMAN->m_sLightsStepsDifficulty.Get();
-	vector<RString> asDifficulties;
-	split( sDifficulty, ",", asDifficulties );
+	auto sDifficulty = PREFSMAN->m_sLightsStepsDifficulty.Get();
+	auto asDifficulties = Rage::split(sDifficulty, ",");
 
 	// Always use the steps from the primary steps type so that lights are consistent over single and double styles.
 	StepsType st = GAMEMAN->GetHowToPlayStyleForGame( GAMESTATE->m_pCurGame )->m_StepsType;

--- a/src/ScreenInstallOverlay.cpp
+++ b/src/ScreenInstallOverlay.cpp
@@ -48,8 +48,7 @@ PlayAfterLaunchInfo DoInstalls( CommandLineActions::CommandLineArgs args );
 
 static void Parse(const RString &sDir, PlayAfterLaunchInfo &out)
 {
-	vector<RString> vsDirParts;
-	split(sDir, "/", vsDirParts, true);
+	auto vsDirParts = Rage::split(sDir, ",", Rage::EmptyEntries::skip);
 	// sanity check
 	if (vsDirParts.size() < 1)
 	{

--- a/src/ScreenManager.cpp
+++ b/src/ScreenManager.cpp
@@ -316,8 +316,7 @@ void ScreenManager::ReloadOverlayScreens()
 
 	// reload overlay screens
 	RString sOverlays = THEME->GetMetric( "Common","OverlayScreens" );
-	vector<RString> asOverlays;
-	split( sOverlays, ",", asOverlays );
+	auto asOverlays = Rage::split(sOverlays, ",");
 	for (auto &overlay: asOverlays)
 	{
 		Screen *pScreen = MakeNewScreen( overlay );

--- a/src/ScreenMapControllers.cpp
+++ b/src/ScreenMapControllers.cpp
@@ -75,8 +75,7 @@ void ScreenMapControllers::Init()
 	else
 	{
 		/* Map the specified buttons. */
-		vector<RString> asBits;
-		split( sButtons, ",", asBits );
+		auto asBits = Rage::split(sButtons, ",");
 		for (auto &bit: asBits)
 		{
 			KeyToMap k;

--- a/src/ScreenOptionsMaster.cpp
+++ b/src/ScreenOptionsMaster.cpp
@@ -28,8 +28,7 @@ REGISTER_SCREEN_CLASS( ScreenOptionsMaster );
 
 void ScreenOptionsMaster::Init()
 {
-	vector<RString> asLineNames;
-	split( LINE_NAMES, ",", asLineNames );
+	auto asLineNames = Rage::split(LINE_NAMES, ",");
 	if( asLineNames.empty() )
 	{
 		LuaHelpers::ReportScriptErrorFmt("\"%s:LineNames\" is empty.", m_sName.c_str());

--- a/src/ScreenRanking.cpp
+++ b/src/ScreenRanking.cpp
@@ -101,8 +101,7 @@ void ScreenRanking::Init()
 		this->AddChild( &m_textCourseTitle );
 		LOAD_ALL_COMMANDS( m_textCourseTitle );
 
-		vector<RString> asCoursePaths;
-		split( COURSES_TO_SHOW.GetValue(), ",", asCoursePaths, true );
+		auto asCoursePaths = Rage::split(COURSES_TO_SHOW.GetValue(), ",", Rage::EmptyEntries::skip);
 		for( unsigned i=0; i<STEPS_TYPES_TO_SHOW.GetValue().size(); i++ )
 		{
 			for( unsigned c=0; c<asCoursePaths.size(); c++ )

--- a/src/ScreenSelect.cpp
+++ b/src/ScreenSelect.cpp
@@ -11,10 +11,8 @@
 
 using std::vector;
 
-#define CHOICE_NAMES		THEME->GetMetric (m_sName,"ChoiceNames")
 #define CHOICE( s )		THEME->GetMetric (m_sName,fmt::sprintf("Choice%s",s.c_str()))
 #define IDLE_TIMEOUT_SCREEN	THEME->GetMetric (m_sName,"IdleTimeoutScreen")
-#define UPDATE_ON_MESSAGE	THEME->GetMetric (m_sName,"UpdateOnMessage")
 
 void ScreenSelect::Init()
 {
@@ -25,7 +23,8 @@ void ScreenSelect::Init()
 	ScreenWithMenuElements::Init();
 
 	// Load messages to update on
-	split( UPDATE_ON_MESSAGE, ",", m_asSubscribedMessages );
+	auto toDump = Rage::split(THEME->GetMetric(m_sName, "UpdateOnMessage"), ",");
+	m_asSubscribedMessages.insert(m_asSubscribedMessages.end(), std::make_move_iterator(toDump.begin()), std::make_move_iterator(toDump.end()));
 	for (auto &message: m_asSubscribedMessages)
 	{
 		MESSAGEMAN->Subscribe(this, message);
@@ -37,7 +36,7 @@ void ScreenSelect::Init()
 	}
 	// Load choices
 	// Allow lua as an alternative to metrics.
-	RString choice_names= CHOICE_NAMES;
+	RString choice_names = THEME->GetMetric(m_sName,"ChoiceNames");
 	if (Rage::starts_with(choice_names, "lua,"))
 	{
 		RString command = Rage::tail(choice_names, -4);
@@ -81,8 +80,7 @@ void ScreenSelect::Init()
 		// Each element in the list is a choice name. This level of indirection
 		// makes it easier to add or remove items without having to change a
 		// bunch of indices.
-		vector<RString> asChoiceNames;
-		split( CHOICE_NAMES, ",", asChoiceNames, true );
+		auto asChoiceNames = Rage::split(THEME->GetMetric (m_sName,"ChoiceNames"), ",", Rage::EmptyEntries::skip );
 
 		for( unsigned c=0; c<asChoiceNames.size(); c++ )
 		{

--- a/src/ScreenSelectMaster.cpp
+++ b/src/ScreenSelectMaster.cpp
@@ -277,13 +277,12 @@ void ScreenSelectMaster::Init()
 	FOREACH_MenuDir( dir )
 	{
 		const RString order = OPTION_ORDER.GetValue( dir );
-		vector<RString> parts;
-		split( order, ",", parts, true );
+		auto parts = Rage::split(order, ",", Rage::EmptyEntries::skip);
 
 		for (auto &item: parts)
 		{
 			int from, to;
-			if( sscanf( item, "%d:%d", &from, &to ) != 2 )
+			if( std::sscanf( item.c_str(), "%d:%d", &from, &to ) != 2 )
 			{
 				LuaHelpers::ReportScriptErrorFmt( "%s::OptionOrder%s parse error", m_sName.c_str(), MenuDirToString(dir).c_str() );
 				continue;

--- a/src/ScreenServiceAction.cpp
+++ b/src/ScreenServiceAction.cpp
@@ -418,8 +418,7 @@ REGISTER_SCREEN_CLASS( ScreenServiceAction );
 void ScreenServiceAction::BeginScreen()
 {
 	RString sActions = THEME->GetMetric(m_sName,"Actions");
-	vector<RString> vsActions;
-	split( sActions, ",", vsActions );
+	auto vsActions = Rage::split(sActions, ",");
 
 	vector<std::string> vsResults;
 	for (auto &s: vsActions)

--- a/src/Song.cpp
+++ b/src/Song.cpp
@@ -298,8 +298,7 @@ bool Song::LoadFromSongDir( RString sDir, bool load_autosave )
 	m_sSongDir = sDir;
 
 	// save group name
-	vector<RString> sDirectoryParts;
-	split( m_sSongDir, "/", sDirectoryParts, false );
+	auto sDirectoryParts = Rage::split(m_sSongDir, "/", Rage::EmptyEntries::include);
 	ASSERT( sDirectoryParts.size() >= 4 ); /* e.g. "/Songs/Slow/Taps/" */
 	m_sGroupName = sDirectoryParts[sDirectoryParts.size()-3];	// second from last item
 	ASSERT( m_sGroupName != "" );
@@ -361,8 +360,7 @@ bool Song::LoadFromSongDir( RString sDir, bool load_autosave )
 				return false;
 			}
 			// Make sure we have a future filename figured out.
-			vector<RString> folders;
-			split(sDir, "/", folders);
+			auto folders = Rage::split(sDir, "/");
 			RString songName = folders[2] + ".ssc";
 			this->m_sSongFileName = sDir + songName;
 			// Continue on with a blank Song so that people can make adjustments using the editor.
@@ -1810,8 +1808,7 @@ bool Song::Matches(RString sGroup, RString sSong) const
 
 	RString sDir = this->GetSongDir();
 	Rage::replace(sDir, "\\", "/");
-	vector<RString> bits;
-	split( sDir, "/", bits );
+    auto bits = Rage::split( sDir, "/" );
 	ASSERT(bits.size() >= 2); // should always have at least two parts
 	const RString &sLastBit = bits[bits.size()-1];
 

--- a/src/SongManager.cpp
+++ b/src/SongManager.cpp
@@ -94,8 +94,7 @@ SongManager::~SongManager()
 
 void SongManager::InitAll( LoadingWindow *ld )
 {
-	vector<RString> never_cache;
-	split(PREFSMAN->m_NeverCacheList.Get(), ",", never_cache);
+	auto never_cache = Rage::split(PREFSMAN->m_NeverCacheList.Get(), ",");
 	for (auto &group: never_cache)
 	{
 		m_GroupsToNeverCache.insert(group);
@@ -1164,8 +1163,7 @@ void SongManager::SaveEnabledSongsToPref()
 
 void SongManager::LoadEnabledSongsFromPref()
 {
-	vector<RString> asDisabledSongs;
-	split( g_sDisabledSongs.Get(), ";", asDisabledSongs, true );
+	auto asDisabledSongs = Rage::split(g_sDisabledSongs.Get(), ";", Rage::EmptyEntries::skip);
 
 	for (auto &s: asDisabledSongs)
 	{
@@ -1173,7 +1171,9 @@ void SongManager::LoadEnabledSongsFromPref()
 		sid.FromString( s );
 		Song *pSong = sid.ToSong();
 		if( pSong )
+		{
 			pSong->SetEnabled( false );
+		}
 	}
 }
 
@@ -1475,14 +1475,16 @@ Course* SongManager::GetCourseFromName( RString sName ) const
 Song *SongManager::FindSong( RString sPath ) const
 {
 	Rage::replace(sPath, '\\', '/' );
-	vector<RString> bits;
-	split( sPath, "/", bits );
+	auto bits = Rage::split( sPath, "/" );
 
 	if( bits.size() == 1 )
+	{
 		return FindSong( "", bits[0] );
-	else if( bits.size() == 2 )
+	}
+	if( bits.size() == 2 )
+	{
 		return FindSong( bits[0], bits[1] );
-
+	}
 	return nullptr;
 }
 
@@ -1504,14 +1506,16 @@ Song *SongManager::FindSong( RString sGroup, RString sSong ) const
 Course *SongManager::FindCourse( RString sPath ) const
 {
 	Rage::replace(sPath, '\\', '/' );
-	vector<RString> bits;
-	split( sPath, "/", bits );
+	auto bits = Rage::split( sPath, "/" );
 
 	if( bits.size() == 1 )
+	{
 		return FindCourse( "", bits[0] );
-	else if( bits.size() == 2 )
+	}
+	if( bits.size() == 2 )
+	{
 		return FindCourse( bits[0], bits[1] );
-
+	}
 	return nullptr;
 }
 
@@ -1778,15 +1782,14 @@ void SongManager::UpdateRankingCourses()
 {
 	/* Updating the ranking courses data is fairly expensive since it involves
 	 * comparing strings. Do so sparingly. */
-	vector<RString> RankingCourses;
-	split( THEME->GetMetric("ScreenRanking","CoursesToShow"),",", RankingCourses);
+	auto rankingCourses = Rage::split(THEME->GetMetric("ScreenRanking", "CoursesToShow"), ",");
 
 	for (auto *c: m_pCourses)
 	{
 		bool bLotsOfStages = c->GetEstimatedNumStages() > 7;
 		c->m_SortOrder_Ranking = bLotsOfStages? 3 : 2;
 		Rage::ci_ascii_string ciPath{ c->m_sPath.c_str() };
-		for (auto &course: RankingCourses)
+		for (auto &course: rankingCourses)
 		{
 			if (ciPath == course)
 			{

--- a/src/SongOptions.cpp
+++ b/src/SongOptions.cpp
@@ -152,8 +152,7 @@ std::string SongOptions::GetLocalizedString() const
 void SongOptions::FromString( const RString &sMultipleMods )
 {
 	RString sTemp = sMultipleMods;
-	vector<RString> vs;
-	split( sTemp, ",", vs, true );
+	auto vs = Rage::split(sTemp, ",", Rage::EmptyEntries::skip);
 	RString sThrowAway;
 	for (auto &s: vs)
 	{
@@ -175,8 +174,7 @@ bool SongOptions::FromOneModString( const RString &sOneMod, RString &sErrorOut )
 
 	matches.clear();
 
-	vector<RString> asParts;
-	split( sBit, " ", asParts, true );
+	auto asParts = Rage::split( sBit, " ", Rage::EmptyEntries::skip );
 	bool on = true;
 	if( asParts.size() > 1 )
 	{
@@ -185,22 +183,62 @@ bool SongOptions::FromOneModString( const RString &sOneMod, RString &sErrorOut )
 			on = false;
 	}
 
-	if( sBit == "clap" )				m_bAssistClap = on;
-	else if( sBit == "metronome" )				m_bAssistMetronome = on;
-	else if( sBit == "autosync" || sBit == "autosyncsong" )	m_AutosyncType = on ? AutosyncType_Song : AutosyncType_Off;
-	else if( sBit == "autosyncmachine" )			m_AutosyncType = on ? AutosyncType_Machine : AutosyncType_Off;
-	else if( sBit == "autosynctempo" )			m_AutosyncType = on ? AutosyncType_Tempo : AutosyncType_Off;
-	else if( sBit == "effect" && !on )			m_SoundEffectType = SoundEffectType_Off;
-	else if( sBit == "effectspeed" )			m_SoundEffectType = on ? SoundEffectType_Speed : SoundEffectType_Off;
-	else if( sBit == "effectpitch" )			m_SoundEffectType = on ? SoundEffectType_Pitch : SoundEffectType_Off;
-	else if( sBit == "staticbg" )				m_bStaticBackground = on;
-	else if( sBit == "randombg" )				m_bRandomBGOnly = on;
-	else if( sBit == "savescore" )				m_bSaveScore = on;
-	else if( sBit == "savereplay" )			m_bSaveReplay = on;
-	else if( sBit == "haste" )				m_fHaste = on? 1.0f:0.0f;
+	if( sBit == "clap" )
+	{
+		m_bAssistClap = on;
+	}
+	else if( sBit == "metronome" )
+	{
+		m_bAssistMetronome = on;
+	}
+	else if( sBit == "autosync" || sBit == "autosyncsong" )
+	{
+		m_AutosyncType = on ? AutosyncType_Song : AutosyncType_Off;
+	}
+	else if( sBit == "autosyncmachine" )
+	{
+		m_AutosyncType = on ? AutosyncType_Machine : AutosyncType_Off;
+	}
+	else if( sBit == "autosynctempo" )
+	{
+		m_AutosyncType = on ? AutosyncType_Tempo : AutosyncType_Off;
+	}
+	else if( sBit == "effect" && !on )
+	{
+		m_SoundEffectType = SoundEffectType_Off;
+	}
+	else if( sBit == "effectspeed" )
+	{
+		m_SoundEffectType = on ? SoundEffectType_Speed : SoundEffectType_Off;
+	}
+	else if( sBit == "effectpitch" )
+	{
+		m_SoundEffectType = on ? SoundEffectType_Pitch : SoundEffectType_Off;
+	}
+	else if( sBit == "staticbg" )
+	{
+		m_bStaticBackground = on;
+	}
+	else if( sBit == "randombg" )
+	{
+		m_bRandomBGOnly = on;
+	}
+	else if( sBit == "savescore" )
+	{
+		m_bSaveScore = on;
+	}
+	else if( sBit == "savereplay" )
+	{
+		m_bSaveReplay = on;
+	}
+	else if( sBit == "haste" )
+	{
+		m_fHaste = on? 1.0f:0.0f;
+	}
 	else
+	{
 		return false;
-
+	}
 	return true;
 }
 

--- a/src/StepMania.cpp
+++ b/src/StepMania.cpp
@@ -752,12 +752,12 @@ RageDisplay *CreateDisplay()
 		VIDEO_TROUBLESHOOTING_URL "\n\n"+
 		fmt::sprintf(ERROR_VIDEO_DRIVER.GetValue(), GetVideoDriverName().c_str())+"\n\n";
 
-	vector<RString> asRenderers;
-	split( PREFSMAN->m_sVideoRenderers.Get(), ",", asRenderers, true );
+	auto asRenderers = Rage::split( PREFSMAN->m_sVideoRenderers.Get(), ",", Rage::EmptyEntries::skip);
 
 	if( asRenderers.empty() )
+	{
 		RageException::Throw( "%s", ERROR_NO_VIDEO_RENDERERS.GetValue().c_str() );
-
+	}
 	RageDisplay *pRet = nullptr;
 	for (auto const &sRenderer: asRenderers)
 	{
@@ -1019,28 +1019,28 @@ int sm_main(int argc, char* argv[])
 	WriteLogHeader();
 
 	// Set up alternative filesystem trees.
-	if( PREFSMAN->m_sAdditionalFolders.Get() != "" )
+	auto const &addFolders = PREFSMAN->m_sAdditionalFolders.Get();
+	if( addFolders != "" )
 	{
-		vector<RString> dirs;
-		split( PREFSMAN->m_sAdditionalFolders.Get(), ",", dirs, true );
+		auto dirs = Rage::split(addFolders, ",", Rage::EmptyEntries::skip);
 		for (auto const &dir: dirs)
 		{
 			FILEMAN->Mount( "dir", dir, "/" );
 		}
 	}
-	if( PREFSMAN->m_sAdditionalSongFolders.Get() != "" )
+	auto const &songFolders = PREFSMAN->m_sAdditionalSongFolders.Get();
+	if( songFolders != "" )
 	{
-		vector<RString> dirs;
-		split( PREFSMAN->m_sAdditionalSongFolders.Get(), ",", dirs, true );
+		auto dirs = Rage::split(songFolders, ",", Rage::EmptyEntries::skip);
 		for (auto const &dir: dirs)
 		{
 			FILEMAN->Mount( "dir", dir, "/AdditionalSongs" );
 		}
 	}
-	if( PREFSMAN->m_sAdditionalCourseFolders.Get() != "" )
+	auto const &courseFolders = PREFSMAN->m_sAdditionalCourseFolders.Get();
+	if( courseFolders != "" )
 	{
-		vector<RString> dirs;
-		split( PREFSMAN->m_sAdditionalCourseFolders.Get(), ",", dirs, true );
+		auto dirs = Rage::split(courseFolders, ",", Rage::EmptyEntries::skip);
 		for (auto const &dir: dirs)
 		{
 			FILEMAN->Mount( "dir", dir, "/AdditionalCourses" );

--- a/src/Style.h
+++ b/src/Style.h
@@ -33,26 +33,26 @@ public:
 	 * @brief The name of the style.
 	 *
 	 * Used by GameManager::GameAndStringToStyle to determine whether this is the style that matches the string. */
-	const char *		m_szName;
+	std::string m_szName;
 
 	/**
 	 * @brief Steps format used for each player.
 	 *
 	 * For example, "dance versus" reads the Steps with the tag "dance-single". */
-	StepsType		m_StepsType;
+	StepsType m_StepsType;
 
 	/** @brief Style format used for each player. */
-	StyleType		m_StyleType;
+	StyleType m_StyleType;
 
 	/**
 	 * @brief The number of total tracks/columns this style expects.
 	 *
 	 * As an example, 4 is expected for ITG style versus, but 8 for ITG style double. */
-	int			m_iColsPerPlayer;
+	int m_iColsPerPlayer;
 	/** @brief Some general column infromation */
 	struct ColumnInfo
 	{
-		int   track;		/**< Take note data from this track. */
+		int track;		/**< Take note data from this track. */
 		float fXOffset;		/**< This is the x position of the column relative to the player's center. */
 		const char *pzName;	/**< The name of the column, or nullptr to use the button name mapped to it. */
 	};

--- a/src/ThemeMetric.h
+++ b/src/ThemeMetric.h
@@ -275,7 +275,7 @@ public:
 	}
 };
 
-typedef std::string (*MetricNameMap)(RString s);
+typedef std::string (*MetricNameMap)(std::string s);
 
 template <class T>
 class ThemeMetricMap : public IThemeMetric
@@ -284,11 +284,11 @@ class ThemeMetricMap : public IThemeMetric
 	std::unordered_map<std::string,ThemeMetricT> m_metric;
 
 public:
-	ThemeMetricMap( std::string const & sGroup = "", MetricNameMap pfn = nullptr, const std::vector<RString> vsValueNames = std::vector<RString>() )
+	ThemeMetricMap( std::string const & sGroup = "", MetricNameMap pfn = nullptr, const std::vector<std::string> vsValueNames = std::vector<std::string>() )
 	{
 		Load( sGroup, pfn, vsValueNames );
 	}
-	void Load( std::string const & sGroup, MetricNameMap pfn, const std::vector<RString> vsValueNames )
+	void Load( std::string const & sGroup, MetricNameMap pfn, const std::vector<std::string> vsValueNames )
 	{
 		m_metric.clear();
 		for (auto const &s: vsValueNames)

--- a/src/UnlockManager.cpp
+++ b/src/UnlockManager.cpp
@@ -484,8 +484,7 @@ void UnlockManager::Load()
 {
 	LOG->Trace( "UnlockManager::Load()" );
 
-	vector<RString> asUnlockNames;
-	split( UNLOCK_NAMES, ",", asUnlockNames );
+	auto asUnlockNames = Rage::split(UNLOCK_NAMES, ",");
 
 	Lua *L = LUA->Get();
 	for (auto const &sUnlockName: asUnlockNames)

--- a/src/XmlToLua.cpp
+++ b/src/XmlToLua.cpp
@@ -298,7 +298,7 @@ void actor_template_t::store_cmd(RString const& cmd_name, RString const& full_cm
 		vector<std::string> args = Rage::split(*cmd, ",", Rage::EmptyEntries::skip);
 		if(!args.empty())
 		{
-			for(auto arg= args.begin(); arg != args.end(); ++arg)
+			for(auto arg = args.begin(); arg != args.end(); ++arg)
 			{
 				size_t first_nonspace= 0;
 				size_t last_nonspace= arg->size();
@@ -335,7 +335,7 @@ void actor_template_t::store_cmd(RString const& cmd_name, RString const& full_cm
 		size_t states_in_curr= 0;
 		RString this_name= cmd_name;
 		vector<std::string> curr_cmd;
-		for(auto cmd= cmds.begin(); cmd != cmds.end(); ++cmd)
+		for(auto cmd = cmds.begin(); cmd != cmds.end(); ++cmd)
 		{
 			curr_cmd.push_back(*cmd);
 			auto args = Rage::split(*cmd, ",", Rage::EmptyEntries::skip);

--- a/src/arch/Dialog/Dialog.cpp
+++ b/src/arch/Dialog/Dialog.cpp
@@ -17,10 +17,7 @@ static Preference<std::string> g_sIgnoredDialogs( "IgnoredDialogs", "" );
 DialogDriver *MakeDialogDriver()
 {
 	RString sDrivers = "win32,cocoa,null";
-	vector<RString> asDriversToTry;
-	split( sDrivers, ",", asDriversToTry, true );
-
-	ASSERT( asDriversToTry.size() != 0 );
+	auto asDriversToTry = Rage::split(sDrivers, ",", Rage::EmptyEntries::skip);
 
 	RString sDriver;
 	DialogDriver *pRet = nullptr;
@@ -89,18 +86,16 @@ void Dialog::Shutdown()
 static bool MessageIsIgnored( RString sID )
 {
 #if !defined(SMPACKAGE)
-	vector<RString> asList;
-	split( g_sIgnoredDialogs.Get(), ",", asList );
+	auto asList = Rage::split(g_sIgnoredDialogs, ",");
 	Rage::ci_ascii_string ciId{ sID.c_str() };
-	for (unsigned i = 0; i < asList.size(); ++i)
-	{
-		if (ciId == asList[i])
-		{
-			return true;
-		}
-	}
-#endif
+
+	auto shouldIgnore = [&ciId](std::string const &item) {
+		return ciId == item;
+	};
+	return std::any_of(asList.cbegin(), asList.cend(), shouldIgnore);
+#else
 	return false;
+#endif
 }
 
 void Dialog::IgnoreMessage( RString sID )
@@ -110,7 +105,9 @@ void Dialog::IgnoreMessage( RString sID )
 	if( PREFSMAN == nullptr )
 	{
 		if( sID != "" && LOG )
+		{
 			LOG->Warn( "Dialog: message \"%s\" set ID too early for ignorable messages", sID.c_str() );
+		}
 		return;
 	}
 
@@ -134,11 +131,13 @@ void Dialog::Error( RString sMessage, RString sID )
 	Dialog::Init();
 
 	if( LOG )
+	{
 		LOG->Trace( "Dialog: \"%s\" [%s]", sMessage.c_str(), sID.c_str() );
-
+	}
 	if( sID != "" && MessageIsIgnored(sID) )
+	{
 		return;
-
+	}
 	RageThread::SetIsShowingDialog( true );
 
 	g_pImpl->Error( sMessage, sID );
@@ -156,19 +155,24 @@ void Dialog::OK( RString sMessage, RString sID )
 	Dialog::Init();
 
 	if( LOG )
+	{
 		LOG->Trace( "Dialog: \"%s\" [%s]", sMessage.c_str(), sID.c_str() );
-
+	}
 	if( sID != "" && MessageIsIgnored(sID) )
+	{
 		return;
-
+	}
 	RageThread::SetIsShowingDialog( true );
 
 	// only show Dialog if windowed
 	if( DialogsEnabled() )
+	{
 		g_pImpl->OK( sMessage, sID );	// call derived version
+	}
 	else
+	{
 		g_NullDriver.OK( sMessage, sID );
-
+	}
 	RageThread::SetIsShowingDialog( false );
 }
 
@@ -177,20 +181,25 @@ Dialog::Result Dialog::OKCancel( RString sMessage, RString sID )
 	Dialog::Init();
 
 	if( LOG )
+	{
 		LOG->Trace( "Dialog: \"%s\" [%s]", sMessage.c_str(), sID.c_str() );
-
+	}
 	if( sID != "" && MessageIsIgnored(sID) )
+	{
 		return g_NullDriver.OKCancel( sMessage, sID );
-
+	}
 	RageThread::SetIsShowingDialog( true );
 
 	// only show Dialog if windowed
 	Dialog::Result ret;
 	if( DialogsEnabled() )
+	{
 		ret = g_pImpl->OKCancel( sMessage, sID ); // call derived version
+	}
 	else
+	{
 		ret = g_NullDriver.OKCancel( sMessage, sID );
-
+	}
 	RageThread::SetIsShowingDialog( false );
 
 	return ret;
@@ -201,20 +210,25 @@ Dialog::Result Dialog::AbortRetryIgnore( RString sMessage, RString sID )
 	Dialog::Init();
 
 	if( LOG )
+	{
 		LOG->Trace( "Dialog: \"%s\" [%s]", sMessage.c_str(), sID.c_str() );
-
+	}
 	if( sID != "" && MessageIsIgnored(sID) )
+	{
 		return g_NullDriver.AbortRetryIgnore( sMessage, sID );
-
+	}
 	RageThread::SetIsShowingDialog( true );
 
 	// only show Dialog if windowed
 	Dialog::Result ret;
 	if( DialogsEnabled() )
+	{
 		ret = g_pImpl->AbortRetryIgnore( sMessage, sID );	// call derived version
+	}
 	else
+	{
 		ret = g_NullDriver.AbortRetryIgnore( sMessage, sID );
-
+	}
 	RageThread::SetIsShowingDialog( false );
 
 	return ret;
@@ -225,20 +239,25 @@ Dialog::Result Dialog::AbortRetry( RString sMessage, RString sID )
 	Dialog::Init();
 
 	if( LOG )
+	{
 		LOG->Trace( "Dialog: \"%s\" [%s]", sMessage.c_str(), sID.c_str() );
-
+	}
 	if( sID != "" && MessageIsIgnored(sID) )
+	{
 		return g_NullDriver.AbortRetry( sMessage, sID );
-
+	}
 	RageThread::SetIsShowingDialog( true );
 
 	// only show Dialog if windowed
 	Dialog::Result ret;
 	if( DialogsEnabled() )
+	{
 		ret = g_pImpl->AbortRetry( sMessage, sID );	// call derived version
+	}
 	else
+	{
 		ret = g_NullDriver.AbortRetry( sMessage, sID );
-
+	}
 	RageThread::SetIsShowingDialog( false );
 
 	return ret;
@@ -249,20 +268,25 @@ Dialog::Result Dialog::YesNo( RString sMessage, RString sID )
 	Dialog::Init();
 
 	if( LOG )
+	{
 		LOG->Trace( "Dialog: \"%s\" [%s]", sMessage.c_str(), sID.c_str() );
-
+	}
 	if( sID != "" && MessageIsIgnored(sID) )
+	{
 		return g_NullDriver.YesNo( sMessage, sID );
-
+	}
 	RageThread::SetIsShowingDialog( true );
 
 	// only show Dialog if windowed
 	Dialog::Result ret;
 	if( DialogsEnabled() )
+	{
 		ret = g_pImpl->YesNo( sMessage, sID );	// call derived version
+	}
 	else
+	{
 		ret = g_NullDriver.YesNo( sMessage, sID );
-
+	}
 	RageThread::SetIsShowingDialog( false );
 
 	return ret;

--- a/src/arch/Dialog/DialogDriver.cpp
+++ b/src/arch/Dialog/DialogDriver.cpp
@@ -20,8 +20,7 @@ REGISTER_DIALOG_DRIVER_CLASS( Null );
 DialogDriver *DialogDriver::Create()
 {
 	RString sDrivers = "win32,macosx,null";
-	vector<RString> asDriversToTry;
-	split( sDrivers, ",", asDriversToTry, true );
+	auto asDriversToTry = Rage::split( sDrivers, ",", Rage::EmptyEntries::skip );
 
 	ASSERT( asDriversToTry.size() != 0 );
 
@@ -30,16 +29,19 @@ DialogDriver *DialogDriver::Create()
 		auto iter = RegisterDialogDriver::g_pRegistrees->find( Rage::ci_ascii_string{Driver.c_str()} );
 
 		if( iter == RegisterDialogDriver::g_pRegistrees->end() )
+		{
 			continue;
-
+		}
 		DialogDriver *pRet = (iter->second)();
 		DEBUG_ASSERT( pRet );
 		const RString sError = pRet->Init();
 
 		if( sError.empty() )
-			return pRet;
+		{	return pRet;
+		}
 		if( LOG )
-			LOG->Info( "Couldn't load driver %s: %s", Driver.c_str(), sError.c_str() );
+		{	LOG->Info( "Couldn't load driver %s: %s", Driver.c_str(), sError.c_str() );
+		}
 		SAFE_DELETE( pRet );
 	}
 	return nullptr;

--- a/src/arch/InputHandler/InputHandler.cpp
+++ b/src/arch/InputHandler/InputHandler.cpp
@@ -173,12 +173,12 @@ static LocalizedString INPUT_HANDLERS_EMPTY( "Arch", "Input Handlers cannot be e
 void InputHandler::Create( const RString &drivers_, vector<InputHandler *> &Add )
 {
 	const RString drivers = drivers_.empty()? RString(DEFAULT_INPUT_DRIVER_LIST):drivers_;
-	vector<RString> DriversToTry;
-	split( drivers, ",", DriversToTry, true );
+	auto DriversToTry = Rage::split( drivers, ",", Rage::EmptyEntries::skip );
 
 	if( DriversToTry.empty() )
+	{
 		RageException::Throw( "%s", INPUT_HANDLERS_EMPTY.GetValue().c_str() );
-
+	}
 	for (auto const &s: DriversToTry)
 	{
 		RageDriver *pDriver = InputHandler::m_pDriverList.Create( s );

--- a/src/arch/Lights/LightsDriver.cpp
+++ b/src/arch/Lights/LightsDriver.cpp
@@ -11,8 +11,7 @@ void LightsDriver::Create( const RString &sDrivers, vector<LightsDriver *> &Add 
 {
 	LOG->Trace( "Initializing lights drivers: %s", sDrivers.c_str() );
 
-	vector<RString> asDriversToTry;
-	split( sDrivers, ",", asDriversToTry, true );
+	auto asDriversToTry = Rage::split(sDrivers, ",", Rage::EmptyEntries::skip);
 
 	for (auto const &Driver: asDriversToTry)
 	{

--- a/src/arch/LoadingWindow/LoadingWindow.cpp
+++ b/src/arch/LoadingWindow/LoadingWindow.cpp
@@ -9,16 +9,15 @@ using std::vector;
 LoadingWindow *LoadingWindow::Create()
 {
 	if( !PREFSMAN->m_bShowLoadingWindow )
+	{
 		return new LoadingWindow_Null;
+	}
 #if defined(UNIX) && !defined(HAVE_GTK)
 	return new LoadingWindow_Null;
 #endif
 	// Don't load nullptr by default.
 	const RString drivers = "win32,macosx,gtk";
-	vector<RString> DriversToTry;
-	split( drivers, ",", DriversToTry, true );
-
-	ASSERT( DriversToTry.size() != 0 );
+	auto DriversToTry = Rage::split(drivers, ",", Rage::EmptyEntries::skip);
 
 	RString Driver;
 	LoadingWindow *ret = nullptr;

--- a/src/arch/LoadingWindow/LoadingWindow_Win32.cpp
+++ b/src/arch/LoadingWindow/LoadingWindow_Win32.cpp
@@ -13,6 +13,7 @@
 #include "RageSurface.h"
 #include "RageSurfaceUtils.h"
 #include "RageLog.h"
+#include "RageString.hpp"
 #include "ProductInfo.h"
 #include "LocalizedString.h"
 
@@ -58,7 +59,7 @@ static HBITMAP LoadWin32Surface( const RageSurface *pSplash, HWND hWnd )
 		for( int x = 0; x < s->w; ++x )
 		{
 			unsigned const char *data = line + (x*s->format->BytesPerPixel);
-			
+
 			SetPixelV( BitmapDC, x, y, RGB( data[3], data[2], data[1] ) );
 		}
 	}
@@ -97,10 +98,10 @@ BOOL CALLBACK LoadingWindow_Win32::WndProc( HWND hWnd, UINT msg, WPARAM wParam, 
 		}
 		if( g_hBitmap == nullptr )
 			g_hBitmap = LoadWin32Surface( "Data/splash.bmp", hWnd );
-		SendMessage( 
-			GetDlgItem(hWnd,IDC_SPLASH), 
-			STM_SETIMAGE, 
-			(WPARAM) IMAGE_BITMAP, 
+		SendMessage(
+			GetDlgItem(hWnd,IDC_SPLASH),
+			STM_SETIMAGE,
+			(WPARAM) IMAGE_BITMAP,
 			(LPARAM) (HANDLE) g_hBitmap );
 		SetWindowTextA( hWnd, PRODUCT_ID );
 		break;
@@ -180,8 +181,7 @@ void LoadingWindow_Win32::Paint()
 
 void LoadingWindow_Win32::SetText( RString sText )
 {
-	vector<RString> asMessageLines;
-	split( sText, "\n", asMessageLines, false );
+	auto asMessageLines = Rage::split(sText, "\n", Rage::EmptyEntries::include);
 	while( asMessageLines.size() < 3 )
 		asMessageLines.push_back( "" );
 
@@ -230,7 +230,7 @@ void LoadingWindow_Win32::SetIndeterminate(bool indeterminate)
 /*
  * (c) 2001-2004 Chris Danford, Glenn Maynard
  * All rights reserved.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the
  * "Software"), to deal in the Software without restriction, including
@@ -240,7 +240,7 @@ void LoadingWindow_Win32::SetIndeterminate(bool indeterminate)
  * copyright notice(s) and this permission notice appear in all copies of
  * the Software and that both the above copyright notice(s) and this
  * permission notice appear in supporting documentation.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
  * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
  * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF

--- a/src/arch/MemoryCard/MemoryCardDriverThreaded_Linux.cpp
+++ b/src/arch/MemoryCard/MemoryCardDriverThreaded_Linux.cpp
@@ -234,8 +234,7 @@ void MemoryCardDriverThreaded_Linux::GetUSBStorageDevices( vector<UsbStorageDevi
 				 * the number of hops.
 				 */
 				szLink[iRet] = 0;
-				vector<RString> asBits;
-				split( szLink, "/", asBits );
+				auto asBits = Rage::split(szLink, "/");
 
 				RString sHostPort = asBits[asBits.size()-1];
 				if( !sHostPort.empty() )
@@ -247,12 +246,12 @@ void MemoryCardDriverThreaded_Linux::GetUSBStorageDevices( vector<UsbStorageDevi
 
 					/* sHostPort is eg. 2-2.1. */
 					Rage::replace(sHostPort, '-', '.' );
-					asBits.clear();
-					split( sHostPort, ".", asBits );
+					// Repurpose the vector.
+					asBits = Rage::split(sHostPort, ".");
 					if( asBits.size() > 1 )
 					{
-						usbd.iBus = atoi( asBits[0] );
-						usbd.iPort = atoi( asBits[asBits.size()-1] );
+						usbd.iBus = std::stoi( asBits[0] );
+						usbd.iPort = std::stoi( asBits[asBits.size()-1] );
 						usbd.iLevel = asBits.size() - 1;
 					}
 				}

--- a/src/arch/MovieTexture/MovieTexture.cpp
+++ b/src/arch/MovieTexture/MovieTexture.cpp
@@ -87,14 +87,15 @@ RageMovieTexture *RageMovieTexture::Create( RageTextureID ID )
 
 	RString sDrivers = g_sMovieDrivers.Get();
 	if( sDrivers.empty() )
+	{
 		sDrivers = DEFAULT_MOVIE_DRIVER_LIST;
-
-	vector<RString> DriversToTry;
-	split( sDrivers, ",", DriversToTry, true );
+	}
+	auto DriversToTry = Rage::split( sDrivers, ",", Rage::EmptyEntries::skip );
 
 	if( DriversToTry.empty() )
+	{
 		RageException::Throw( "%s", MOVIE_DRIVERS_EMPTY.GetValue().c_str() );
-
+	}
 	RageMovieTexture *ret = nullptr;
 
 	for (auto const &Driver: DriversToTry)
@@ -126,8 +127,9 @@ RageMovieTexture *RageMovieTexture::Create( RageTextureID ID )
 		break;
 	}
 	if ( !ret )
+	{
 		RageException::Throw( "%s", COULDNT_CREATE_MOVIE_DRIVER.GetValue().c_str() );
-
+	}
 	return ret;
 }
 

--- a/src/arch/Sound/RageSoundDriver.cpp
+++ b/src/arch/Sound/RageSoundDriver.cpp
@@ -10,8 +10,7 @@ DriverList RageSoundDriver::m_pDriverList;
 
 RageSoundDriver *RageSoundDriver::Create( const RString& sDrivers )
 {
-	vector<RString> DriversToTry;
-	split( sDrivers.empty()? DEFAULT_SOUND_DRIVER_LIST:sDrivers, ",", DriversToTry, true );
+	auto DriversToTry = Rage::split(sDrivers.empty() ? DEFAULT_SOUND_DRIVER_LIST : sDrivers, ",", Rage::EmptyEntries::skip);
 
 	for (auto const &Driver: DriversToTry)
 	{

--- a/src/arch/Sound/RageSoundDriver_JACK.cpp
+++ b/src/arch/Sound/RageSoundDriver_JACK.cpp
@@ -2,6 +2,7 @@
 #include "RageSoundDriver_JACK.h"
 #include "RageLog.h"
 #include "RageUtil.h"
+#include "RageString.hpp"
 #include "PrefsManager.h"
 #include "ProductInfo.h"
 
@@ -111,8 +112,7 @@ out_close:
 
 RString RageSoundDriver_JACK::ConnectPorts()
 {
-	vector<RString> portNames;
-	split(PREFSMAN->m_iSoundDevice.Get(), ",", portNames, true);
+	auto portNames = Rage::split(PREFSMAN->m_iSoundDevice.Get(), ",", Rage::EmptyEntries::skip);
 
 	const char *port_out_l = nullptr, *port_out_r = nullptr;
 	const char **ports = nullptr;
@@ -147,7 +147,7 @@ RString RageSoundDriver_JACK::ConnectPorts()
 		// "aliases" in the docs.)
 		for (auto &portName: portNames)
 		{
-			jack_port_t *out = jack_port_by_name( client, portName );
+			jack_port_t *out = jack_port_by_name( client, portName.c_str() );
 			// Make sure the port is a sink.
 			if( ! ( jack_port_flags( out ) & JackPortIsInput ) )
 				continue;

--- a/src/archutils/Unix/CrashHandlerChild.cpp
+++ b/src/archutils/Unix/CrashHandlerChild.cpp
@@ -12,6 +12,7 @@
 #include "BacktraceNames.h"
 
 #include "RageUtil.h"
+#include "RageString.hpp"
 #include "CrashHandler.h"
 #include "CrashHandlerInternal.h"
 #include "RageLog.h" /* for RageLog::GetAdditionalLog, etc. only */
@@ -136,8 +137,7 @@ static void child_process()
 	if( !child_read(3, temp, size) )
 		return;
 
-	vector<RString> Checkpoints;
-	split(temp, "$$", Checkpoints);
+	auto checkpoints = Rage::split(temp, "$$");
 	delete [] temp;
 
 	/* 6. Read the crashed thread's name. */
@@ -244,9 +244,9 @@ static void child_process()
 	fprintf( CrashDump, "Crashed thread: %s\n\n", CrashedThread.c_str() );
 
 	fprintf(CrashDump, "Checkpoints:\n");
-	for (auto &checkpoint: Checkpoints)
+	for (auto &checkpoint: checkpoints)
 	{
-		fputs( checkpoint, CrashDump );
+		fputs( checkpoint.c_str(), CrashDump );
 	}
 	fprintf( CrashDump, "\n" );
 

--- a/src/archutils/Win32/CrashHandlerChild.cpp
+++ b/src/archutils/Win32/CrashHandlerChild.cpp
@@ -308,7 +308,7 @@ namespace SymbolLookup
 			| UNDNAME_NO_CV_THISTYPE
 			| UNDNAME_NO_ALLOCATION_MODEL
 			| UNDNAME_NO_ACCESS_SPECIFIERS // no public:
-			| UNDNAME_NO_MS_KEYWORDS // no __cdecl 
+			| UNDNAME_NO_MS_KEYWORDS // no __cdecl
 			| UNDNAME_NO_MEMBER_TYPE // no virtual, static
 			) )
 		{
@@ -387,7 +387,7 @@ namespace SymbolLookup
 		}
 
 		wsprintf( buf, "%08lx: %s!%08lx",
-			(unsigned long) ptr, sName.c_str(), 
+			(unsigned long) ptr, sName.c_str(),
 			(unsigned long) meminfo.AllocationBase );
 	}
 }
@@ -585,7 +585,8 @@ bool ReadCrashDataFromParent( int iFD, CompleteCrashData &Data )
 	{
 		return false;
 	}
-	split(tmp, "$$", Data.m_asCheckpoints);
+	auto toDump = Rage::split(tmp, "$$");
+	Data.m_asCheckpoints.insert(Data.m_asCheckpoints.end(), std::make_move_iterator(toDump.begin()), std::make_move_iterator(toDump.end()));
 
 	// 6. Read the crashed thread's name.
 	if( !ReadFromParent(iFD, &iSize, sizeof(iSize)) )
@@ -707,7 +708,7 @@ BOOL CrashDialog::HandleMessage( UINT msg, WPARAM wParam, LPARAM lParam )
 			{
 			case IDC_STATIC_HEADER_TEXT:
 			case IDC_STATIC_ICON:
-				hbr = (HBRUSH)::GetStockObject(WHITE_BRUSH); 
+				hbr = (HBRUSH)::GetStockObject(WHITE_BRUSH);
 				SetBkMode( hdc, OPAQUE );
 				SetBkColor( hdc, RGB(255,255,255) );
 				break;
@@ -907,7 +908,7 @@ void CrashHandler::CrashHandlerHandleArgs( int argc, char* argv[] )
 /*
  * (c) 2003-2006 Glenn Maynard
  * All rights reserved.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the
  * "Software"), to deal in the Software without restriction, including
@@ -917,7 +918,7 @@ void CrashHandler::CrashHandlerHandleArgs( int argc, char* argv[] )
  * copyright notice(s) and this permission notice appear in all copies of
  * the Software and that both the above copyright notice(s) and this
  * permission notice appear in supporting documentation.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
  * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
  * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF

--- a/src/archutils/Win32/CrashHandlerNetworking.cpp
+++ b/src/archutils/Win32/CrashHandlerNetworking.cpp
@@ -5,6 +5,7 @@
 #include "RageThreads.h"
 #include "RageTimer.h"
 #include "RageUtil.h"
+#include "RageString.hpp"
 
 #if defined(WINDOWS)
 #include <windows.h>
@@ -673,7 +674,7 @@ void NetworkPostData::HttpThread()
 	std::map<RString,RString> mapHeaders;
 	while( 1 )
 	{
-		split( sResult, "\n", iStart, iSize, false );
+		Rage::split_in_place( sResult, "\n", iStart, iSize, Rage::EmptyEntries::include );
 		if( iStart == (int) sResult.size() )
 			break;
 

--- a/src/archutils/Win32/GraphicsWindow.cpp
+++ b/src/archutils/Win32/GraphicsWindow.cpp
@@ -171,7 +171,7 @@ static LRESULT CALLBACK GraphicsWindow_WndProc( HWND hWnd, UINT msg, WPARAM wPar
 			PCOPYDATASTRUCT pMyCDS = (PCOPYDATASTRUCT) lParam;
 			RString sCommandLine( (char*)pMyCDS->lpData, pMyCDS->cbData );
 			CommandLineActions::CommandLineArgs args;
-			split( sCommandLine, "|", args.argv, false );
+			args.argv = Rage::split(sCommandLine, "|", Rage::EmptyEntries::include);
 			CommandLineActions::ToProcess.push_back( args );
 			break;
 		}


### PR DESCRIPTION
Due to the behavior changes, split now returns a vector.
Prior calls that depended on concatenation use a [move-iterator
approach](http://stackoverflow.com/a/21972296).

There may be some OS specific items missed on the first go-around.