### PR TITLE
Use constexpr where it is safe to.

### DIFF
--- a/src/Actor.h
+++ b/src/Actor.h
@@ -20,19 +20,19 @@ typedef AutoPtrCopyOnWrite<LuaReference> apActorCommands;
 
 const int max_draw_order= 16777216;
 /** @brief The background layer. */
-#define DRAW_ORDER_BEFORE_EVERYTHING		-200
+int CONSTEXPR_VARIABLE DRAW_ORDER_BEFORE_EVERYTHING = -200;
 /** @brief The underlay layer. */
-#define DRAW_ORDER_UNDERLAY			-100
+int CONSTEXPR_VARIABLE  DRAW_ORDER_UNDERLAY = -100;
 /** @brief The decorations layer. */
-#define DRAW_ORDER_DECORATIONS			   0
+int CONSTEXPR_VARIABLE DRAW_ORDER_DECORATIONS = 0;
 /** @brief The overlay layer.
  *
  * Normal screen elements go here. */
-#define DRAW_ORDER_OVERLAY			+100
+int CONSTEXPR_VARIABLE DRAW_ORDER_OVERLAY = 100;
 /** @brief The transitions layer. */
-#define DRAW_ORDER_TRANSITIONS			+200
+int CONSTEXPR_VARIABLE DRAW_ORDER_TRANSITIONS = 200;
 /** @brief The over everything layer. */
-#define DRAW_ORDER_AFTER_EVERYTHING		+300
+int CONSTEXPR_VARIABLE DRAW_ORDER_AFTER_EVERYTHING = 300;
 
 /** @brief The different horizontal alignments. */
 enum HorizAlign
@@ -57,24 +57,24 @@ enum VertAlign
 LuaDeclareType( VertAlign );
 
 /** @brief The left horizontal alignment constant. */
-#define align_left 0.0f
+float CONSTEXPR_VARIABLE_FLOAT align_left = 0.f;
 /** @brief The center horizontal alignment constant. */
-#define align_center 0.5f
+float CONSTEXPR_VARIABLE_FLOAT align_center = 0.5f;
 /** @brief The right horizontal alignment constant. */
-#define align_right 1.0f
+float CONSTEXPR_VARIABLE_FLOAT align_right = 1.f;
 /** @brief The top vertical alignment constant. */
-#define align_top 0.0f
+float CONSTEXPR_VARIABLE_FLOAT align_top = 0.f;
 /** @brief The middle vertical alignment constant. */
-#define align_middle 0.5f
+float CONSTEXPR_VARIABLE_FLOAT align_middle = 0.5f;
 /** @brief The bottom vertical alignment constant. */
-#define align_bottom 1.0f
+float CONSTEXPR_VARIABLE_FLOAT align_bottom = 1.f;
 
 // This is the number of colors in Actor::diffuse.  Actor has multiple
 // diffuse colors so that each edge can be a different color, and the actor
 // is drawn with a gradient between them.
 // I doubt I actually found all the places that touch diffuse and rely on the
 // number of diffuse colors, so change this at your own risk. -Kyz
-#define NUM_DIFFUSE_COLORS 4
+int CONSTEXPR_VARIABLE NUM_DIFFUSE_COLORS = 4;
 
 // ssc futures:
 /*

--- a/src/ArrowEffects.cpp
+++ b/src/ArrowEffects.cpp
@@ -629,8 +629,8 @@ float ArrowEffects::ReceptorGetRotationZ( const PlayerState* pPlayerState )
 	return fRotation;
 }
 
-#define CENTER_LINE_Y 160	// from fYOffset == 0
-#define FADE_DIST_Y 40
+float CONSTEXPR_VARIABLE_FLOAT CENTER_LINE_Y = 160;	// from fYOffset == 0
+float CONSTEXPR_VARIABLE_FLOAT FADE_DIST_Y = 40;
 
 static float GetCenterLine()
 {

--- a/src/Attack.h
+++ b/src/Attack.h
@@ -1,11 +1,11 @@
 #ifndef ATTACK_H
 #define ATTACK_H
 
-#define ATTACK_STARTS_NOW (-10000.f)
-
 #include <string>
 #include "GameConstantsAndTypes.h"
 #include "PlayerNumber.h"
+#include "RageConfig.hpp"
+float CONSTEXPR_VARIABLE_FLOAT ATTACK_STARTS_NOW = -10000.f;
 class Song;
 class PlayerState;
 /** @brief An action made against a Player to make things more difficult. */

