### PR TITLE
Clean up three sets of warnings:

### DIFF
--- a/src/ActorMultiVertex.cpp
+++ b/src/ActorMultiVertex.cpp
@@ -326,6 +326,8 @@ void ActorMultiVertex::DrawInternal( const AMV_TweenState *TS )
 			DISPLAY->DrawSymmetricQuadStrip( &TS->vertices[FirstToDraw], NumToDraw );
 			break;
 		}
+		default:
+			break;
 	}
 
 	DISPLAY->SetEffectMode( EffectMode_Normal );
@@ -386,6 +388,8 @@ void ActorMultiVertex::SetVertsFromSplines()
 			break;
 		case DrawMode_LineStrip:
 			SetVertsFromSplinesInternal(1, 0);
+			break;
+		default:
 			break;
 	}
 }
@@ -552,6 +556,8 @@ void ActorMultiVertex::UpdateAnimationState(bool force_update)
 							break;
 					}
 				}
+				break;
+			default:
 				break;
 		}
 	}

--- a/src/NoteDataUtil.cpp
+++ b/src/NoteDataUtil.cpp
@@ -932,6 +932,8 @@ void NoteDataUtil::AutogenKickbox(const NoteData& in, NoteData& out, const Timin
 					this_limb= prev_limb_used == left_fist ? right_fist : left_fist;
 				}
 				break;
+			default:
+				break;
 		}
 		size_t this_panel= prev_limb_panels[this_limb];
 		if(panel_repeat_counts[this_limb] + 1 > panel_repeat_goals[this_limb])
@@ -1116,6 +1118,8 @@ void NoteDataUtil::CalculateRadarValues( const NoteData &in, float fSongSeconds,
 					break;
 				case TapNoteType_Fake:
 					++out[RadarCategory_Fakes];
+					break;
+				default:
 					break;
 			}
 		}

--- a/src/NoteDataWithScoring.cpp
+++ b/src/NoteDataWithScoring.cpp
@@ -373,6 +373,7 @@ void NoteDataWithScoring::GetActualRadarValues(const NoteData &in,
 					state.mines_avoided+= (curr_note->result.tns == TNS_AvoidMine);
 					break;
 				case TapNoteType_Fake:
+				default:
 					break;
 			}
 		}

--- a/src/NoteDisplay.cpp
+++ b/src/NoteDisplay.cpp
@@ -360,6 +360,8 @@ void NoteColumnRenderArgs::spae_pos_for_beat(const PlayerState* player_state,
 		case NCSM_Position:
 			pos_handler->EvalForBeat(song_beat, beat, sp_pos);
 			break;
+		default:
+			break;
 	}
 }
 void NoteColumnRenderArgs::spae_zoom_for_beat(const PlayerState* state, float beat,
@@ -376,6 +378,8 @@ void NoteColumnRenderArgs::spae_zoom_for_beat(const PlayerState* state, float be
 			break;
 		case NCSM_Position:
 			zoom_handler->EvalForBeat(song_beat, beat, sp_zoom);
+			break;
+		default:
 			break;
 	}
 }
@@ -893,6 +897,8 @@ void NoteDisplay::DrawHoldPart(vector<Sprite*> &vpSpr,
 				column_args.pos_handler->EvalDerivForBeat(column_args.song_beat, cur_beat, sp_pos_forward);
 				RageVec3Normalize(&sp_pos_forward, &sp_pos_forward);
 				break;
+			default:
+				break;
 		}
 
 		render_forward.x+= sp_pos_forward.x;
@@ -918,6 +924,8 @@ void NoteDisplay::DrawHoldPart(vector<Sprite*> &vpSpr,
 				column_args.zoom_handler->EvalForBeat(column_args.song_beat, cur_beat, sp_zoom);
 				render_width= fFrameWidth * sp_zoom.x;
 				break;
+			default:
+				break;
 		}
 
 		const float fFrameWidthScale	= ArrowEffects::GetFrameWidthScale(m_pPlayerState, fYOffset, part_args.overlapped_time);
@@ -937,6 +945,8 @@ void NoteDisplay::DrawHoldPart(vector<Sprite*> &vpSpr,
 				break;
 			case NCSM_Position:
 				column_args.rot_handler->EvalForBeat(column_args.song_beat, cur_beat, sp_rot);
+				break;
+			default:
 				break;
 		}
 
