### PR TITLE
include syntax highlighting in ThemerDocs markdown

### DIFF
--- a/Docs/Themerdocs/item_scroller.md
+++ b/Docs/Themerdocs/item_scroller.md
@@ -16,7 +16,7 @@ scroll function is called.
 
 Write an item metatable to control the items.  It must have create_actors,
 set, and transform functions.  It can have any other functions that you need.
-```
+```lua
 local item_mt= {
   __index= {
 	-- create_actors must return an actor.  The name field is a convenience.
@@ -43,7 +43,7 @@ local item_mt= {
 ```
 
 Create a lua table with item_scroller_mt as its metatable.
-```
+```lua
 local scroller= setmetatable({disable_wrapping= true}, item_scroller_mt)
 ```
 If disable_wrapping is false or nil, the scroller will be in wheel mode,
@@ -52,14 +52,14 @@ info elements are repeated if there are more items than info elements, and
 info elements wrap around when the scroller is scrolled to the top or bottom.
 
 Create the actor for the scroller.
-```
+```lua
 t[#t+1]= scroller:create_actors("foo", 5, item_mt, 0, 0)
 ```
 This creates a scroller with 5 items, using item_mt as the metatable for each
 item.  The base position of the scroller is 0, 0.
 
 Create a table with the pieces of info you need the items to display.
-```
+```lua
 local info_set= {"fin", "tail", "gorg", "lilk", "zos", "mink"}
 ```
 item_scroller does not place any restrictions or requirements on what an
@@ -68,7 +68,7 @@ info_set will be passed to the set function in item_mt.  So one element
 should contain everything an item needs to display that element.
 
 After screen creation, use set_info_set to pass info_set to the scroller.
-```
+```lua
 scroller:set_info_set(info_set, 1)
 ```
 This passes the table of information to the scroller, and tells it to focus
@@ -80,7 +80,7 @@ to position the items.
 # Scrolling
 
 Call the scroll_to_pos and scroll_by_amount functions to scroll.
-```
+```lua
 scroller:scroll_to_pos(3)
 scroller:scroll_by_amount(2)
 ```

--- a/Docs/Themerdocs/lua_config_system.md
+++ b/Docs/Themerdocs/lua_config_system.md
@@ -17,7 +17,7 @@ they just delete the folder for that theme.
 Machine wide data is stored in a folder in the Save folder.
 
 The folder is named this way:
-```
+```lua
 "/"..THEME:GetCurThemeName().."_config/"
 ```
 
@@ -97,7 +97,7 @@ is replaced with the default value.
 
 #### Examples:
 Default config for the example:
-```
+```lua
 local default_foo_config= {
   bar= 1, baz= "quux",
   zeen= {
@@ -107,29 +107,29 @@ local default_foo_config= {
 ```
 
 Config file with one field missing:
-```
+```lua
 local config_data= {baz= "zork", zeen= {torg= 5, dorn= "loo"},}
 ```
 After sanity checking, that config data looks like this:
-```
+```lua
 config_data= {bar= 1, baz= "zork", zeen= {torg= 5, dorn= "loo"},}
 ```
 
 Config file with a field that is the wrong type:
-```
+```lua
 local config_data= {bar= 3, baz= 6, zeen= {torg= 5, dorn= "loo"},}
 ```
 After sanity checking:
-```
+```lua
 config_data= {bar= 3, baz= "quux", zeen= {torg= 5, dorn= "loo"},}
 ```
 
 Config file with an extra field:
-```
+```lua
 local config_data= {bar= 3, yun= "awk", baz= "quux", zeen= {torg= 5, dorn= "loo"},}
 ```
 After sanity checking:
-```
+```lua
 config_data= {bar= 3, baz= "quux", zeen= {torg= 5, dorn= "loo"},}
 ```
 
@@ -154,7 +154,7 @@ The lua config system provides functions to deal with these problems.
 Do not create LoadProfileCustom or SaveProfileCustom functions anywhere.
 Call add_standard_lua_config_save_load_hooks after the config object is
 created to register the config to be saved and loaded with the profile.
-```
+```lua
 add_standard_lua_config_save_load_hooks(some_config)
 ```
 If you have other things to do when saving or loading profiles, read the
@@ -191,18 +191,18 @@ to add_profile_save_callback.
 
 When you need the config data for a player, call get_data on the config
 object and pass it the player number.
-```
+```lua
 local player_config= foo_config:get_data(pn)
 ```
 If you are getting the machine wide config, pass nil instead of the player
 number.
-```
+```lua
 local machine_config= foo_config:get_data()
 ```
 get_data returns a table with the config values.  If you modify anything in
 the table, call set_dirty on the config object with the same arg that you
 passed to get_data.
-```
+```lua
 player_config.bar= 5
 foo_config:set_dirty(pn)
 ```


### PR DESCRIPTION
This commit adds Lua syntax highlighting via GitHub Flavored Markdown under the notion that many novice themers will be viewing the .md files in a web-browser at GitHub.