### PR TITLE
Remappable screenshot key

### DIFF
--- a/Themes/_fallback/Languages/en.ini
+++ b/Themes/_fallback/Languages/en.ini
@@ -128,6 +128,7 @@ MenuLeft=MenuLeft
 MenuRight=MenuRight
 MenuUp=MenuUp
 Operator=Operator
+Screenshot=Screenshot
 EffectUp=EffectUp
 EffectDown=EffectDown
 Right=Right

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -16,7 +16,7 @@ TapNoteScore Game::MapTapNoteScore( TapNoteScore tns ) const
 	}
 }
 
-static std::array<Game::PerButtonInfo, 11> const g_CommonButtonInfo =
+static std::array<Game::PerButtonInfo, 12> const g_CommonButtonInfo =
 {
 	{
 		Game::PerButtonInfo{ GameButtonType_Menu }, // GAME_BUTTON_MENULEFT
@@ -28,6 +28,7 @@ static std::array<Game::PerButtonInfo, 11> const g_CommonButtonInfo =
 		Game::PerButtonInfo{ GameButtonType_Menu }, // GAME_BUTTON_BACK
 		Game::PerButtonInfo{ GameButtonType_Menu }, // GAME_BUTTON_COIN
 		Game::PerButtonInfo{ GameButtonType_Menu }, // GAME_BUTTON_OPERATOR
+		Game::PerButtonInfo{ GameButtonType_Menu }, // GAME_BUTTON_SCREENSHOT
 		Game::PerButtonInfo{ GameButtonType_Menu }, // GAME_BUTTON_EFFECT_UP
 		Game::PerButtonInfo{ GameButtonType_Menu }  // GAME_BUTTON_EFFECT_DOWN
 	}
@@ -36,7 +37,7 @@ static std::array<Game::PerButtonInfo, 11> const g_CommonButtonInfo =
 const Game::PerButtonInfo *Game::GetPerButtonInfo( GameButton gb ) const
 {
 	// TODO: Replace the need for this compile assert.
-	COMPILE_ASSERT( GAME_BUTTON_NEXT == 11 );
+	COMPILE_ASSERT( GAME_BUTTON_NEXT == 12 );
 	if( gb < GAME_BUTTON_NEXT )
 		return &g_CommonButtonInfo[gb];
 	else

--- a/src/GameInput.h
+++ b/src/GameInput.h
@@ -28,6 +28,7 @@ enum GameButton
 	GAME_BUTTON_BACK,
 	GAME_BUTTON_COIN, /**< Insert a coin to play. */
 	GAME_BUTTON_OPERATOR, /**< Access the operator menu. */
+	GAME_BUTTON_SCREENSHOT,
 	GAME_BUTTON_EFFECT_UP,
 	GAME_BUTTON_EFFECT_DOWN,
 	GAME_BUTTON_CUSTOM_01,

--- a/src/InputMapper.cpp
+++ b/src/InputMapper.cpp
@@ -68,7 +68,12 @@ static const AutoMappings g_DefaultKeyMappings = AutoMappings(
 	AutoMappingEntry( 0, KEY_KP_C0,	GAME_BUTTON_SELECT,	true ),
 	AutoMappingEntry( 0, KEY_HYPHEN,	GAME_BUTTON_BACK,	true ), // laptop keyboards.
 	AutoMappingEntry( 0, KEY_F1,	GAME_BUTTON_COIN,	false ),
-	AutoMappingEntry( 0, KEY_SCRLLOCK,	GAME_BUTTON_OPERATOR,	false )
+	AutoMappingEntry( 0, KEY_SCRLLOCK,	GAME_BUTTON_OPERATOR,	false ),
+#ifdef MACOSX
+	AutoMappingEntry( 0, KEY_F13, GAME_BUTTON_SCREENSHOT, false )
+#else
+	AutoMappingEntry( 0, KEY_PRTSC, GAME_BUTTON_SCREENSHOT, false )
+#endif
 );
 
 void InputMapper::AddDefaultMappingsForCurrentGameIfUnmapped()
@@ -1193,6 +1198,7 @@ static const InputScheme::GameButtonInfo g_CommonGameButtonInfo[] =
 	{ "Back",	GAME_BUTTON_BACK },
 	{ "Coin",	GAME_BUTTON_COIN },
 	{ "Operator",	GAME_BUTTON_OPERATOR },
+	{ "Screenshot",	GAME_BUTTON_SCREENSHOT },
 	{ "EffectUp",	GAME_BUTTON_EFFECT_UP },
 	{ "EffectDown",	GAME_BUTTON_EFFECT_DOWN },
 };

--- a/src/ScreenManager.cpp
+++ b/src/ScreenManager.cpp
@@ -252,6 +252,7 @@ ScreenManager::ScreenManager()
 
 	g_pSharedBGA = new Actor;
 
+	m_disable_special_keys= false;
 	m_bReloadOverlayScreensAfterInput= false;
 	m_bZeroNextUpdate = false;
 	m_PopTopScreen = SM_Invalid;

--- a/src/ScreenManager.h
+++ b/src/ScreenManager.h
@@ -74,6 +74,12 @@ public:
 
 	void	PlaySharedBackgroundOffCommand();
 	void    ZeroNextUpdate();
+
+	// ScreenMapControllers needs some way to disable special actions like
+	// taking a screenshot or opening the operator menu to allow remapping the
+	// keys mapped to those actions.  If m_disable_special_keys is true, those
+	// actions are ignored. -Kyz
+	bool m_disable_special_keys;
 private:
 	// Screen loads, removals, and concurrent prepares are delayed until the next update.
 	std::string		m_sDelayedScreen;

--- a/src/ScreenMapControllers.cpp
+++ b/src/ScreenMapControllers.cpp
@@ -316,6 +316,7 @@ void ScreenMapControllers::Update( float fDeltaTime )
 		}
 		Refresh();
 		SCREENMAN->PlayStartSound();
