### PR TITLE
Ignore OS X special files

### DIFF
--- a/src/RageFileManager.cpp
+++ b/src/RageFileManager.cpp
@@ -432,6 +432,22 @@ void RageFileManager::GetDirListing( const RString &sPath_, vector<RString> &Add
 
 	UnreferenceAllDrivers( apDriverList );
 
+	// Remove files that start with ._ from the list because these are special
+	// OS X files that cause interference on other platforms. -Kyz
+	for(size_t i= iOldSize; i < AddTo.size(); ++i)
+	{
+		size_t last_slash= AddTo[i].rfind('/');
+		last_slash= (last_slash == string::npos) ? 0 : (last_slash+1);
+		if(last_slash < AddTo[i].size() - 1)
+		{
+			if(AddTo[i][last_slash] == '.' && AddTo[i][last_slash+1] == '_')
+			{
+				AddTo.erase(AddTo.begin() + i);
+				--i;
+			}
+		}
+	}
+
 	if( iDriversThatReturnedFiles > 1 )
 	{
 		/* More than one driver returned files.  Remove duplicates (case-insensitively). */


### PR DESCRIPTION
This should fix problems that occur when moving simfiles from an OS X machine to another platform, which tends to create files that start with "._".  This can cause songs to not load.
I don't have any simfiles from an OS X machine to test with, so someone else needs to check this.