@@ -1300,6 +1310,8 @@ void NoteDisplay::DrawActor(const TapNote& tn, Actor* pActor, NotePart part,
 		case NCSM_Position:
 			column_args.rot_handler->EvalForBeat(column_args.song_beat, spline_beat, sp_rot);
 			break;
+		default:
+			break;
 	}
 	column_args.spae_zoom_for_beat(m_pPlayerState, spline_beat, sp_zoom, ae_zoom);
 	column_args.SetPRZForActor(pActor, sp_pos, ae_pos, sp_rot, ae_rot, sp_zoom, ae_zoom);
@@ -1447,6 +1459,8 @@ void NoteColumnRenderer::UpdateReceptorGhostStuff(Actor* receptor) const
 		case NCSM_Position:
 			NCR_current.m_pos_handler.EvalForReceptor(song_beat, sp_pos);
 			break;
+		default:
+			break;
 	}
 	switch(NCR_current.m_rot_handler.m_spline_mode)
 	{
@@ -1460,6 +1474,8 @@ void NoteColumnRenderer::UpdateReceptorGhostStuff(Actor* receptor) const
 		case NCSM_Position:
 			NCR_current.m_rot_handler.EvalForReceptor(song_beat, sp_rot);
 			break;
+		default:
+			break;
 	}
 	switch(NCR_current.m_zoom_handler.m_spline_mode)
 	{
@@ -1472,6 +1488,8 @@ void NoteColumnRenderer::UpdateReceptorGhostStuff(Actor* receptor) const
 			break;
 		case NCSM_Position:
 			NCR_current.m_zoom_handler.EvalForReceptor(song_beat, sp_zoom);
+			break;
+		default:
 			break;
 	}
 	m_column_render_args.SetPRZForActor(receptor, sp_pos, ae_pos, sp_rot, ae_rot, sp_zoom, ae_zoom);
@@ -1523,6 +1541,8 @@ void NoteColumnRenderer::DrawPrimitives()
 				{
 					holds[tn.pn].push_back(begin);
 				}
+				break;
+			default:
 				break;
 		}
 	}

--- a/src/NoteSkinManager.cpp
+++ b/src/NoteSkinManager.cpp
@@ -397,6 +397,8 @@ RString NoteSkinManager::GetPath( const RString &sButtonName, const RString &sEl
 				RageException::Throw("%s", message.c_str());
 			case Dialog::ignore:
 				return "";
+			default:
+				break;
 		}
 	}
 
@@ -439,6 +441,8 @@ RString NoteSkinManager::GetPath( const RString &sButtonName, const RString &sEl
 					RageException::Throw("%s", message.c_str());
 				case Dialog::ignore:
 					return "";
+				default:
+					break;
 			}
 		}
 		

--- a/src/NotesLoaderBMS.cpp
+++ b/src/NotesLoaderBMS.cpp
@@ -1455,9 +1455,9 @@ bool BMSChartReader::ReadNoteData()
 		}
 	}
 
-	delete transform;
-	delete holdStart;
-	delete lastNote;
+	delete[] transform;
+	delete[] holdStart;
+	delete[] lastNote;
 
 	td.TidyUpData( false );
 	out->SetNoteData(nd);

--- a/src/NotesLoaderSSC.cpp
+++ b/src/NotesLoaderSSC.cpp
@@ -912,6 +912,7 @@ bool SSCLoader::LoadNoteDataFromSimfile( const RString & cachePath, Steps &out )
 						out.SetSMNoteData(matcher);
 						out.TidyUpData();
 						return true;
+					default:
 						break;
 				}
 			}
@@ -926,6 +927,8 @@ bool SSCLoader::LoadNoteDataFromSimfile( const RString & cachePath, Steps &out )
 						break;
 					case LNDID_notedata:
 						tryingSteps = true;
+						break;
+					default:
 						break;
 				}
 			}

