### PR TITLE
Compile FFMPEG in PIC when configured as such.

### DIFF
--- a/CMake/SetupFfmpeg.cmake
+++ b/CMake/SetupFfmpeg.cmake
@@ -22,6 +22,10 @@ list(APPEND FFMPEG_CONFIGURE
   "--enable-static"
 )
 
+if(CMAKE_POSITION_INDEPENDENT_CODE)
+    list(APPEND FFMPEG_CONFIGURE "--enable-pic")
+endif()
+
 if(MACOSX)
   # TODO: Remove these two items when Mac OS X StepMania builds in 64-bit.
   list(APPEND FFMPEG_CONFIGURE


### PR DESCRIPTION
When the CMake flag is specified for position independent code, FFMPEG will be compiled with the `--enable-pic` flag.

This fixes a broken build on recent Fedoras and other platforms desiring hardened builds.