### PR TITLE
[fix] add namespace to isnan

### DIFF
--- a/src/Sprite.cpp
+++ b/src/Sprite.cpp
@@ -1185,7 +1185,7 @@ public:
 		for( int i=0; i<8; ++i )
 		{
 			coords[i]= FArg(i+1);
-			if( isnan(coords[i]) )
+			if( std::isnan(coords[i]) )
 			{
 				coords[i]= 0.0f;
 			}

--- a/src/StreamDisplay.cpp
+++ b/src/StreamDisplay.cpp
@@ -141,7 +141,7 @@ void StreamDisplay::SetPercent( float fPercent )
 	float fLifeMultiplier = THEME->GetMetricF("LifeMeterBar","LifeMultiplier");
 #endif
 	DEBUG_ASSERT( fPercent >= 0.0f && fPercent <= 1.0f * fLifeMultiplier );
-	if( isnan(fPercent) )
+	if( std::isnan(fPercent) )
 	{
 		DEBUG_ASSERT_M( 0, "fPercent is NaN" );
 		fPercent = 1;


### PR DESCRIPTION
gcc 5.3.0 seams to need explicit namespace std:: for isnan 