### PR TITLE
remove guitar cruft

### DIFF
--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -17,17 +17,17 @@ TapNoteScore Game::MapTapNoteScore( TapNoteScore tns ) const
 
 static const Game::PerButtonInfo g_CommonButtonInfo[] =
 {
-	{ GameButtonType_INVALID }, // GAME_BUTTON_MENULEFT
-	{ GameButtonType_INVALID }, // GAME_BUTTON_MENURIGHT
-	{ GameButtonType_INVALID }, // GAME_BUTTON_MENUUP
-	{ GameButtonType_INVALID }, // GAME_BUTTON_MENUDOWN
-	{ GameButtonType_INVALID }, // GAME_BUTTON_START
-	{ GameButtonType_INVALID }, // GAME_BUTTON_SELECT
-	{ GameButtonType_INVALID }, // GAME_BUTTON_BACK
-	{ GameButtonType_INVALID }, // GAME_BUTTON_COIN
-	{ GameButtonType_INVALID }, // GAME_BUTTON_OPERATOR
-	{ GameButtonType_INVALID }, // GAME_BUTTON_EFFECT_UP
-	{ GameButtonType_INVALID }, // GAME_BUTTON_EFFECT_DOWN
+	{ GameButtonType_Menu }, // GAME_BUTTON_MENULEFT
+	{ GameButtonType_Menu }, // GAME_BUTTON_MENURIGHT
+	{ GameButtonType_Menu }, // GAME_BUTTON_MENUUP
+	{ GameButtonType_Menu }, // GAME_BUTTON_MENUDOWN
+	{ GameButtonType_Menu }, // GAME_BUTTON_START
+	{ GameButtonType_Menu }, // GAME_BUTTON_SELECT
+	{ GameButtonType_Menu }, // GAME_BUTTON_BACK
+	{ GameButtonType_Menu }, // GAME_BUTTON_COIN
+	{ GameButtonType_Menu }, // GAME_BUTTON_OPERATOR
+	{ GameButtonType_Menu }, // GAME_BUTTON_EFFECT_UP
+	{ GameButtonType_Menu }, // GAME_BUTTON_EFFECT_DOWN
 };
 
 const Game::PerButtonInfo *Game::GetPerButtonInfo( GameButton gb ) const

--- a/src/GameConstantsAndTypes.h
+++ b/src/GameConstantsAndTypes.h
@@ -321,8 +321,6 @@ const RString& ScoreEventToString( ScoreEvent se );
 enum GameButtonType
 {
 	GameButtonType_Step,
-	GameButtonType_Fret,
-	GameButtonType_Strum,
 	GameButtonType_INVALID
 };
 

--- a/src/GameConstantsAndTypes.h
+++ b/src/GameConstantsAndTypes.h
@@ -321,7 +321,7 @@ const RString& ScoreEventToString( ScoreEvent se );
 enum GameButtonType
 {
 	GameButtonType_Step,
-	GameButtonType_INVALID
+	GameButtonType_Menu
 };
 
 /** @brief The list of judge types for the tap note scores. */

--- a/src/GameState.cpp
+++ b/src/GameState.cpp
@@ -1188,7 +1188,6 @@ void GameState::ResetMusicStatistics()
 
 	FOREACH_PlayerNumber( p )
 	{
-		m_pPlayerState[p]->ClearHopoState();
 		m_pPlayerState[p]->m_Position.Reset();
 	}
 }

--- a/src/NoteDataUtil.cpp
+++ b/src/NoteDataUtil.cpp
@@ -3006,34 +3006,6 @@ bool NoteDataUtil::GetPrevEditorPosition( const NoteData& in, int &rowInOut )
 	return true;
 }
 
