### PR TITLE
Compile dependencies statically into the binary.

### DIFF
--- a/extern/CMakeProject-glew.cmake
+++ b/extern/CMakeProject-glew.cmake
@@ -2,7 +2,7 @@ set(GLEW_SRC "glew-1.5.8/src/glew.c")
 
 source_group("" FILES ${GLEW_SRC})
 
-add_library("glew" ${GLEW_SRC})
+add_library("glew" STATIC ${GLEW_SRC})
 
 set_property(TARGET "glew" PROPERTY FOLDER "External Libraries")
 

--- a/extern/CMakeProject-json.cmake
+++ b/extern/CMakeProject-json.cmake
@@ -16,7 +16,7 @@ list(APPEND JSON_HPP
 
 source_group("" FILES ${JSON_SRC} ${JSON_HPP})
 
-add_library("jsoncpp" ${JSON_SRC} ${JSON_HPP})
+add_library("jsoncpp" STATIC ${JSON_SRC} ${JSON_HPP})
 
 set_property(TARGET "jsoncpp" PROPERTY FOLDER "External Libraries")
 

--- a/extern/CMakeProject-lua.cmake
+++ b/extern/CMakeProject-lua.cmake
@@ -58,7 +58,7 @@ set(LUA_HPP
 source_group("" FILES ${LUA_SRC})
 source_group("" FILES ${LUA_HPP})
 
-add_library("lua-5.1" ${LUA_SRC} ${LUA_HPP})
+add_library("lua-5.1" STATIC ${LUA_SRC} ${LUA_HPP})
 
 set_property(TARGET "lua-5.1" PROPERTY FOLDER "External Libraries")
 

--- a/extern/CMakeProject-mad.cmake
+++ b/extern/CMakeProject-mad.cmake
@@ -43,7 +43,7 @@ source_group("Source Files" FILES ${MAD_SRC})
 source_group("Header Files" FILES ${MAD_HPP})
 source_group("Data Files" FILES ${MAD_DAT})
 
-add_library("mad" ${MAD_SRC} ${MAD_HPP} ${MAD_DAT})
+add_library("mad" STATIC ${MAD_SRC} ${MAD_HPP} ${MAD_DAT})
 
 set_property(TARGET "mad" PROPERTY FOLDER "External Libraries")
 

--- a/extern/CMakeProject-ogg.cmake
+++ b/extern/CMakeProject-ogg.cmake
@@ -14,7 +14,7 @@ list(APPEND OGG_HPP
 source_group("Source Files" FILES ${OGG_SRC})
 source_group("Header Files" FILES ${OGG_HPP})
 
-add_library("ogg" ${OGG_SRC} ${OGG_HPP} ${OGG_DAT})
+add_library("ogg" STATIC ${OGG_SRC} ${OGG_HPP} ${OGG_DAT})
 
 set_property(TARGET "ogg" PROPERTY FOLDER "External Libraries")
 

--- a/extern/CMakeProject-png.cmake
+++ b/extern/CMakeProject-png.cmake
@@ -30,7 +30,7 @@ set(PNG_HPP
 source_group("" FILES ${PNG_SRC})
 source_group("" FILES ${PNG_HPP})
 
-add_library("png" ${PNG_SRC} ${PNG_HPP})
+add_library("png" STATIC ${PNG_SRC} ${PNG_HPP})
 
 set_property(TARGET "png" PROPERTY FOLDER "External Libraries")
 

--- a/extern/CMakeProject-tomcrypt.cmake
+++ b/extern/CMakeProject-tomcrypt.cmake
@@ -265,7 +265,7 @@ list(APPEND TOMCRYPT_HPP
 
 source_group("headers" FILES ${TOMCRYPT_HPP})
 
-add_library("tomcrypt" ${TOMCRYPT_SRC} ${TOMCRYPT_HPP})
+add_library("tomcrypt" STATIC ${TOMCRYPT_SRC} ${TOMCRYPT_HPP})
 
 set_property(TARGET "tomcrypt" PROPERTY FOLDER "External Libraries")
 

--- a/extern/CMakeProject-tommath.cmake
+++ b/extern/CMakeProject-tommath.cmake
@@ -131,7 +131,7 @@ list(APPEND TOMMATH_HPP
 source_group("" FILES ${TOMMATH_SRC})
 source_group("" FILES ${TOMMATH_HPP})
 
-add_library("tommath" ${TOMMATH_SRC} ${TOMMATH_HPP})
+add_library("tommath" STATIC ${TOMMATH_SRC} ${TOMMATH_HPP})
 
 set_property(TARGET "tommath" PROPERTY FOLDER "External Libraries")
 


### PR DESCRIPTION
On Linux when building this under RPM, RPM insists on linking in standard system libraries like libpng, libjpeg-turbo, libGLEW, Lua, etc. because we are removing the RPATH from the binary for security reasons. This patch causes all dependencies to be statically compiled into the binary, which is ideal as the alternative is segfaulting because of incompatible library changes.

StepMania also uses a modified Lua library which exports functions that don't exist in any standard Lua library, so there's no easy way around this.

The only other solution appears to be to rewrite StepMania source code to update it to use modern libraries, but that doesn't seem likely to happen and would involve a lot of effort.

This solves #1008.
