### PR TITLE
Checking for first second now ignores autokeysounds

### DIFF
--- a/src/NoteData.cpp
+++ b/src/NoteData.cpp
@@ -422,7 +422,7 @@ int NoteData::GetFirstRow() const
 	for( int t=0; t < GetNumTracks(); t++ )
 	{
 		int iRow = -1;
-		if( !GetNextTapNoteRowForTrack( t, iRow ) )
+		if( !GetNextTapNoteRowForTrack( t, iRow, true ) )
 			continue;
 
 		if( iEarliestRowFoundSoFar == -1 )
@@ -972,7 +972,7 @@ int NoteData::GetNumTracksHeldAtRow( int row )
 	return viTracks.size();
 }
 
-bool NoteData::GetNextTapNoteRowForTrack( int track, int &rowInOut ) const
+bool NoteData::GetNextTapNoteRowForTrack( int track, int &rowInOut, bool ignoreAutoKeysounds ) const
 {
 	const TrackMap &mapTrack = m_TapNotes[track];
 
@@ -987,6 +987,14 @@ bool NoteData::GetNextTapNoteRowForTrack( int track, int &rowInOut ) const
 		return false;
 
 	ASSERT( iter->first > rowInOut );
+
+	// If we want to ignore autokeysounds, keep going until we find a real note.
+	if(ignoreAutoKeysounds) {
+		while(iter->second.type == TapNoteType_AutoKeysound) {
+			iter++;
+			if(iter==mapTrack.end()) return false;
+		}
+	}
 	rowInOut = iter->first;
 	return true;
 }

--- a/src/NoteData.h
+++ b/src/NoteData.h
@@ -243,7 +243,7 @@ public:
 
 
 	/* Returns the row of the first TapNote on the track that has a row greater than rowInOut. */
-	bool GetNextTapNoteRowForTrack( int track, int &rowInOut ) const;
+	bool GetNextTapNoteRowForTrack( int track, int &rowInOut, bool ignoreKeySounds=false ) const;
 	bool GetNextTapNoteRowForAllTracks( int &rowInOut ) const;
 	bool GetPrevTapNoteRowForTrack( int track, int &rowInOut ) const;
 	bool GetPrevTapNoteRowForAllTracks( int &rowInOut ) const;

--- a/src/NotesLoaderBMS.cpp
+++ b/src/NotesLoaderBMS.cpp
@@ -962,8 +962,8 @@ StepsType BMSChartReader::DetermineStepsType()
 					// type, since they are more common.
 					//return StepsType_dance_solo;
 					return StepsType_beat_single5;
-				// az: Allow kb7 style charts
-				case 7:		return StepsType_kb7_single;
+				// az: Allow kb7 style charts - this breaks IIDX files right now. Waiting for a proper way to determine steps type.
+				// case 7:		return StepsType_kb7_single;
 				case 8:		return StepsType_beat_single7;
 				case 9:		return StepsType_popn_nine;
 				// XXX: Some double files doesn't have #player.
@@ -1063,7 +1063,7 @@ bool BMSChartReader::ReadNoteData()
 	TimingData td;
 
 	td.m_fBeat0OffsetInSeconds = out->m_Timing.m_fBeat0OffsetInSeconds;
-	
+
 	nd.SetNumTracks( tracks );
 	td.SetBPMAtRow( 0, currentBPM = initialBPM );
 

--- a/src/NotesLoaderBMS.cpp
+++ b/src/NotesLoaderBMS.cpp
@@ -1111,11 +1111,6 @@ bool BMSChartReader::ReadNoteData()
 	TimingData td;
 
 	td.m_fBeat0OffsetInSeconds = out->m_Timing.m_fBeat0OffsetInSeconds;
-<<<<<<< HEAD
-
-=======
-	
->>>>>>> abfff53c2b8aa3033ffa3bc5fc5d05088708067f
 	nd.SetNumTracks( tracks );
 	td.SetBPMAtRow( 0, currentBPM = initialBPM );
 
@@ -1770,8 +1765,4 @@ bool BMSLoader::LoadFromDir( const RString &sDir, Song &out )
  * OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
  * OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
  * PERFORMANCE OF THIS SOFTWARE.
-<<<<<<< HEAD
  */
-=======
- */
->>>>>>> abfff53c2b8aa3033ffa3bc5fc5d05088708067f


### PR DESCRIPTION
When checking for the first second in a song, AutoKeysound notes are now ignored, being treated as if they were background music. This allows the intro of BMS files to play as soon as ScreenGameplay is loaded, while still having a delay before the real notes come in.