+		SCREENMAN->m_disable_special_keys= false;
 	}
 }
 
@@ -690,6 +691,7 @@ void ScreenMapControllers::SetCursorFromSetListCurrent()
 
 void ScreenMapControllers::StartWaitingForPress()
 {
+	SCREENMAN->m_disable_special_keys= true;
 	const KeyToMap *pKey = &m_KeysToMap[CurKeyIndex()];
 	BitmapText *pText = pKey->m_textMappedTo[m_CurController][m_CurSlot];
 	pText->PlayCommand( "Waiting" );

--- a/src/StepMania.cpp
+++ b/src/StepMania.cpp
@@ -1376,14 +1376,15 @@ bool HandleGlobalInputs( const InputEventPlus &input )
 			/* Global operator key, to get quick access to the options menu. Don't
 			 * do this if we're on a "system menu", which includes the editor
 			 * (to prevent quitting without storing changes). */
-			if( SCREENMAN->AllowOperatorMenuButton() )
+			if( SCREENMAN->AllowOperatorMenuButton() && !SCREENMAN->m_disable_special_keys)
 			{
 				SCREENMAN->SystemMessage( SERVICE_SWITCH_PRESSED.GetValue() );
 				SCREENMAN->PopAllScreens();
 				GAMESTATE->Reset();
 				SCREENMAN->SetNewScreen( CommonMetrics::OPERATOR_MENU_SCREEN.GetValue() );
 			}
-			return true;
+			// Return false if special keys are disabled, to allow remapping. -Kyz
+			return !SCREENMAN->m_disable_special_keys;
 
 		case GAME_BUTTON_COIN:
 			// Handle a coin insertion.
@@ -1471,11 +1472,9 @@ bool HandleGlobalInputs( const InputEventPlus &input )
 	}
 #endif
 
-	bool bDoScreenshot =
 #if defined(MACOSX)
+	bool do_screenshot = input.MenuI == GAME_BUTTON_SCREENSHOT ||
 	// Notebooks don't have F13. Use cmd-F12 as well.
-		input.DeviceI == DeviceInput( DEVICE_KEYBOARD, KEY_PRTSC ) ||
-		input.DeviceI == DeviceInput( DEVICE_KEYBOARD, KEY_F13 ) ||
 		( input.DeviceI == DeviceInput(DEVICE_KEYBOARD, KEY_F12) &&
 		  (INPUTFILTER->IsBeingPressed(DeviceInput(DEVICE_KEYBOARD, KEY_LMETA), &input.InputList) ||
 		   INPUTFILTER->IsBeingPressed(DeviceInput(DEVICE_KEYBOARD, KEY_RMETA), &input.InputList)) );
@@ -1485,11 +1484,11 @@ bool HandleGlobalInputs( const InputEventPlus &input )
 	 * Alt+PrntScrn. Windows will do this whether or not we save a screenshot
 	 * ourself by dumping the frame buffer. */
 	// "if pressing PrintScreen and not pressing Alt"
-		input.DeviceI == DeviceInput(DEVICE_KEYBOARD, KEY_PRTSC) &&
+	bool do_screenshot = input.MenuI == GAME_BUTTON_SCREENSHOT &&
 		!INPUTFILTER->IsBeingPressed(DeviceInput(DEVICE_KEYBOARD, KEY_LALT), &input.InputList) &&
 		!INPUTFILTER->IsBeingPressed(DeviceInput(DEVICE_KEYBOARD, KEY_RALT), &input.InputList);
 #endif
-	if( bDoScreenshot )
+	if(do_screenshot && !SCREENMAN->m_disable_special_keys)
 	{
 		// If holding Shift save uncompressed, else save compressed
 		bool bHoldingShift = ( INPUTFILTER->IsBeingPressed( DeviceInput(DEVICE_KEYBOARD, KEY_LSHIFT) )


### PR DESCRIPTION
A few changes to allow mapping a key for taking screenshots, and using the Print Screen key for other things.

LightsDriver_SextetStream sets light states based on game buttons, so maybe adding a new game button affects lights somehow?
@psmay should look into this, since he did that lights driver.