--- a/src/NotesWriterDWI.cpp
+++ b/src/NotesWriterDWI.cpp
@@ -367,18 +367,20 @@ bool NotesWriterDWI::Write( RString sPath, const Song &out )
 		f.PutLine( ssprintf("#CDTITLE:%s;", DwiEscape(out.m_sCDTitleFile).c_str()) );
 	switch( out.m_DisplayBPMType )
 	{
-	case DISPLAY_BPM_ACTUAL:
-		// write nothing
-		break;
-	case DISPLAY_BPM_SPECIFIED:
-		if( out.m_fSpecifiedBPMMin == out.m_fSpecifiedBPMMax )
-			f.PutLine( ssprintf("#DISPLAYBPM:%i;\n", (int) out.m_fSpecifiedBPMMin) );
-		else
-			f.PutLine( ssprintf("#DISPLAYBPM:%i..%i;\n", (int) out.m_fSpecifiedBPMMin, (int) out.m_fSpecifiedBPMMax) );
-		break;
-	case DISPLAY_BPM_RANDOM:
-		f.PutLine( "#DISPLAYBPM:*" );
-		break;
+		case DISPLAY_BPM_ACTUAL:
+			// write nothing
+			break;
+		case DISPLAY_BPM_SPECIFIED:
+			if( out.m_fSpecifiedBPMMin == out.m_fSpecifiedBPMMax )
+				f.PutLine( ssprintf("#DISPLAYBPM:%i;\n", (int) out.m_fSpecifiedBPMMin) );
+			else
+				f.PutLine( ssprintf("#DISPLAYBPM:%i..%i;\n", (int) out.m_fSpecifiedBPMMin, (int) out.m_fSpecifiedBPMMax) );
+			break;
+		case DISPLAY_BPM_RANDOM:
+			f.PutLine( "#DISPLAYBPM:*" );
+			break;
+		default:
+			break;
 	}
 
 	// TODO: Also check for delays, add them as stops minus one row?

--- a/src/NotesWriterSM.cpp
+++ b/src/NotesWriterSM.cpp
@@ -59,19 +59,21 @@ static void WriteGlobalTags( RageFile &f, Song &out )
 
 	switch( out.m_DisplayBPMType )
 	{
-	case DISPLAY_BPM_ACTUAL:
-		// write nothing
-		break;
-	case DISPLAY_BPM_SPECIFIED:
-		if( out.m_fSpecifiedBPMMin == out.m_fSpecifiedBPMMax )
-			f.PutLine( ssprintf( "#DISPLAYBPM:%.6f;", out.m_fSpecifiedBPMMin ) );
-		else
-			f.PutLine( ssprintf( "#DISPLAYBPM:%.6f:%.6f;", 
-					    out.m_fSpecifiedBPMMin, out.m_fSpecifiedBPMMax ) );
-		break;
-	case DISPLAY_BPM_RANDOM:
-		f.PutLine( ssprintf( "#DISPLAYBPM:*;" ) );
-		break;
+		case DISPLAY_BPM_ACTUAL:
+			// write nothing
+			break;
+		case DISPLAY_BPM_SPECIFIED:
+			if( out.m_fSpecifiedBPMMin == out.m_fSpecifiedBPMMax )
+				f.PutLine( ssprintf( "#DISPLAYBPM:%.6f;", out.m_fSpecifiedBPMMin ) );
+			else
+				f.PutLine( ssprintf( "#DISPLAYBPM:%.6f:%.6f;", 
+							out.m_fSpecifiedBPMMin, out.m_fSpecifiedBPMMax ) );
+			break;
+		case DISPLAY_BPM_RANDOM:
+			f.PutLine( ssprintf( "#DISPLAYBPM:*;" ) );
+			break;
+		default:
+			break;
 	}
 
 

