### PR TITLE
Fix Texture Font Generator PNG write

### DIFF
--- a/src/RageSurface_Save_PNG.cpp
+++ b/src/RageSurface_Save_PNG.cpp
@@ -90,7 +90,7 @@ static bool RageSurface_Save_PNG( RageFile &f, char szErrorbuf[1024], RageSurfac
 	png_info *pInfo = png_create_info_struct(pPng);
 	if( pInfo == NULL )
 	{
-		png_destroy_read_struct( &pPng, NULL, NULL );
+		png_destroy_write_struct( &pPng, NULL );
 		if( bDeleteImg )
 			delete pImg;
 		sprintf( szErrorbuf, "creating png_create_info_struct failed");
@@ -99,7 +99,7 @@ static bool RageSurface_Save_PNG( RageFile &f, char szErrorbuf[1024], RageSurfac
 
 	if( setjmp(png_jmpbuf(pPng)) )
 	{
-		png_destroy_read_struct( &pPng, &pInfo, NULL );
+		png_destroy_write_struct( &pPng, &pInfo );
 		return false;
 	}
 

--- a/src/Texture Font Generator/Utils.cpp
+++ b/src/Texture Font Generator/Utils.cpp
@@ -180,7 +180,6 @@ bool SavePNG( FILE *f, char szErrorbuf[1024], const Surface *pSurf )
 		PNG_INTERLACE_NONE, PNG_COMPRESSION_TYPE_BASE, PNG_FILTER_TYPE_BASE );
 
 	png_write_info( pPng, pInfo );
-	png_set_filler( pPng, 0, PNG_FILLER_AFTER );
 
 	png_byte *pixels = (png_byte *) pSurf->pRGBA;
 	for( int y = 0; y < pSurf->iHeight; y++ )

--- a/src/Texture Font Generator/Utils.cpp
+++ b/src/Texture Font Generator/Utils.cpp
@@ -162,14 +162,14 @@ bool SavePNG( FILE *f, char szErrorbuf[1024], const Surface *pSurf )
 	png_info *pInfo = png_create_info_struct(pPng);
 	if( pInfo == NULL )
 	{
-		png_destroy_read_struct( &pPng, NULL, NULL );
+		png_destroy_write_struct( &pPng, NULL );
 		sprintf( szErrorbuf, "creating png_create_info_struct failed");
 		return false;
 	}
 
 	if( setjmp(png_jmpbuf(pPng)) )
 	{
-		png_destroy_read_struct( &pPng, &pInfo, NULL );
+		png_destroy_write_struct( &pPng, &pInfo );
 		return false;
 	}
 


### PR DESCRIPTION
Using the correct "destroy" function for the `png_struct` in `SavePNG` (`png_destroy_write_struct` as opposed to `png_destroy_read_struct`) seems to prevent the crash described in #964 . Removing the "filler" transformation function specification (`png_set_filler`) in Texture Font Generator's `SavePNG` allows the PNG creation to succeed (no filler transformation is necessary when we're writing an RGBA image to a PNG with alpha channel).