### PR TITLE
Release Lua locks responsibly; fix a USB profile crash

### DIFF
--- a/src/ActorFrame.cpp
+++ b/src/ActorFrame.cpp
@@ -238,6 +238,7 @@ void ActorFrame::DrawPrimitives()
 		m_DrawFunction.PushSelf( L );
 		if( lua_isnil(L, -1) )
 		{
+			LUA->Release(L);
 			LuaHelpers::ReportScriptErrorFmt( "Error compiling DrawFunction" );
 			return;
 		}
@@ -487,6 +488,7 @@ void ActorFrame::UpdateInternal( float fDeltaTime )
 		m_UpdateFunction.PushSelf( L );
 		if( lua_isnil(L, -1) )
 		{
+			LUA->Release(L);
 			LuaHelpers::ReportScriptErrorFmt( "Error compiling UpdateFunction" );
 			return;
 		}

--- a/src/NoteSkinManager.cpp
+++ b/src/NoteSkinManager.cpp
@@ -487,6 +487,7 @@ Actor *NoteSkinManager::LoadActor( const RString &sButton, const RString &sEleme
 
 	if( !PushActorTemplate(L, sButton, sElement, bSpriteOnly) )
 	{
+		LUA->Release( L );
 		// ActorUtil will warn about the error
 		return Sprite::NewBlankSprite();
 	}
@@ -494,6 +495,7 @@ Actor *NoteSkinManager::LoadActor( const RString &sButton, const RString &sEleme
 	auto_ptr<XNode> pNode( XmlFileUtil::XNodeFromTable(L) );
 	if( pNode.get() == NULL )
 	{
+		LUA->Release( L );
 		// XNode will warn about the error
 		return Sprite::NewBlankSprite();
 	}

--- a/src/Player.cpp
+++ b/src/Player.cpp
@@ -3142,6 +3142,7 @@ void Player::SetHoldJudgment( TapNote &tn, int iTrack )
 		Lua* L = LUA->Get();
 		tn.PushSelf(L);
 		msg.SetParamFromStack( L, "TapNote" );
+		LUA->Release( L );
 
 		MESSAGEMAN->Broadcast( msg );
 	}


### PR DESCRIPTION
We were missing some LUA->Release calls.  It looks like this (particularly the edit in Player.cpp) will also magically fix memory card crashes on Linux.  It used to encounter a mutex "deadlock" on the first plug after playing a round, I assume due to the main thread getting a bunch of Luas without releasing, thereby preventing the memory card thread from ever getting any at all.