-extern Preference<float> g_fTimingWindowHopo;
-
-
-void NoteDataUtil::SetHopoPossibleFlags( const Song *pSong, NoteData& ndInOut )
-{
-	float fLastRowMusicSeconds = -1;
-	int iLastTapTrackOfLastRow = -1;
-	FOREACH_NONEMPTY_ROW_ALL_TRACKS( ndInOut, r )
-	{
-		float fBeat = NoteRowToBeat( r );
-		float fSeconds = pSong->m_SongTiming.GetElapsedTimeFromBeat( fBeat );
-
-		int iLastTapTrack = ndInOut.GetLastTrackWithTapOrHoldHead( r );
-		if( iLastTapTrack != -1  &&  fSeconds <= fLastRowMusicSeconds + g_fTimingWindowHopo )
-		{
-			int iNumNotesInRow = ndInOut.GetNumTapNotesInRow( r );
-			TapNote &tn = ndInOut.FindTapNote( iLastTapTrack, r )->second;
-		
-			if( iNumNotesInRow == 1  &&  iLastTapTrack != iLastTapTrackOfLastRow )
-			{
-				tn.bHopoPossible = true;
-			}
-		}
-
-		fLastRowMusicSeconds = fSeconds;
-		iLastTapTrackOfLastRow = iLastTapTrack;
-	}
-}
 
 unsigned int NoteDataUtil::GetTotalHoldTicks( NoteData* nd, const TimingData* td )
 {

--- a/src/NoteDataUtil.h
+++ b/src/NoteDataUtil.h
@@ -182,8 +182,6 @@ namespace NoteDataUtil
 
 	bool GetNextEditorPosition( const NoteData& in, int &rowInOut );
 	bool GetPrevEditorPosition( const NoteData& in, int &rowInOut );
-
-	void SetHopoPossibleFlags( const Song *pSong, NoteData& ndInOut );
 	
 	/** @brief Count the number of hold ticks that will fire, assuming that tickholds are on.
 	  * @param td The TimingData from the relevant Steps. */

--- a/src/NoteDisplay.cpp
+++ b/src/NoteDisplay.cpp
@@ -501,8 +501,6 @@ bool NoteDisplay::DrawHoldsInRange(const NoteFieldRenderArgs& field_args,
 		}
 
 		bool is_addition = (tn.source == TapNoteSource_Addition);
-		bool hopo_possible = (tn.bHopoPossible);
-		bool use_addition_coloring = is_addition || hopo_possible;
 		const bool hold_ghost_showing = tn.HoldResult.bActive  &&  tn.HoldResult.fLife > 0;
 		const bool is_holding = tn.HoldResult.bHeld;
 		if(hold_ghost_showing)
@@ -520,7 +518,7 @@ bool NoteDisplay::DrawHoldsInRange(const NoteFieldRenderArgs& field_args,
 		}
 
 		DrawHold(tn, field_args, column_args, start_row, is_holding, result,
-			use_addition_coloring,
+			is_addition,
 			in_selection_range ? field_args.selection_glow : field_args.fail_fade);
 
 		bool note_upcoming = NoteRowToBeat(start_row) >
@@ -602,12 +600,10 @@ bool NoteDisplay::DrawTapsInRange(const NoteFieldRenderArgs& field_args,
 		}
 
 		bool is_addition = (tn.source == TapNoteSource_Addition);
-		bool hopo_possible = (tn.bHopoPossible);
-		bool use_addition_coloring = is_addition || hopo_possible;
 		DrawTap(tn, field_args, column_args,
 			NoteRowToVisibleBeat(m_pPlayerState, tap_row),
 			hold_begins_on_this_beat, roll_begins_on_this_beat,
-			use_addition_coloring,
+			is_addition,
 			in_selection_range ? field_args.selection_glow : field_args.fail_fade);
 
 		any_upcoming |= NoteRowToBeat(tap_row) >

--- a/src/NoteTypes.h
+++ b/src/NoteTypes.h
@@ -138,8 +138,6 @@ struct TapNote
 	TapNoteResult	result;
 	/** @brief The Player that is supposed to hit this note. This is mainly for Routine Mode. */
 	PlayerNumber	pn;
-	/** @brief Can this note be hammered on or pulled off? This is set before gameplay begins. */
-	bool		bHopoPossible;
 
 	// used only if Type == attack:
 	RString		sAttackModifiers;
@@ -160,16 +158,14 @@ struct TapNote
 	void PushSelf( lua_State *L );
 
 	TapNote(): type(TapNoteType_Empty), subType(TapNoteSubType_Invalid),
-		source(TapNoteSource_Original),	result(), pn(PLAYER_INVALID), 
-		bHopoPossible(false), sAttackModifiers(""), fAttackDurationSeconds(0), 
-		iKeysoundIndex(-1), iDuration(0), HoldResult() {}
+		source(TapNoteSource_Original),	result(), pn(PLAYER_INVALID),  sAttackModifiers(""), 
+		fAttackDurationSeconds(0), iKeysoundIndex(-1), iDuration(0), HoldResult() {}
 	void Init()
 	{
 		type = TapNoteType_Empty;
 		subType = TapNoteSubType_Invalid; 
 		source = TapNoteSource_Original; 
 		pn = PLAYER_INVALID, 
-		bHopoPossible = false;
 		fAttackDurationSeconds = 0.f; 
 		iKeysoundIndex = -1;
 		iDuration = 0;
@@ -182,8 +178,7 @@ struct TapNote
 		float fAttackDurationSeconds_,
 		int iKeysoundIndex_ ):
 		type(type_), subType(subType_), source(source_), result(),
-		pn(PLAYER_INVALID), bHopoPossible(false),
-		sAttackModifiers(sAttackModifiers_),
+		pn(PLAYER_INVALID), sAttackModifiers(sAttackModifiers_),
 		fAttackDurationSeconds(fAttackDurationSeconds_),
 		iKeysoundIndex(iKeysoundIndex_), iDuration(0), HoldResult()
 	{

--- a/src/Player.cpp
+++ b/src/Player.cpp
@@ -150,8 +150,6 @@ static Preference<float> m_fMaxInputLatencySeconds	( "MaxInputLatencySeconds",	0
 static Preference<bool> g_bEnableAttackSoundPlayback	( "EnableAttackSounds", true );
 static Preference<bool> g_bEnableMineSoundPlayback	( "EnableMineHitSound", true );
 
-Preference<float> g_fTimingWindowHopo		( "TimingWindowHopo",		0.25 );		// max time between notes in a hopo chain
-Preference<float> g_fTimingWindowStrum		( "TimingWindowStrum",		0.1f );		// max time between strum and when the frets must match
 /** @brief How much life is in a hold note when you start on it? */
 ThemeMetric<float> INITIAL_HOLD_LIFE		( "Player", "InitialHoldLife" );
 /**
@@ -936,13 +934,6 @@ void Player::Update( float fDeltaTime )
 	// during pause.
 	if( m_bPaused )
 		return;
-
-	// Check for a strum miss
-	if( m_pPlayerState->m_fLastStrumMusicSeconds != -1  &&
-		m_pPlayerState->m_fLastStrumMusicSeconds + g_fTimingWindowStrum < m_pPlayerState->m_Position.m_fMusicSeconds )
-	{
-		DoStrumMiss();
-	}
 
 	// update pressed flag
 	const int iNumCols = GAMESTATE->GetCurrentStyle(GetPlayerState()->m_PlayerNumber)->m_iColsPerPlayer;
@@ -1843,124 +1834,6 @@ bool Player::IsOniDead() const
 	return m_pPlayerState->m_PlayerOptions.GetStage().m_LifeType == LifeType_Battery && m_pPlayerStageStats  && m_pPlayerStageStats->m_bFailed;
 }
 
-void Player::Fret( int col, int row, const RageTimer &tm, bool bHeld, bool bRelease )
-{
-	if( IsOniDead() )
-		return;
-
-	DEBUG_ASSERT_M( col >= 0  &&  col <= m_NoteData.GetNumTracks(), ssprintf("%i, %i", col, m_NoteData.GetNumTracks()) );
-
-	m_vbFretIsDown[ col ] = !bRelease;
-
-
-	// Handle changing fret during a strum
-	if( m_pPlayerState->m_fLastStrumMusicSeconds != -1 )
-	{
-		LOG->Trace( "StrumTry" );
-		StepStrumHopo( col, row, tm, bHeld, bRelease, ButtonType_StrumFretsChanged );
-	}
-
-	// Handle hammer-ons and pull-offs
-	const float fPositionSeconds = m_pPlayerState->m_Position.m_fMusicSeconds - tm.Ago();
-	int iHopoCol = -1;
-	bool bDoHopo = 
-		m_pPlayerState->m_fLastHopoNoteMusicSeconds != -1  &&
-		fPositionSeconds <= m_pPlayerState->m_fLastHopoNoteMusicSeconds + g_fTimingWindowHopo;
-	if( bDoHopo )
-	{
-		// do a Hopo:
-		//  - on pressed fret is no higher fret is held
-		//  - on next lowest held fret when the highest held fret is released
-		bool bHigherFretIsDown = false;
-		for( int i=col+1; i<m_NoteData.GetNumTracks(); i++ )
-		{
-			if( m_vbFretIsDown[i] )
-			{
-				bHigherFretIsDown = true;
-				break;
-			}
-		}
-		if( bHigherFretIsDown )
-			bDoHopo = false;
-	}
-
-	if( bDoHopo )
-	{
-		if( !bRelease )
-		{
-			// hammer-on
-			iHopoCol = col;
-		}
-		else
-		{
-			// pull-off
-			// find next lowest fret that is held
-			for( int i=col-1; i>=0; i-- )
-			{
-				if( m_vbFretIsDown[i] )
-				{
-					iHopoCol = i;
-					break;
-				}
-			}
-			if( iHopoCol == -1 )
-				bDoHopo = false;
-		}
-	}
-
-	if( bDoHopo )
-		Hopo( iHopoCol, row, tm, bHeld, bRelease );
-
-	// Check if this fret breaks all active holds.
-	if( !bRelease )
-	{
-		const float fSongBeat = m_pPlayerState->m_Position.m_fSongBeat;
-		const int iSongRow = BeatToNoteRow( fSongBeat );
-
-		int iMaxHoldCol = -1;
-		int iNumColsHeld = 0;
-
-		// Score all active holds to NotHeld
-		for( int iTrack=0; iTrack<m_NoteData.GetNumTracks(); ++iTrack )
-		{
-			// Since this is being called every frame, let's not check the whole array every time.
-			// Instead, only check 1 beat back.  Even 1 is overkill.
-			const int iStartCheckingAt = max( 0, iSongRow-BeatToNoteRow(1) );
-			NoteData::TrackMap::iterator begin, end;
-			m_NoteData.GetTapNoteRangeInclusive( iTrack, iStartCheckingAt, iSongRow+1, begin, end );
-			for( ; begin != end; ++begin )
-			{
-				TapNote &tn = begin->second;
-				if( tn.HoldResult.bActive )
-				{
-					iMaxHoldCol = iTrack;
-					iNumColsHeld++;
-				}
-			}
-		}
-
-		// Any frets to the right of an active hold will break the hold.
-		if( col > iMaxHoldCol  ||  iNumColsHeld >= 2 )
-			ScoreAllActiveHoldsLetGo();
-	}
-}
-
-
-void Player::Strum( int col, int row, const RageTimer &tm, bool bHeld, bool bRelease )
-{
-	if( bRelease )
-		return;
-
-	if( m_pPlayerState->m_fLastStrumMusicSeconds != -1 )
-	{
-		DoStrumMiss();
-	}
-
-	m_pPlayerState->m_fLastStrumMusicSeconds = m_pPlayerState->m_Position.m_fMusicSeconds;
-
-	StepStrumHopo( col, row, tm, bHeld, bRelease, ButtonType_StrumFretsChanged );
-}
-
 void Player::DoTapScoreNone()
 {
 	Message msg( "ScoreNone" );
@@ -1990,14 +1863,6 @@ void Player::DoTapScoreNone()
 		SetJudgment( BeatToNoteRow( m_pPlayerState->m_Position.m_fSongBeat ), -1, TAP_EMPTY, TNS_Miss, 0 );
 		// the ScoreKeeper will subtract points later.
 	}
-}
-
-void Player::DoStrumMiss()
-{
-	m_pPlayerState->m_fLastStrumMusicSeconds = -1;
-	DoTapScoreNone();
-
-	ScoreAllActiveHoldsLetGo();
 }
 
 void Player::ScoreAllActiveHoldsLetGo()
@@ -2062,7 +1927,7 @@ void Player::PlayKeysound( const TapNote &tn, TapNoteScore score )
 	}
 }
 
-void Player::StepStrumHopo( int col, int row, const RageTimer &tm, bool bHeld, bool bRelease, Player::ButtonType pbt )
+void Player::Step( int col, int row, const RageTimer &tm, bool bHeld, bool bRelease )
 {
 	if( IsOniDead() )
 		return;
@@ -2072,18 +1937,6 @@ void Player::StepStrumHopo( int col, int row, const RageTimer &tm, bool bHeld, b
 	const float fLastBeatUpdate = m_pPlayerState->m_Position.m_LastBeatUpdate.Ago();
 	const float fPositionSeconds = m_pPlayerState->m_Position.m_fMusicSeconds - tm.Ago();
 	const float fTimeSinceStep = tm.Ago();
-
-	switch( pbt )
-	{
-	DEFAULT_FAIL(pbt);
-	case ButtonType_Step:
-		break;
-	case ButtonType_StrumFretsChanged:
-	case ButtonType_Hopo:
-		// releasing should hit regular notes, not lifts
-		bRelease = false;
-		break;
-	}
 
 	float fSongBeat = m_pPlayerState->m_Position.m_fSongBeat;
 	
@@ -2227,19 +2080,7 @@ void Player::StepStrumHopo( int col, int row, const RageTimer &tm, bool bHeld, b
 	) + ROWS_PER_BEAT;
 	int iRowOfOverlappingNoteOrRow = row;
 	if( row == -1 )
-	{
-		switch( pbt )
-		{
-		DEFAULT_FAIL(pbt);
-		case ButtonType_StrumFretsChanged:
-			iRowOfOverlappingNoteOrRow = GetClosestNonEmptyRow( iSongRow, iStepSearchRows, iStepSearchRows, false );
-			break;
-		case ButtonType_Hopo:
-		case ButtonType_Step:
-			iRowOfOverlappingNoteOrRow = GetClosestNote( col, iSongRow, iStepSearchRows, iStepSearchRows, false );
-			break;
-		}
-	}
+		iRowOfOverlappingNoteOrRow = GetClosestNote( col, iSongRow, iStepSearchRows, iStepSearchRows, false );
 
 	// calculate TapNoteScore
 	TapNoteScore score = TNS_None;
@@ -2277,19 +2118,9 @@ void Player::StepStrumHopo( int col, int row, const RageTimer &tm, bool bHeld, b
 
 		TapNote tnDummy = TAP_ORIGINAL_TAP;
 		TapNote *pTN = NULL;
-		switch( pbt )
-		{
-		DEFAULT_FAIL(pbt);
-		case ButtonType_StrumFretsChanged:
-			pTN = &tnDummy;
-			break;
-		case ButtonType_Hopo:
-		case ButtonType_Step:
-			NoteData::iterator iter = m_NoteData.FindTapNote( col, iRowOfOverlappingNoteOrRow );
-			DEBUG_ASSERT( iter!= m_NoteData.end(col) );
-			pTN = &iter->second;
-			break;
-		}
+		NoteData::iterator iter = m_NoteData.FindTapNote( col, iRowOfOverlappingNoteOrRow );
+		DEBUG_ASSERT( iter!= m_NoteData.end(col) );
+		pTN = &iter->second;
 
 		switch( m_pPlayerState->m_PlayerController )
 		{
@@ -2451,99 +2282,6 @@ void Player::StepStrumHopo( int col, int row, const RageTimer &tm, bool bHeld, b
 			FAIL_M(ssprintf("Invalid player controller type: %i", m_pPlayerState->m_PlayerController));
 		}
 
-		switch( pbt )
-		{
-		DEFAULT_FAIL(pbt);
-		case ButtonType_StrumFretsChanged:
-			{
-				bool bNoteRowMatchesFrets = true;
-				int iFirstNoteCol = -1;
-				for( int i=0; i<GAMESTATE->GetCurrentStyle(GetPlayerState()->m_PlayerNumber)->m_iColsPerPlayer; i++ )
-				{
-					const TapNote &tn = m_NoteData.GetTapNote( i, iRowOfOverlappingNoteOrRow );
-					bool bIsNote = (tn.type != TapNoteType_Empty);
-					if( iFirstNoteCol == -1  &&  bIsNote )
-						iFirstNoteCol = i;
-
-					// Extra notes to the left (higher up on the string) can be held without penalty.  It's necessary to hold
-					// the extra frets or pull-offs.
-					if( iFirstNoteCol == -1 )
-						continue;
-
-					bool bNoteMatchesFret = m_vbFretIsDown[i] == bIsNote;
-					if( !bNoteMatchesFret )
-					{
-						bNoteRowMatchesFrets = false;
-						break;
-					}
-				}
-				ASSERT( iFirstNoteCol != -1 );
-				if( !bNoteRowMatchesFrets )
-				{
-					score = TNS_None;
-				}
-				else
-				{
-					int iLastNoteCol = -1;
-					for( int i=GAMESTATE->GetCurrentStyle(GetPlayerState()->m_PlayerNumber)->m_iColsPerPlayer-1; i>=0; i-- )
-					{
-						const TapNote &tn = m_NoteData.GetTapNote( i, iRowOfOverlappingNoteOrRow );
-						bool bIsNote = (tn.type != TapNoteType_Empty);
-						if( bIsNote )
-						{
-							iLastNoteCol = i;
-							break;
-						}
-					}
-
-					m_pPlayerState->m_fLastHopoNoteMusicSeconds = fStepSeconds;
-					m_pPlayerState->m_iLastHopoNoteCol = iLastNoteCol; 
-				}
-			}
-			break;
-		case ButtonType_Hopo:
-			{
-				// only can hopo on a row with one note
-				if( m_NoteData.GetNumTapNotesInRow(iRowOfOverlappingNoteOrRow) != 1 )
-				{
-					score = TNS_None;
-					break;
-				}
-
-				// con't hopo on the same note 2x in a row
-				if( col == m_pPlayerState->m_iLastHopoNoteCol )
-				{
-					score = TNS_None;
-					break;
-				}
-
-				const TapNote &tn = m_NoteData.GetTapNote( col, iRowOfOverlappingNoteOrRow );
-				ASSERT( tn.type != TapNoteType_Empty );
-
-				int iRowsAgoLastNote = 100000;	// TODO: find more reasonable value based on HOPO_CHAIN_SECONDS?
-				NoteData::all_tracks_reverse_iterator iter = m_NoteData.GetTapNoteRangeAllTracksReverse( iRowsAgoLastNote-iRowsAgoLastNote, iRowOfOverlappingNoteOrRow-1 );
-				ASSERT( !iter.IsAtEnd() );	// there must have been a note that started the hopo
-				if( !NoteDataWithScoring::IsRowCompletelyJudged(m_NoteData, iter.Row()) )
-				{
-					score = TNS_None;
-					break;
-				}
-
-				const TapNoteResult &lastTNR = NoteDataWithScoring::LastTapNoteWithResult( m_NoteData, iter.Row() ).result;
-				if( lastTNR.tns <= TNS_Miss )
-				{
-					score = TNS_None;
-					break;
-				}
-
-				m_pPlayerState->m_fLastHopoNoteMusicSeconds = fStepSeconds;
-				m_pPlayerState->m_iLastHopoNoteCol = col;
-			}
-			break;
-		case ButtonType_Step:
-			break;
-		}
-
 		// handle attack notes
 		if( pTN->type == TapNoteType_Attack && score == TNS_W2 )
 		{
@@ -2586,27 +2324,8 @@ void Player::StepStrumHopo( int col, int row, const RageTimer &tm, bool bHeld, b
 
 		if( score != TNS_None )
 		{
-			switch( pbt )
-			{
-			DEFAULT_FAIL(pbt);
-			case ButtonType_StrumFretsChanged:
-				for( int t=0; t<m_NoteData.GetNumTracks(); t++ )
-				{
-					TapNote tn = m_NoteData.GetTapNote( t, iRowOfOverlappingNoteOrRow );
-					if( tn.type != TapNoteType_Empty )
-					{
-						tn.result.tns = score;
-						tn.result.fTapNoteOffset = -fNoteOffset;
-						m_NoteData.SetTapNote( t, iRowOfOverlappingNoteOrRow, tn );
-					}
-				}
-				break;
-			case ButtonType_Hopo:
-			case ButtonType_Step:
-				pTN->result.tns = score;
-				pTN->result.fTapNoteOffset = -fNoteOffset;
-				break;
-			}
+			pTN->result.tns = score;
+			pTN->result.fTapNoteOffset = -fNoteOffset;
 		}
 
 		m_LastTapNoteScore = score;
@@ -2630,42 +2349,8 @@ void Player::StepStrumHopo( int col, int row, const RageTimer &tm, bool bHeld, b
 		}
 	}
 
-	// check for hopo end
-	if( score <= TNS_Miss )
-	{
-		m_pPlayerState->ClearHopoState();
-	}
-
-	// check for strum end
-	if( score != TNS_None )
-	{
-		switch( pbt )
-		{
-		DEFAULT_FAIL(pbt);
-		case ButtonType_Step:
-			break;
-		case ButtonType_StrumFretsChanged:
-			m_pPlayerState->m_fLastStrumMusicSeconds = -1;
-			break;
-		case ButtonType_Hopo:
-			break;
-		}
-	}
-
 	if( score == TNS_None )
-	{
-		switch( pbt )
-		{
-		DEFAULT_FAIL(pbt);
-		case ButtonType_Step:
-			DoTapScoreNone();
-			break;
-		case ButtonType_StrumFretsChanged:
-		case ButtonType_Hopo:
-			break;
-		}
-
-	}
+		DoTapScoreNone();
 
 	if( !bRelease )
 	{
@@ -2694,23 +2379,8 @@ void Player::StepStrumHopo( int col, int row, const RageTimer &tm, bool bHeld, b
 		}
 		if( iRowOfOverlappingNoteOrRow != -1 )
 		{
-			switch( pbt )
-			{
-			DEFAULT_FAIL(pbt);
-			case ButtonType_StrumFretsChanged:
-				for( int i=0; i<m_NoteData.GetNumTracks(); i++ )
-				{
-					const TapNote &tn = m_NoteData.GetTapNote( i, iRowOfOverlappingNoteOrRow );
-					PlayKeysound( tn, score );
-				}
-				break;
-			case ButtonType_Step:
-			case ButtonType_Hopo:
-				const TapNote &tn = m_NoteData.GetTapNote( col, iRowOfOverlappingNoteOrRow );
-				PlayKeysound( tn, score );
-				break;
-			}
-			
+			const TapNote &tn = m_NoteData.GetTapNote( col, iRowOfOverlappingNoteOrRow );
+			PlayKeysound( tn, score );
 		}
 	}
 	// XXX:
@@ -2718,29 +2388,7 @@ void Player::StepStrumHopo( int col, int row, const RageTimer &tm, bool bHeld, b
 	{
 		if( m_pNoteField )
 		{
-			switch( pbt )
-			{
-			DEFAULT_FAIL(pbt);
-			case ButtonType_StrumFretsChanged:
-				{
-					// only pulse the shortest string fret
-					int iLastFret = -1;
-					for( int i=0; i<m_NoteData.GetNumTracks(); i++ )
-					{
-						if( m_vbFretIsDown[i] )
-							iLastFret = i;
-					}
-					if( iLastFret != -1 ) 
-						m_pNoteField->Step( iLastFret, score );
-				}
-				break;
-			case ButtonType_Step:
-				m_pNoteField->Step( col, score );
-				break;
-			case ButtonType_Hopo:
-				// no animation
-				break;
-			}
+			m_pNoteField->Step( col, score );
 		}
 		Message msg( "Step" );
 		msg.SetParam( "PlayerNumber", m_pPlayerState->m_PlayerNumber );

--- a/src/Player.h
+++ b/src/Player.h
@@ -103,23 +103,10 @@ public:
 		return *(this->m_Timing);
 	}
 
-	// Called when a fret, step, or strum type button changes
-	void Fret( int col, int row, const RageTimer &tm, bool bHeld, bool bRelease );
-
-	// Called when the strum bar is pressed down
-	void Strum( int col, int row, const RageTimer &tm, bool bHeld, bool bRelease );
-
-	// Called when the strum window passes without a row being hit
-	void DoStrumMiss();
 	void ScoreAllActiveHoldsLetGo();
 	void DoTapScoreNone();
 
-	enum ButtonType { ButtonType_Step, ButtonType_StrumFretsChanged, ButtonType_Hopo };
-	void StepStrumHopo( int col, int row, const RageTimer &tm, bool bHeld, bool bRelease, ButtonType gbt );
-	void Step( int col, int row, const RageTimer &tm, bool bHeld, bool bRelease )	{ StepStrumHopo(col, row, tm, bHeld, bRelease, ButtonType_Step); }
-
-	// called by Fret for Hammer-ons and Pull-offs
-	void Hopo( int col, int row, const RageTimer &tm, bool bHeld, bool bRelease )	{ StepStrumHopo(col, row, tm, bHeld, bRelease, ButtonType_Hopo); }
+	void Step( int col, int row, const RageTimer &tm, bool bHeld, bool bRelease );
 
 	void FadeToFail();
 	void CacheAllUsedNoteSkins();

--- a/src/PlayerState.cpp
+++ b/src/PlayerState.cpp
@@ -23,9 +23,6 @@ void PlayerState::Reset()
 
 	m_HealthState = HealthState_Alive;
 
-	m_fLastHopoNoteMusicSeconds = -1;
-	m_iLastHopoNoteCol = -1;
-
 	m_PlayerController = PC_HUMAN;
 
 	m_iCpuSkill = 5;
@@ -46,8 +43,6 @@ void PlayerState::Reset()
 	for( int i=0; i<NUM_INVENTORY_SLOTS; i++ )
 		m_Inventory[i].MakeBlank();
 
-	m_fLastStrumMusicSeconds = -1;
-	ClearHopoState();
 }
 
 void PlayerState::Update( float fDelta )

--- a/src/PlayerState.h
+++ b/src/PlayerState.h
@@ -94,28 +94,6 @@ public:
 	/** @brief The Player's HealthState in general terms. */
 	HealthState		m_HealthState;
 
-	/**
-	 * @brief Set to the MusicSeconds of when the a strum button was pressed. 
-	 *
-	 * If -1, the strum window has passed. */
-	float		m_fLastStrumMusicSeconds;
-	/**
-	 * @brief Set to the MusicSeconds of the last note successfully strummed or hammered in a hopochain.
-	 *
-	 * If -1, then there is no current hopo chain. */
-	float		m_fLastHopoNoteMusicSeconds;
-	/**
-	 * @brief Set to the column in the current hopo chain.
-	 *
-	 * If -1, then there is no current hopo chain. */
-	int			m_iLastHopoNoteCol;
-
-	/** @brief Reset the hopo state to its default. */
-	void ClearHopoState()
-	{
-		m_fLastHopoNoteMusicSeconds = -1;
-		m_iLastHopoNoteCol = -1;
-	}
 	/** @brief The type of person/machine controlling the Player. */
 	PlayerController	m_PlayerController;
 

--- a/src/ScreenEdit.cpp
+++ b/src/ScreenEdit.cpp
@@ -3230,7 +3230,7 @@ bool ScreenEdit::InputPlay( const InputEventPlus &input, EditButton EditB )
 		}
 	}
 
-	if( gbt == GameButtonType_INVALID  &&  input.type == IET_FIRST_PRESS )
+	if( gbt == GameButtonType_Menu  &&  input.type == IET_FIRST_PRESS )
 	{
 		switch( EditB )
 		{

--- a/src/ScreenEdit.cpp
+++ b/src/ScreenEdit.cpp
@@ -3222,13 +3222,6 @@ bool ScreenEdit::InputPlay( const InputEventPlus &input, EditButton EditB )
 					if( iCol != -1 )
 						m_Player->Step( iCol, -1, input.DeviceI.ts, false, bRelease );
 					return true;
-				case GameButtonType_Fret:
-					if( iCol != -1 )
-						m_Player->Fret( iCol, -1, input.DeviceI.ts, false, bRelease );
-					return true;
-				case GameButtonType_Strum:
-					m_Player->Strum( iCol, -1, input.DeviceI.ts, false, bRelease );
-					return true;
 				default:
 					break;
 				}

--- a/src/ScreenGameplay.cpp
+++ b/src/ScreenGameplay.cpp
@@ -2568,7 +2568,7 @@ bool ScreenGameplay::Input( const InputEventPlus &input )
 				GameButtonType gbt = GAMESTATE->m_pCurGame->GetPerButtonInfo(input.GameI.button)->m_gbt;
 				switch( gbt )
 				{
-				case GameButtonType_INVALID:
+				case GameButtonType_Menu:
 					return false;
 				case GameButtonType_Step:
 					if( iCol != -1 )

--- a/src/ScreenGameplay.cpp
+++ b/src/ScreenGameplay.cpp
@@ -2574,13 +2574,6 @@ bool ScreenGameplay::Input( const InputEventPlus &input )
 					if( iCol != -1 )
 						pi.m_pPlayer->Step( iCol, -1, input.DeviceI.ts, false, bRelease );
 					return true;
-				case GameButtonType_Fret:
-					if( iCol != -1 )
-						pi.m_pPlayer->Fret( iCol, -1, input.DeviceI.ts, false, bRelease );
-					return true;
-				case GameButtonType_Strum:
-					pi.m_pPlayer->Strum( iCol, -1, input.DeviceI.ts, false, bRelease );
-					return true;
 				}
 			}
 		}


### PR DESCRIPTION
There was a bunch of code for handling guitar-specific input such as hammer-ons/pull-offs and strumming. Given that guitar was removed, and as far as I understand, will not be added back into SM5, it makes sense to remove code that had no other use.

I have tested this, everything seems to work fine.