--- a/src/BeginnerHelper.cpp
+++ b/src/BeginnerHelper.cpp
@@ -21,12 +21,13 @@
 #define HELPER_X			THEME->GetMetricF("BeginnerHelper","HelperX")
 #define HELPER_Y			THEME->GetMetricF("BeginnerHelper","HelperY")
 
-#define ST_LEFT		0x01
-#define ST_DOWN		0x02
-#define ST_UP		0x04
-#define ST_RIGHT	0x08
-#define ST_JUMPLR	(ST_LEFT | ST_RIGHT)
-#define ST_JUMPUD	(ST_UP | ST_DOWN)
+// TODO: Replace with enum flags.
+int CONSTEXPR_VARIABLE ST_LEFT = 0x01;
+int CONSTEXPR_VARIABLE ST_DOWN = 0x02;
+int CONSTEXPR_VARIABLE ST_UP = 0x04;
+int CONSTEXPR_VARIABLE ST_RIGHT = 0x08;
+int CONSTEXPR_VARIABLE ST_JUMPLR = ST_LEFT | ST_RIGHT;
+int CONSTEXPR_VARIABLE ST_JUMPUD = ST_UP | ST_DOWN;
 
 enum Animation
 {

--- a/src/CreateZip.cpp
+++ b/src/CreateZip.cpp
@@ -13,10 +13,11 @@ typedef char TCHAR;
 #include <time.h>
 #include "CreateZip.h"
 #include "RageFile.h"
+#include "RageConfig.hpp"
 #include "RageUtil.h"
 #include "RageUtil.hpp"
 
-#define MAX_PATH 1024
+int CONSTEXPR_VARIABLE MAX_PATH = 1024;
 
 // TODO: remove header "extra fields" (the 3 dates)
 // Adapted for StepMania from http://www.codeproject.com/KB/files/zip_utils.aspx

--- a/src/CryptManager.cpp
+++ b/src/CryptManager.cpp
@@ -67,11 +67,8 @@ void CryptManager::GetRandomBytes( void *pData, int iBytes )
 
 #else
 
-static const int KEY_LENGTH = 1024;
-#define MAX_SIGNATURE_SIZE_BYTES 1024	// 1 KB
-
-
-
+static int CONSTEXPR_VARIABLE KEY_LENGTH = 1024;
+int CONSTEXPR_VARIABLE MAX_SIGNATURE_SIZE_BYTES = 1024; // 1 KB
 
 /*
  openssl genrsa -out testing -outform DER

--- a/src/LuaManager.cpp
+++ b/src/LuaManager.cpp
@@ -601,6 +601,8 @@ void LuaManager::Register( RegisterWithLuaFn pfn )
 	g_vRegisterActorTypes->push_back( pfn );
 }
 
+// Store the thread pool in a table on the stack, in the main thread.
+int CONSTEXPR_VARIABLE THREAD_POOL = 1;
 
 LuaManager::LuaManager()
 {
@@ -626,8 +628,6 @@ LuaManager::LuaManager()
 	lua_pushcfunction( L, luaopen_os ); lua_call( L, 0, 0 );
 #endif
 
-	// Store the thread pool in a table on the stack, in the main thread.
-#define THREAD_POOL 1
 	lua_newtable( L );
 
 	RegisterTypes();

--- a/src/ModelTypes.cpp
+++ b/src/ModelTypes.cpp
@@ -11,7 +11,7 @@
 
 #include <numeric>
 
-#define MS_MAX_NAME	32
+int CONSTEXPR_VARIABLE MS_MAX_NAME = 32;
 
 AnimatedTexture::AnimatedTexture()
 {

--- a/src/MusicWheel.cpp
+++ b/src/MusicWheel.cpp
@@ -1624,30 +1624,36 @@ Song *MusicWheel::GetPreferredSelectionForRandomOrPortal()
 
 	StepsType st = GAMESTATE->GetCurrentStyle(PLAYER_INVALID)->m_StepsType;
 
-#define NUM_PROBES 1000
+	int CONSTEXPR_VARIABLE NUM_PROBES = 1000;
 	for( int i=0; i<NUM_PROBES; i++ )
 	{
 		bool isValid = true;
 		/* Maintaining difficulties is higher priority than maintaining
 		 * the current group. */
 		if( i == NUM_PROBES/4 )
+		{
 			sPreferredGroup = "";
+		}
 		if( i == NUM_PROBES/2 )
+		{
 			vDifficultiesToRequire.clear();
-
+		}
 		int iSelection = RandomInt( wid.size() );
 		if( wid[iSelection]->m_Type != WheelItemDataType_Song )
+		{
 			continue;
-
+		}
 		const Song *pSong = wid[iSelection]->m_pSong;
 
 		if( !sPreferredGroup.empty() && wid[iSelection]->m_sText != sPreferredGroup )
+		{
 			continue;
-
+		}
 		// There's an off possibility that somebody might have only one song with only beginner steps.
 		if( i < 900 && pSong->IsTutorial() )
+		{
 			continue;
-
+		}
 		for (auto &d: vDifficultiesToRequire)
 		{
 			if( !pSong->HasStepsTypeAndDifficulty(st,d) )

--- a/src/ProfileManager.cpp
+++ b/src/ProfileManager.cpp
@@ -28,9 +28,9 @@ using std::vector;
 
 ProfileManager*	PROFILEMAN = nullptr;	// global and accessible from anywhere in our program
 
-#define ID_DIGITS 8
+int CONSTEXPR_VARIABLE ID_DIGITS = 8;
 #define ID_DIGITS_STR "8"
-#define MAX_ID 99999999
+int CONSTEXPR_VARIABLE MAX_ID = 99999999;
 
 static void DefaultLocalProfileIDInit( size_t /*PlayerNumber*/ i, std::string &sNameOut, std::string &defaultValueOut )
 {

--- a/src/RadarValues.h
+++ b/src/RadarValues.h
@@ -5,7 +5,7 @@
 #include "ThemeMetric.h"
 
 /** @brief Unknown radar values are given a default value. */
-#define RADAR_VAL_UNKNOWN -1
+int CONSTEXPR_VARIABLE_FLOAT RADAR_VAL_UNKNOWN = -1.f;
 
 class XNode;
 struct lua_State;

--- a/src/RageModelGeometry.cpp
+++ b/src/RageModelGeometry.cpp
@@ -7,7 +7,7 @@
 
 using std::vector;
 
-#define MS_MAX_NAME	32
+int CONSTEXPR_VARIABLE MS_MAX_NAME = 32;
 
 RageModelGeometry::RageModelGeometry ()
 {

--- a/src/RageSoundReader_Resample_Good.cpp
+++ b/src/RageSoundReader_Resample_Good.cpp
@@ -16,7 +16,7 @@
 #include <numeric>
 
 /* Filter length.  This must be a power of 2. */
-#define L 8
+int CONSTEXPR_VARIABLE L = 8;
 
 namespace
 {

--- a/src/RageSurfaceUtils_Dither.cpp
+++ b/src/RageSurfaceUtils_Dither.cpp
@@ -5,7 +5,7 @@
 #include "RageSurface.h"
 #include "RageSurfaceUtils.h"
 
-#define DitherMatDim 4
+int CONSTEXPR_VARIABLE DitherMatDim = 4;
 
 // Fractions, 0/16 to 15/16:
 static const int DitherMat[DitherMatDim][DitherMatDim] =

--- a/src/RageSurfaceUtils_Palettize.cpp
+++ b/src/RageSurfaceUtils_Palettize.cpp
@@ -58,9 +58,7 @@ struct acolorhash_hash
 	}
 };
 
-
-
-#define MAXCOLORS  32767
+int CONSTEXPR_VARIABLE MAXCOLORS = 32767;
 #define FS_SCALE   1024     /* Floyd-Steinberg scaling factor */
 
 /* #define REP_AVERAGE_COLORS */

--- a/src/RageSurface_Load_GIF.cpp
+++ b/src/RageSurface_Load_GIF.cpp
@@ -5,12 +5,10 @@
 #include "RageLog.h"
 #include "RageSurface.h"
 
-#define	MAXCOLORMAPSIZE		256
-
-#define	MAX_LWZ_BITS		12
-
-#define INTERLACE		0x40
-#define LOCALCOLORMAP	0x80
+int CONSTEXPR_VARIABLE MAXCOLORMAPSIZE = 256;
+int CONSTEXPR_VARIABLE MAX_LWZ_BITS = 12;
+int CONSTEXPR_VARIABLE INTERLACE = 0x40;
+int CONSTEXPR_VARIABLE LOCALCOLORMAP = 0x80;
 #define BitSet(byte, bit)	(((byte) & (bit)) == (bit))
 
 #define	ReadOK(file,buffer,len)	(file.Read( buffer, len, 1) != 0)

--- a/src/RageThreads.cpp
+++ b/src/RageThreads.cpp
@@ -36,7 +36,7 @@
 bool RageThread::s_bSystemSupportsTLS = false;
 bool RageThread::s_bIsShowingDialog = false;
 
-#define MAX_THREADS 128
+int CONSTEXPR_VARIABLE MAX_THREADS = 128;
 //static vector<RageMutex*> *g_MutexList = nullptr; /* watch out for static initialization order problems */
 
 struct ThreadSlot

--- a/src/ScreenDimensions.h
+++ b/src/ScreenDimensions.h
@@ -16,9 +16,9 @@ namespace ScreenDimensions
 #define SCREEN_WIDTH	ScreenDimensions::GetScreenWidth()
 #define SCREEN_HEIGHT	ScreenDimensions::GetScreenHeight()
 
-#define	SCREEN_LEFT	(0)
+float CONSTEXPR_VARIABLE_FLOAT SCREEN_LEFT = 0.f;
 #define	SCREEN_RIGHT	(SCREEN_WIDTH)
-#define	SCREEN_TOP	(0)
+float CONSTEXPR_VARIABLE_FLOAT SCREEN_TOP	= 0.f;
 #define	SCREEN_BOTTOM	(SCREEN_HEIGHT)
 
 #define	SCREEN_CENTER_X	(SCREEN_LEFT + (SCREEN_RIGHT - SCREEN_LEFT)/2.0f)
@@ -35,7 +35,7 @@ namespace ScreenDimensions
  * This is referenced in ArrowEffects, GameManager, NoteField, and SnapDisplay.
  * XXX: doesn't always have to be 64. -aj
  */
-#define	ARROW_SIZE	(64)
+int CONSTEXPR_VARIABLE ARROW_SIZE = 64;
 
 #endif
 

--- a/src/ScreenHowToPlay.cpp
+++ b/src/ScreenHowToPlay.cpp
@@ -213,13 +213,14 @@ ScreenHowToPlay::~ScreenHowToPlay()
 
 void ScreenHowToPlay::Step()
 {
-// xxx: assumes dance. -freem
-#define ST_LEFT		0x01
-#define ST_DOWN		0x02
-#define ST_UP		0x04
-#define ST_RIGHT	0x08
-#define ST_JUMPLR	(ST_LEFT | ST_RIGHT)
-#define ST_JUMPUD	(ST_UP | ST_DOWN)
+  // xxx: assumes dance. -freem
+  // TODO: Replace with enum flags.
+  int CONSTEXPR_VARIABLE ST_LEFT = 0x01;
+  int CONSTEXPR_VARIABLE ST_DOWN = 0x02;
+  int CONSTEXPR_VARIABLE ST_UP = 0x04;
+  int CONSTEXPR_VARIABLE ST_RIGHT = 0x08;
+  int CONSTEXPR_VARIABLE ST_JUMPLR = ST_LEFT | ST_RIGHT;
+  int CONSTEXPR_VARIABLE ST_JUMPUD = ST_UP | ST_DOWN;
 
 	int iStep = 0;
 	const int iNoteRow = BeatToNoteRowNotRounded( GAMESTATE->m_Position.m_fSongBeat + 0.6f );

--- a/src/UnlockManager.h
+++ b/src/UnlockManager.h
@@ -99,6 +99,8 @@ public:
 	void PushSelf( lua_State *L );
 };
 
+// TODO: Replace all of these with enum flags.
+
 // Option is locked due to an unsatisfied unlock entry.
 #define LOCKED_LOCK          0x1
 

--- a/src/rage/RageConfig.hpp
+++ b/src/rage/RageConfig.hpp
@@ -4,11 +4,15 @@
 #if defined(_MSC_VER) && _MSC_VER <= 1800
 /** @brief A cross platform way of indicating a constant expression variable if the compiler was intelligent enough. */
 #define CONSTEXPR_VARIABLE const
+/** @brief A cross platform way of indicating a const expression variable (float specifically) if the compiler was intelligent enough. */
+#define CONSTEXPR_VARIABLE_FLOAT
 /** @brief A cross platform way of indicating a constant expression function if the compiler was intelligent enough. */
 #define CONSTEXPR_FUNCTION
 #else
-/** @brief A cross platform way of indiciating a constant expression variable. */
+/** @brief A cross platform way of indicating a constant expression variable. */
 #define CONSTEXPR_VARIABLE constexpr
+/** @brief A cross platform way of indicating a constant exprssion variable (float specifically). */
+#define CONSTEXPR_VARIABLE_FLOAT constexpr
 /** @brief A cross platform way of indicating a constant expression function. */
 #define CONSTEXPR_FUNCTION constexpr
 #endif


### PR DESCRIPTION
Any float variables in non constexpr scenarios are left alone.