### PR TITLE
Alloca problems

### DIFF
--- a/src/RageSoundReader_Resample_Good.cpp
+++ b/src/RageSoundReader_Resample_Good.cpp
@@ -667,8 +667,7 @@ int RageSoundReader_Resample_Good::Read( float *pBuf, int iFrames )
 
 	{
 		int iFramesNeeded = m_apResamplers[0]->NumInputsForOutputSamples(iFrames);
-		float *pTmpBuf = (float *) alloca( iFramesNeeded * sizeof(float) * iChannels );
-		ASSERT( pTmpBuf != NULL );
+		float pTmpBuf[iFramesNeeded * iChannels];
 		int iFramesIn = m_pSource->Read( pTmpBuf, iFramesNeeded );
 		if( iFramesIn < 0 )
 			return iFramesIn;

--- a/src/RageSoundReader_Resample_Good.cpp
+++ b/src/RageSoundReader_Resample_Good.cpp
@@ -667,7 +667,7 @@ int RageSoundReader_Resample_Good::Read( float *pBuf, int iFrames )
 
 	{
 		int iFramesNeeded = m_apResamplers[0]->NumInputsForOutputSamples(iFrames);
-		float pTmpBuf[iFramesNeeded * iChannels];
+		float *pTmpBuf = (float *) alloca( iFramesNeeded * sizeof(float) * iChannels );
 		int iFramesIn = m_pSource->Read( pTmpBuf, iFramesNeeded );
 		if( iFramesIn < 0 )
 			return iFramesIn;

--- a/src/RageSoundReader_SpeedChange.cpp
+++ b/src/RageSoundReader_SpeedChange.cpp
@@ -89,7 +89,7 @@ int RageSoundReader_SpeedChange::FillData( int iMaxFrames )
 		if( iBytesToRead <= 0 )
 			return m_iDataBufferAvailFrames;
 
-		float *pTempBuffer = (float *) alloca( iBytesToRead );
+		float pTempBuffer[iBytesToRead/sizeof(float)];
 		int iGotFrames = m_pSource->Read( pTempBuffer, iFramesToRead );
 		if( iGotFrames < 0 )
 		{

--- a/src/RageSoundReader_SpeedChange.cpp
+++ b/src/RageSoundReader_SpeedChange.cpp
@@ -89,10 +89,11 @@ int RageSoundReader_SpeedChange::FillData( int iMaxFrames )
 		if( iBytesToRead <= 0 )
 			return m_iDataBufferAvailFrames;
 
-		float pTempBuffer[iBytesToRead/sizeof(float)];
+		float* pTempBuffer= new float[iBytesToRead/sizeof(float)];
 		int iGotFrames = m_pSource->Read( pTempBuffer, iFramesToRead );
 		if( iGotFrames < 0 )
 		{
+			delete[] pTempBuffer;
 			if( iGotFrames == END_OF_FILE && m_iDataBufferAvailFrames )
 				return m_iDataBufferAvailFrames;
 			return iGotFrames;
@@ -114,6 +115,7 @@ int RageSoundReader_SpeedChange::FillData( int iMaxFrames )
 				++pOut;
 			}
 		}
+		delete[] pTempBuffer;
 
 		m_iDataBufferAvailFrames += iGotFrames;
 	}

--- a/src/RageSoundReader_WAV.cpp
+++ b/src/RageSoundReader_WAV.cpp
@@ -288,8 +288,8 @@ public:
 		/* We've read the block header; read the rest.  Don't read past the end of the data chunk. */
 		int iMaxSize = min( (int) m_WavData.m_iBlockAlign - 7 * m_WavData.m_iChannels, (m_WavData.m_iDataChunkSize+m_WavData.m_iDataChunkPos) - m_File.Tell() );
 
-		char *pBuf = (char *) alloca( iMaxSize );
-		ASSERT( pBuf != NULL );
+		char cBuf[iMaxSize];
+		char* pBuf= cBuf;
 
 		int iBlockSize = m_File.Read( pBuf, iMaxSize );
 		if( iBlockSize == 0 )

--- a/src/RageSoundReader_WAV.cpp
+++ b/src/RageSoundReader_WAV.cpp
@@ -288,8 +288,7 @@ public:
 		/* We've read the block header; read the rest.  Don't read past the end of the data chunk. */
 		int iMaxSize = min( (int) m_WavData.m_iBlockAlign - 7 * m_WavData.m_iChannels, (m_WavData.m_iDataChunkSize+m_WavData.m_iDataChunkPos) - m_File.Tell() );
 
-		char cBuf[iMaxSize];
-		char* pBuf= cBuf;
+		char *pBuf = (char *) alloca( iMaxSize );
 
 		int iBlockSize = m_File.Read( pBuf, iMaxSize );
 		if( iBlockSize == 0 )

--- a/src/RageSurface_Load_PNG.cpp
+++ b/src/RageSurface_Load_PNG.cpp
@@ -50,7 +50,10 @@ void PNG_Error( png_struct *png, const char *error )
 	strncpy( info->err, error, 1024 );
 	info->err[1023] = 0;
 	LOG->Trace( "loading \"%s\": err: %s", info->fn, info->err );
-	longjmp( png_jmpbuf(png), 1 );
+	// This exception is just thrown to go to the catch block for cleanup.  The
+	// message has already been printed, so the exception value can be ignored.
+	// -Kyz
+	throw int(1);
 }
 
 void PNG_Warning( png_struct *png, const char *warning )
@@ -87,12 +90,10 @@ static RageSurface *RageSurface_Load_PNG( RageFile *f, const char *fn, char erro
 
 	RageSurface *volatile img = NULL;
 	CHECKPOINT_M("Potential issue with png jump about to be analyzed.");
-	if( setjmp(png_jmpbuf(png) ))
+
+	png_byte** row_pointers= NULL;
+	try
 	{
-		png_destroy_read_struct( &png, &info_ptr, NULL );
-		delete img;
-		return NULL;
-	}
 
 	png_set_read_fn( png, f, RageFile_png_read );
 
@@ -227,8 +228,7 @@ static RageSurface *RageSurface_Load_PNG( RageFile *f, const char *fn, char erro
 	}
 	ASSERT( img != NULL );
 
-	/* alloca to prevent memleaks if libpng longjmps us */
-	png_byte **row_pointers = (png_byte **) alloca( sizeof(png_byte*) * height );
+	row_pointers = new png_byte*[height];
 	CHECKPOINT_M( ssprintf("%p",row_pointers) );
 
 	for( unsigned y = 0; y < height; ++y )
@@ -241,6 +241,17 @@ static RageSurface *RageSurface_Load_PNG( RageFile *f, const char *fn, char erro
 
 	png_read_end( png, info_ptr );
 	png_destroy_read_struct( &png, &info_ptr, NULL );
+	}
+	catch(int e)
+	{
+		png_destroy_read_struct(&png, &info_ptr, NULL);
+		delete img;
+		if(row_pointers != NULL)
+		{
+			delete[] row_pointers;
+		}
+		return NULL;
+	}
 
 	return img;
 }


### PR DESCRIPTION
Pretty sure alloca inside a while loop was causing a stack overflow in the sound code.

alloca and setjmp/longjmp don't actually work together, so the png loading has also been changed to use exceptions instead of setjmp/longjmp, and new/delete instead of alloca.