### PR TITLE
Unrestrict pop'n judgment levels

### DIFF
--- a/src/GameManager.cpp
+++ b/src/GameManager.cpp
@@ -2714,11 +2714,11 @@ static const Game g_Game_Popn =
 		{ GameButtonType_Step },
 		{ GameButtonType_Step },
 	},
-	TNS_W2,		// m_mapW1To
-	TNS_W2,		// m_mapW2To
-	TNS_W3,		// m_mapW3To
-	TNS_W3,		// m_mapW4To
-	TNS_Miss,	// m_mapW5To
+	TNS_W1,	// m_mapW1To
+	TNS_W2,	// m_mapW2To
+	TNS_W3,	// m_mapW3To
+	TNS_W4,	// m_mapW4To
+	TNS_W5,	// m_mapW5To
 };
 
 /** Lights *******************************************************************/


### PR DESCRIPTION
It made some sort of sense to only have three judgment levels before, but it makes far more sense to let the theme manage it now, instead of being hard coded into the engine, since it isn't necessarily the case anymore.