### PR TITLE
Add missing ':' key binding

### DIFF
--- a/src/RageInputDevice.cpp
+++ b/src/RageInputDevice.cpp
@@ -26,6 +26,7 @@ static void InitNames()
 
 	g_mapNamesToString[KEY_PERIOD] = "period";
 	g_mapNamesToString[KEY_COMMA] = "comma";
+	g_mapNamesToString[KEY_COLON] = "colon";
 	g_mapNamesToString[KEY_SPACE] = "space";
 	g_mapNamesToString[KEY_DEL] = "delete";
 	g_mapNamesToString[KEY_BACKSLASH] = "backslash";


### PR DESCRIPTION
Add missing ':' (colon) key binding as stated in Keymaps_ini_format.md in the user doc.