--- a/src/NotesWriterSSC.cpp
+++ b/src/NotesWriterSSC.cpp
@@ -259,18 +259,20 @@ static void WriteGlobalTags( RageFile &f, const Song &out )
 
 	switch( out.m_DisplayBPMType )
 	{
-	case DISPLAY_BPM_ACTUAL:
-		// write nothing
-		break;
-	case DISPLAY_BPM_SPECIFIED:
-		if( out.m_fSpecifiedBPMMin == out.m_fSpecifiedBPMMax )
-			f.PutLine( ssprintf( "#DISPLAYBPM:%.6f;", out.m_fSpecifiedBPMMin ) );
-		else
-			f.PutLine( ssprintf( "#DISPLAYBPM:%.6f:%.6f;", out.m_fSpecifiedBPMMin, out.m_fSpecifiedBPMMax ) );
-		break;
-	case DISPLAY_BPM_RANDOM:
-		f.PutLine( ssprintf( "#DISPLAYBPM:*;" ) );
-		break;
+		case DISPLAY_BPM_ACTUAL:
+			// write nothing
+			break;
+		case DISPLAY_BPM_SPECIFIED:
+			if( out.m_fSpecifiedBPMMin == out.m_fSpecifiedBPMMax )
+				f.PutLine( ssprintf( "#DISPLAYBPM:%.6f;", out.m_fSpecifiedBPMMin ) );
+			else
+				f.PutLine( ssprintf( "#DISPLAYBPM:%.6f:%.6f;", out.m_fSpecifiedBPMMin, out.m_fSpecifiedBPMMax ) );
+			break;
+		case DISPLAY_BPM_RANDOM:
+			f.PutLine( ssprintf( "#DISPLAYBPM:*;" ) );
+			break;
+		default:
+			break;
 	}
 
 	WriteTimingTags( f, out.m_SongTiming, true );
@@ -408,6 +410,8 @@ static RString GetSSCNoteData( const Song &song, const Steps &in, bool bSavingCa
 		}
 		case DISPLAY_BPM_RANDOM:
 			lines.push_back( ssprintf( "#DISPLAYBPM:*;" ) );
+			break;
+		default:
 			break;
 	}
 	if (bSavingCache)

--- a/src/PlayerOptions.cpp
+++ b/src/PlayerOptions.cpp
@@ -150,9 +150,15 @@ void PlayerOptions::GetMods( vector<RString> &AddTo, bool bForceNoteSkin ) const
 		case LifeType_Bar:
 			switch(m_DrainType)
 			{
-				case DrainType_Normal:						break;
-				case DrainType_NoRecover:		AddTo.push_back("NoRecover");	break;
-				case DrainType_SuddenDeath:	AddTo.push_back("SuddenDeath");	break;
+				case DrainType_NoRecover:
+					AddTo.push_back("NoRecover");
+					break;
+				case DrainType_SuddenDeath:
+					AddTo.push_back("SuddenDeath");
+					break;
+				case DrainType_Normal:
+				default:
+					break;
 			}
 			break;
 		case LifeType_Battery:

--- a/src/RageDisplay_OGL.cpp
+++ b/src/RageDisplay_OGL.cpp
@@ -1619,35 +1619,37 @@ void RageDisplay_Legacy::SetTextureMode( TextureUnit tu, TextureMode tm )
 
 	switch( tm )
 	{
-	case TextureMode_Modulate:
-		glTexEnvi( GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_MODULATE );
-		break;
-	case TextureMode_Add:
-		glTexEnvi( GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_ADD );
-		break;
-	case TextureMode_Glow:
-		// the below function is glowmode,brighten:
-		if (!GLEW_ARB_texture_env_combine && !GLEW_EXT_texture_env_combine)
-		{
-			/* This is changing blend state, instead of texture state, which
-			 * isn't great, but it's better than doing nothing. */
-			glBlendFunc( GL_SRC_ALPHA, GL_ONE );
-			return;
-		}
+		case TextureMode_Modulate:
+			glTexEnvi( GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_MODULATE );
+			break;
+		case TextureMode_Add:
+			glTexEnvi( GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_ADD );
+			break;
+		case TextureMode_Glow:
+			// the below function is glowmode,brighten:
+			if (!GLEW_ARB_texture_env_combine && !GLEW_EXT_texture_env_combine)
+			{
+				/* This is changing blend state, instead of texture state, which
+				 * isn't great, but it's better than doing nothing. */
+				glBlendFunc( GL_SRC_ALPHA, GL_ONE );
+				return;
+			}
 
-		// and this is glowmode,whiten:
-		// Source color is the diffuse color only:
-		glTexEnvi(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_COMBINE_EXT);
-		glTexEnvi(GL_TEXTURE_ENV, GLenum(GL_COMBINE_RGB_EXT), GL_REPLACE);
-		glTexEnvi(GL_TEXTURE_ENV, GLenum(GL_SOURCE0_RGB_EXT), GL_PRIMARY_COLOR_EXT);
+			// and this is glowmode,whiten:
+			// Source color is the diffuse color only:
+			glTexEnvi(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_COMBINE_EXT);
+			glTexEnvi(GL_TEXTURE_ENV, GLenum(GL_COMBINE_RGB_EXT), GL_REPLACE);
+			glTexEnvi(GL_TEXTURE_ENV, GLenum(GL_SOURCE0_RGB_EXT), GL_PRIMARY_COLOR_EXT);
 
-		// Source alpha is texture alpha * diffuse alpha:
-		glTexEnvi(GL_TEXTURE_ENV, GLenum(GL_COMBINE_ALPHA_EXT), GL_MODULATE);
-		glTexEnvi(GL_TEXTURE_ENV, GLenum(GL_OPERAND0_ALPHA_EXT), GL_SRC_ALPHA);
-		glTexEnvi(GL_TEXTURE_ENV, GLenum(GL_SOURCE0_ALPHA_EXT), GL_PRIMARY_COLOR_EXT);
-		glTexEnvi(GL_TEXTURE_ENV, GLenum(GL_OPERAND1_ALPHA_EXT), GL_SRC_ALPHA);
-		glTexEnvi(GL_TEXTURE_ENV, GLenum(GL_SOURCE1_ALPHA_EXT), GL_TEXTURE);
-		break;
+			// Source alpha is texture alpha * diffuse alpha:
+			glTexEnvi(GL_TEXTURE_ENV, GLenum(GL_COMBINE_ALPHA_EXT), GL_MODULATE);
+			glTexEnvi(GL_TEXTURE_ENV, GLenum(GL_OPERAND0_ALPHA_EXT), GL_SRC_ALPHA);
+			glTexEnvi(GL_TEXTURE_ENV, GLenum(GL_SOURCE0_ALPHA_EXT), GL_PRIMARY_COLOR_EXT);
+			glTexEnvi(GL_TEXTURE_ENV, GLenum(GL_OPERAND1_ALPHA_EXT), GL_SRC_ALPHA);
+			glTexEnvi(GL_TEXTURE_ENV, GLenum(GL_SOURCE1_ALPHA_EXT), GL_TEXTURE);
+			break;
+		default:
+			break;
 	}
 }
 
@@ -1691,15 +1693,35 @@ void RageDisplay_Legacy::SetEffectMode( EffectMode effect )
 	GLhandleARB hShader = 0;
 	switch (effect)
 	{
-	case EffectMode_Normal:		hShader = 0; break;
-	case EffectMode_Unpremultiply:	hShader = g_bUnpremultiplyShader; break;
-	case EffectMode_ColorBurn:	hShader = g_bColorBurnShader; break;
-	case EffectMode_ColorDodge:	hShader = g_bColorDodgeShader; break;
-	case EffectMode_VividLight:	hShader = g_bVividLightShader; break;
-	case EffectMode_HardMix:	hShader = g_hHardMixShader; break;
-	case EffectMode_Overlay:	hShader = g_hOverlayShader; break;
-	case EffectMode_Screen:	hShader = g_hScreenShader; break;
-	case EffectMode_YUYV422:	hShader = g_hYUYV422Shader; break;
+		case EffectMode_Normal:
+			hShader = 0;
+			break;
+		case EffectMode_Unpremultiply:
+			hShader = g_bUnpremultiplyShader;
+			break;
+		case EffectMode_ColorBurn:
+			hShader = g_bColorBurnShader;
+			break;
+		case EffectMode_ColorDodge:
+			hShader = g_bColorDodgeShader;
+			break;
+		case EffectMode_VividLight:
+			hShader = g_bVividLightShader;
+			break;
+		case EffectMode_HardMix:
+			hShader = g_hHardMixShader;
+			break;
+		case EffectMode_Overlay:
+			hShader = g_hOverlayShader;
+			break;
+		case EffectMode_Screen:
+			hShader = g_hScreenShader;
+			break;
+		case EffectMode_YUYV422:
+			hShader = g_hYUYV422Shader;
+			break;
+		default:
+			break;
 	}
 
 	DebugFlushGLErrors();
