### PR TITLE
Don't reset lights due to settings.

### DIFF
--- a/src/LightsManager.cpp
+++ b/src/LightsManager.cpp
@@ -369,6 +369,7 @@ void LightsManager::Update( float fDeltaTime )
 						m_LightsState.m_bGameButtonLights[gc][gb] = m_fSecsLeftInGameButtonBlink[gc][gb] > 0 ;
 					}
 				}
+				break;
 			}
 
 			// fall through to blink on button presses


### PR DESCRIPTION
Thank Trevor Barribeau for the fix.

This is required for the BlinkGameplayButtonLightsOnNote setting, particularly if it's set to 0 instead of 1.