### PR TITLE
Apply inverse bind pose matrix for per-mesh bones

### DIFF
--- a/src/Model.cpp
+++ b/src/Model.cpp
@@ -511,6 +511,14 @@ void Model::DrawMesh( int i ) const
 
 		const Rage::Matrix &mat = m_vpBones[pMesh->m_iBoneIndex].m_Final;
 		DISPLAY->PreMultMatrix( mat );
+
+		Rage::Matrix inverse = m_vpBones[pMesh->m_iBoneIndex].m_Absolute.GetTranspose();
+		Rage::Vector3 vTmp = Rage::Vector3( inverse.m[3][0], inverse.m[3][1], inverse.m[3][2] );
+		vTmp = vTmp.TransformNormal( inverse );
+		inverse.m[3][0] = -vTmp.x;
+		inverse.m[3][1] = -vTmp.y;
+		inverse.m[3][2] = -vTmp.z;
+		DISPLAY->PreMultMatrix( inverse );
 	}
 
 	// Draw it

--- a/src/rage/RageMath.hpp
+++ b/src/rage/RageMath.hpp
@@ -28,7 +28,7 @@ namespace Rage
 	/** @brief Calculate the sin of a number quickly. */
 	float FastSin( float x );
 	
-	/** @brief Claculate the cosine of a number quickly. */
+	/** @brief Calculate the cosine of a number quickly. */
 	float FastCos( float x );
 
 	/** @brief Bring a value within range. */


### PR DESCRIPTION
This fixes bones and animations for models with per-mesh bones.