@@ -1726,18 +1748,27 @@ bool RageDisplay_Legacy::IsEffectModeSupported( EffectMode effect )
 {
 	switch( effect )
 	{
-	case EffectMode_Normal:		return true;
-	case EffectMode_Unpremultiply:	return g_bUnpremultiplyShader != 0;
-	case EffectMode_ColorBurn:	return g_bColorBurnShader != 0;
-	case EffectMode_ColorDodge:	return g_bColorDodgeShader != 0;
-	case EffectMode_VividLight:	return g_bVividLightShader != 0;
-	case EffectMode_HardMix:	return g_hHardMixShader != 0;
-	case EffectMode_Overlay:		return g_hOverlayShader != 0;
-	case EffectMode_Screen:		return g_hScreenShader != 0;
-	case EffectMode_YUYV422:	return g_hYUYV422Shader != 0;
+		case EffectMode_Normal:
+			return true;
+		case EffectMode_Unpremultiply:
+			return g_bUnpremultiplyShader != 0;
+		case EffectMode_ColorBurn:
+			return g_bColorBurnShader != 0;
+		case EffectMode_ColorDodge:
+			return g_bColorDodgeShader != 0;
+		case EffectMode_VividLight:
+			return g_bVividLightShader != 0;
+		case EffectMode_HardMix:
+			return g_hHardMixShader != 0;
+		case EffectMode_Overlay:
+			return g_hOverlayShader != 0;
+		case EffectMode_Screen:
+			return g_hScreenShader != 0;
+		case EffectMode_YUYV422:
+			return g_hYUYV422Shader != 0;
+		default:
+			return false;
 	}
-
-	return false;
 }
 
 void RageDisplay_Legacy::SetBlendMode( BlendMode mode )

--- a/src/ScreenTextEntry.cpp
+++ b/src/ScreenTextEntry.cpp
@@ -214,10 +214,14 @@ bool ScreenTextEntry::Input( const InputEventPlus &input )
 	{
 		switch( input.type )
 		{
-		case IET_FIRST_PRESS:
-			bLCtrl = true; break;
-		case IET_RELEASE:
-			bLCtrl = false; break;
+			case IET_FIRST_PRESS:
+				bLCtrl = true;
+				break;
+			case IET_RELEASE:
+				bLCtrl = false;
+				break;
+			default:
+				break;
 		}
 	}
 	
@@ -225,10 +229,14 @@ bool ScreenTextEntry::Input( const InputEventPlus &input )
 	{
 		switch( input.type )
 		{
-		case IET_FIRST_PRESS:
-			bRCtrl = true; break;
-		case IET_RELEASE:
-			bRCtrl = false; break;
+			case IET_FIRST_PRESS:
+				bRCtrl = true;
+					break;
+			case IET_RELEASE:
+				bRCtrl = false;
+				break;
+			default:
+				break;
 		}
 	}
 	

--- a/src/ThemeManager.cpp
+++ b/src/ThemeManager.cpp
@@ -688,14 +688,15 @@ bool ThemeManager::GetPathInfoToRaw( PathInfo &out, const RString &sThemeName_, 
 
 		switch( LuaHelpers::ReportScriptError(message, "", true) )
 		{
-		case Dialog::abort:
-			RageException::Throw( "%s", message.c_str() ); 
-			break;
-		case Dialog::retry:
-			ReloadMetrics();
-			return GetPathInfoToRaw( out, sThemeName_, category, sMetricsGroup_, sElement_ );
-		case Dialog::ignore:
-			break;
+			case Dialog::abort:
+				RageException::Throw( "%s", message.c_str() ); 
+				break;
+			case Dialog::retry:
+				ReloadMetrics();
+				return GetPathInfoToRaw( out, sThemeName_, category, sMetricsGroup_, sElement_ );
+			case Dialog::ignore:
+			default:
+				break;
 		}
 	}
 
@@ -733,15 +734,15 @@ bool ThemeManager::GetPathInfoToRaw( PathInfo &out, const RString &sThemeName_, 
 
 	switch(LuaHelpers::ReportScriptError(sMessage, "", true))
 	{
-	case Dialog::retry:
-		ReloadMetrics();
-		return GetPathInfoToRaw( out, sThemeName_, category, sMetricsGroup_, sElement_ );
-	case Dialog::ignore:
-		GetPathInfo( out, category, "", "_missing" );
-		return true;
+		case Dialog::retry:
+			ReloadMetrics();
+			return GetPathInfoToRaw( out, sThemeName_, category, sMetricsGroup_, sElement_ );
+		case Dialog::ignore:
+			GetPathInfo( out, category, "", "_missing" );
+			return true;
+		default:
+			RageException::Throw( "%s", sMessage.c_str() );
 	}
-
-	RageException::Throw( "%s", sMessage.c_str() ); 
 }
 
 bool ThemeManager::GetPathInfoToAndFallback( PathInfo &out, ElementCategory category, const RString &sMetricsGroup_, const RString &sElement ) 

--- a/src/TimingData.cpp
+++ b/src/TimingData.cpp
@@ -712,6 +712,8 @@ void TimingData::AddSegment( const TimingSegment *seg )
 			}
 			break;
 		}
+		default:
+			break;
 	}
 
 	// the segment at or before this row is equal to the new one; ignore it

--- a/src/XmlToLua.cpp
+++ b/src/XmlToLua.cpp
@@ -596,6 +596,8 @@ void actor_template_t::load_node(XNode const& node, RString const& dirname, cond
 							store_field("Bones", this_relative, false);
 							handled_level= 2;
 							break;
+						default:
+							break;
 					}
 					if(!handled_level)
 					{

--- a/src/arch/MovieTexture/MovieTexture_FFMpeg.cpp
+++ b/src/arch/MovieTexture/MovieTexture_FFMpeg.cpp
@@ -365,7 +365,7 @@ static RString averr_ssprintf( int err, const char *fmt, ... )
 	char* errbuf = new char[errbuf_size];
 	avcodec::av_strerror(err, errbuf, errbuf_size);
 	RString Error = ssprintf("%i: %s", err, errbuf);
-	delete errbuf;
+	delete[] errbuf;
 
 	return s + " (" + Error + ")";
 }

--- a/src/archutils/Darwin/JoystickDevice.cpp
+++ b/src/archutils/Darwin/JoystickDevice.cpp
@@ -6,13 +6,13 @@
 using __gnu_cxx::hash_map;
 
 Joystick::Joystick() :	id( InputDevice_Invalid ),
-			x_axis( 0 ), x_min( 0 ), x_max( 0 ),
-			y_axis( 0 ), y_min( 0 ), y_max( 0 ),
-			z_axis( 0 ), z_min( 0 ), z_max( 0 ),
-			x_rot( 0 ), rx_min( 0 ), rx_max( 0 ),
-			y_rot( 0 ), ry_min( 0 ), ry_max( 0 ),
-			z_rot( 0 ), rz_min( 0 ), rz_max( 0 ),
-			hat( 0 ), hat_min( 0 ), hat_max( 0 )
+			x_axis( 0 ), y_axis( 0 ), z_axis( 0 ),
+			x_rot( 0 ), y_rot( 0 ), z_rot( 0 ), hat( 0 ),
+			x_min( 0 ), x_max( 0 ), y_min( 0 ),
+			y_max( 0 ), z_min( 0 ), z_max( 0 ),
+			rx_min( 0 ), rx_max( 0 ), ry_min( 0 ),
+			ry_max( 0 ), rz_min( 0 ), rz_max( 0 ),
+			hat_min( 0 ), hat_max( 0 )
 {
 }
 

--- a/src/archutils/Darwin/MouseDevice.cpp
+++ b/src/archutils/Darwin/MouseDevice.cpp
@@ -4,9 +4,9 @@
 using __gnu_cxx::hash_map;
 
 Mouse::Mouse() : id( InputDevice_Invalid ),
-				x_axis( 0 ), x_min( 0 ), x_max( 0 ),
-				y_axis( 0 ), y_min( 0 ), y_max( 0 ),
-				z_axis( 0 ), z_min( 0 ), z_max( 0 )
+				x_axis( 0 ), y_axis( 0 ), z_axis( 0 ),
+				x_min( 0 ), x_max( 0 ), y_min( 0 ),
+				y_max( 0 ), z_min( 0 ), z_max( 0 )
 {
 }
 


### PR DESCRIPTION
* Ensure all switches have a default when working with enums.
* Match defined new[] calls with delete[] calls.
* Respect variable initialization order.