### PR TITLE
Use standard conversion functions for int/float.

### DIFF
--- a/src/BGAnimationLayer.cpp
+++ b/src/BGAnimationLayer.cpp
@@ -417,22 +417,31 @@ void BGAnimationLayer::LoadFromNode( const XNode* pNode )
 		{
 			m_Type = TYPE_TILES;
 		}
-		else if( StringToInt(type) == 1 )
-		{
-			m_Type = TYPE_SPRITE;
-			bStretch = true;
-		}
-		else if( StringToInt(type) == 2 )
-		{
-			m_Type = TYPE_PARTICLES;
-		}
-		else if( StringToInt(type) == 3 )
-		{
-			m_Type = TYPE_TILES;
-		}
 		else
 		{
-			m_Type = TYPE_SPRITE;
+			try
+			{
+				int numType = std::stoi(type);
+				switch (numType)
+				{
+					case 1:
+						m_Type = TYPE_SPRITE;
+						bStretch = true;
+						break;
+					case 2:
+						m_Type = TYPE_PARTICLES;
+						break;
+					case 3:
+						m_Type = TYPE_TILES;
+						break;
+					default:
+						m_Type = TYPE_SPRITE;
+				}
+			}
+			catch (...)
+			{
+				m_Type = TYPE_SPRITE;
+			}
 		}
 	}
 

--- a/src/CourseLoaderCRS.cpp
+++ b/src/CourseLoaderCRS.cpp
@@ -95,17 +95,17 @@ bool CourseLoaderCRS::LoadFromMsd( const std::string &sPath, const MsdFile &msd,
 		}
 		else if(tagName == "LIVES" )
 		{
-			out.m_iLives = max( StringToInt(sParams[1]), 0 );
+			out.m_iLives = max( std::stoi(sParams[1]), 0 );
 		}
 		else if(tagName == "GAINSECONDS" )
 		{
-			fGainSeconds = StringToFloat( sParams[1] );
+			fGainSeconds = std::stof( sParams[1] );
 		}
 		else if(tagName == "METER" )
 		{
 			if( sParams.params.size() == 2 )
 			{
-				out.m_iCustomMeter[Difficulty_Medium] = max( StringToInt(sParams[1]), 0 ); /* compat */
+				out.m_iCustomMeter[Difficulty_Medium] = max( std::stoi(sParams[1]), 0 ); /* compat */
 			}
 			else if( sParams.params.size() == 3 )
 			{
@@ -115,7 +115,7 @@ bool CourseLoaderCRS::LoadFromMsd( const std::string &sPath, const MsdFile &msd,
 					LOG->UserLog( "Course file", sPath, "contains an invalid #METER string: \"%s\"", sParams[1].c_str() );
 					continue;
 				}
-				out.m_iCustomMeter[cd] = max( StringToInt(sParams[2]), 0 );
+				out.m_iCustomMeter[cd] = max( std::stoi(sParams[2]), 0 );
 			}
 		}
 
@@ -134,15 +134,15 @@ bool CourseLoaderCRS::LoadFromMsd( const std::string &sPath, const MsdFile &msd,
 				Rage::ci_ascii_string tagName{ Rage::trim(sBits[0]).c_str() };
 				if( tagName == "TIME" )
 				{
-					attack.fStartSecond = max( StringToFloat(sBits[1]), 0.0f );
+					attack.fStartSecond = max( std::stof(sBits[1]), 0.0f );
 				}
 				else if( tagName == "LEN" )
 				{
-					attack.fSecsRemaining = StringToFloat( sBits[1] );
+					attack.fSecsRemaining = std::stof( sBits[1] );
 				}
 				else if( tagName == "END" )
 				{
-					end = StringToFloat( sBits[1] );
+					end = std::stof( sBits[1] );
 				}
 				else if( tagName == "MODS" )
 				{
@@ -183,7 +183,7 @@ bool CourseLoaderCRS::LoadFromMsd( const std::string &sPath, const MsdFile &msd,
 			// most played
 			if (Rage::starts_with(sParams[1], "BEST"))
 			{
-				int iChooseIndex = StringToInt( Rage::tail( sParams[1], -4 ) ) - 1;
+				int iChooseIndex = std::stoi( Rage::tail( sParams[1], -4 ) ) - 1;
 				if( iChooseIndex > iNumSongs )
 				{
 					// looking up a song that doesn't exist.
@@ -200,7 +200,7 @@ bool CourseLoaderCRS::LoadFromMsd( const std::string &sPath, const MsdFile &msd,
 			// least played
 			else if (Rage::starts_with(sParams[1], "WORST"))
 			{
-				int iChooseIndex = StringToInt(Rage::tail(sParams[1], -5)) - 1;
+				int iChooseIndex = std::stoi(Rage::tail(sParams[1], -5)) - 1;
 				if( iChooseIndex > iNumSongs )
 				{
 					// looking up a song that doesn't exist.
@@ -217,14 +217,14 @@ bool CourseLoaderCRS::LoadFromMsd( const std::string &sPath, const MsdFile &msd,
 			// best grades
 			else if (Rage::starts_with(sParams[1], "GRADEBEST"))
 			{
-				new_entry.iChooseIndex = StringToInt(Rage::tail(sParams[1], -9)) - 1;
+				new_entry.iChooseIndex = std::stoi(Rage::tail(sParams[1], -9)) - 1;
 				new_entry.iChooseIndex = Rage::clamp( new_entry.iChooseIndex, 0, 500 );
 				new_entry.songSort = SongSort_TopGrades;
 			}
 			// worst grades
 			else if (Rage::starts_with(sParams[1], "GRADEWORST"))
 			{
-				new_entry.iChooseIndex = StringToInt(Rage::tail(sParams[1], -10)) - 1;
+				new_entry.iChooseIndex = std::stoi(Rage::tail(sParams[1], -10)) - 1;
 				new_entry.iChooseIndex = Rage::clamp( new_entry.iChooseIndex, 0, 500 );
 				new_entry.songSort = SongSort_LowestGrades;
 			}
@@ -326,7 +326,7 @@ bool CourseLoaderCRS::LoadFromMsd( const std::string &sPath, const MsdFile &msd,
 					}
 					else if (sMod.length() > 5 && Rage::ci_ascii_string{ "award" } == Rage::head(sMod, 5))
 					{
-						new_entry.iGainLives = StringToInt(sMod.substr(5));
+						new_entry.iGainLives = std::stoi(sMod.substr(5));
 					}
 					else
 					{
@@ -349,8 +349,8 @@ bool CourseLoaderCRS::LoadFromMsd( const std::string &sPath, const MsdFile &msd,
 		}
 		else if( bFromCache && tagName == "RADAR" )
 		{
-			StepsType st = (StepsType) StringToInt(sParams[1]);
-			CourseDifficulty cd = (CourseDifficulty) StringToInt( sParams[2] );
+			StepsType st = (StepsType) std::stoi(sParams[1]);
+			CourseDifficulty cd = (CourseDifficulty) std::stoi( sParams[2] );
 
 			RadarValues rv;
 			rv.FromString( sParams[3] );

--- a/src/FileDownload.cpp
+++ b/src/FileDownload.cpp
@@ -271,17 +271,20 @@ void FileTransfer::HTTPUpdate()
 			m_sResponseName = "Malformed response.";
 			return;
 		}
-		m_iResponseCode = StringToInt(m_sBUFFER.substr(i+1,j-i));
+		m_iResponseCode = std::stoi(m_sBUFFER.substr(i+1,j-i));
 		m_sResponseName = m_sBUFFER.substr( j+1, k-j );
 
 		i = m_sBUFFER.find("Content-Length:");
 		j = m_sBUFFER.find("\n", i+1 );
 
 		if( i != string::npos )
-			m_iTotalBytes = StringToInt(m_sBUFFER.substr(i+16,j-i));
+		{
+			m_iTotalBytes = std::stoi(m_sBUFFER.substr(i+16,j-i));
+		}
 		else
+		{
 			m_iTotalBytes = -1;	// We don't know, so go until disconnect
-
+		}
 		m_bGotHeader = true;
 		m_sBUFFER.erase( 0, iHeaderEnd );
 	}
@@ -349,13 +352,16 @@ bool FileTransfer::ParseHTTPAddress( const std::string &URL, std::string &sProto
 	sServer = asMatches[1];
 	if( asMatches[3] != "" )
 	{
-		iPort = StringToInt(asMatches[3]);
+		iPort = std::stoi(asMatches[3]);
 		if( iPort == 0 )
+		{
 			return false;
+		}
 	}
 	else
+	{
 		iPort = 80;
-
+	}
 	sAddress = asMatches[5];
 
 	return true;

--- a/src/Font.cpp
+++ b/src/Font.cpp
@@ -501,7 +501,7 @@ void Font::LoadFontPageSettings( FontPageSettings &cfg, IniFile &ini, const std:
 			// If val is an integer, it's a width, eg. "10=27".
 			if( IsAnInt(sName) )
 			{
-				cfg.m_mapGlyphWidths[StringToInt(sName)] = pValue->GetValue<int>();
+				cfg.m_mapGlyphWidths[std::stoi(sName)] = pValue->GetValue<int>();
 				continue;
 			}
 
@@ -615,7 +615,7 @@ void Font::LoadFontPageSettings( FontPageSettings &cfg, IniFile &ini, const std:
 						row_str.c_str());
 					continue;
 				}
-				const int row = StringToInt(row_str);
+				const int row = std::stoi(row_str);
 				const int first_frame = row * num_frames_wide;
 
 				if(row >= num_frames_high)

--- a/src/GameCommand.cpp
+++ b/src/GameCommand.cpp
@@ -387,12 +387,12 @@ void GameCommand::LoadOne( const Command& cmd )
 
 	else if( sName == "weight" )
 	{
-		m_iWeightPounds = StringToInt( sValue );
+		m_iWeightPounds = std::stoi( sValue );
 	}
 
 	else if( sName == "goalcalories" )
 	{
-		m_iGoalCalories = StringToInt( sValue );
+		m_iGoalCalories = std::stoi( sValue );
 	}
 
 	else if( sName == "goaltype" )

--- a/src/GameState.cpp
+++ b/src/GameState.cpp
@@ -248,10 +248,11 @@ void GameState::ApplyCmdline()
 	std::string sPlayer;
 	for( int i = 0; GetCommandlineArgument( "player", &sPlayer, i ); ++i )
 	{
-		int pn = StringToInt( sPlayer )-1;
+		int pn = std::stoi( sPlayer )-1;
 		if( !IsAnInt( sPlayer ) || pn < 0 || pn >= NUM_PLAYERS )
+		{
 			RageException::Throw( "Invalid argument \"--player=%s\".", sPlayer.c_str() );
-
+		}
 		JoinPlayer( (PlayerNumber) pn );
 	}
 

--- a/src/NoteField.cpp
+++ b/src/NoteField.cpp
@@ -872,11 +872,11 @@ IsOnScreen(fBeat, 0, static_cast<int>(m_FieldRenderArgs.draw_pixels_after_target
 			} \
 		}
 
-		draw_all_segments(FloatToString(seg->GetRatio()), Scroll, SCROLL);
-		draw_all_segments(FloatToString(seg->GetBPM()), BPM, BPM);
-		draw_all_segments(FloatToString(seg->GetPause()), Stop, STOP);
-		draw_all_segments(FloatToString(seg->GetPause()), Delay, DELAY);
-		draw_all_segments(FloatToString(seg->GetLength()), Warp, WARP);
+		draw_all_segments(std::to_string(seg->GetRatio()), Scroll, SCROLL);
+		draw_all_segments(std::to_string(seg->GetBPM()), BPM, BPM);
+		draw_all_segments(std::to_string(seg->GetPause()), Stop, STOP);
+		draw_all_segments(std::to_string(seg->GetPause()), Delay, DELAY);
+		draw_all_segments(std::to_string(seg->GetLength()), Warp, WARP);
 		draw_all_segments(fmt::sprintf("%d\n--\n%d", seg->GetNum(), seg->GetDen()),
 			TimeSignature, TIME_SIG);
 		draw_all_segments(fmt::sprintf("%d", seg->GetTicks()), Tickcount, TICKCOUNT);
@@ -884,10 +884,10 @@ IsOnScreen(fBeat, 0, static_cast<int>(m_FieldRenderArgs.draw_pixels_after_target
 			fmt::sprintf("%d/%d", seg->GetCombo(), seg->GetMissCombo()), Combo, COMBO);
 		draw_all_segments(seg->GetLabel(), Label, LABEL);
 		draw_all_segments(fmt::sprintf("%s\n%s\n%s",
-				FloatToString(seg->GetRatio()).c_str(),
+				std::to_string(seg->GetRatio()).c_str(),
 				(seg->GetUnit() == 1 ? "S" : "B"),
-				FloatToString(seg->GetDelay()).c_str()), Speed, SPEED);
-		draw_all_segments(FloatToString(seg->GetLength()), Fake, FAKE);
+				std::to_string(seg->GetDelay()).c_str()), Speed, SPEED);
+		draw_all_segments(std::to_string(seg->GetLength()), Fake, FAKE);
 #undef draw_all_segments
 
 		// Course mods text

--- a/src/NoteSkinManager.cpp
+++ b/src/NoteSkinManager.cpp
@@ -312,18 +312,18 @@ std::string NoteSkinManager::GetMetric( const std::string &sButtonName, const st
 
 int NoteSkinManager::GetMetricI( const std::string &sButtonName, const std::string &sValueName )
 {
-	return StringToInt( GetMetric(sButtonName,sValueName) );
+	return std::stoi( GetMetric(sButtonName,sValueName) );
 }
 
 float NoteSkinManager::GetMetricF( const std::string &sButtonName, const std::string &sValueName )
 {
-	return StringToFloat( GetMetric(sButtonName,sValueName) );
+	return std::stof( GetMetric(sButtonName,sValueName) );
 }
 
 bool NoteSkinManager::GetMetricB( const std::string &sButtonName, const std::string &sValueName )
 {
 	// Could also call GetMetricI here...hmm.
-	return StringToInt( GetMetric(sButtonName,sValueName) ) != 0;
+	return std::stoi( GetMetric(sButtonName,sValueName) ) != 0;
 }
 
 apActorCommands NoteSkinManager::GetMetricA( const std::string &sButtonName, const std::string &sValueName )

--- a/src/NotesLoaderBMS.cpp
+++ b/src/NotesLoaderBMS.cpp
@@ -482,9 +482,10 @@ struct bmsCommandTree
 		else if (name == "#random")
 		{
 			while (randomStack.size() < currentNode->branchHeight + 1) // if we're on branch level N we need N+1 values.
+			{
 				randomStack.push_back(0);
-
-			randomStack[currentNode->branchHeight] = rand() % StringToInt(value) + 1;
+			}
+			randomStack[currentNode->branchHeight] = rand() % std::stoi(value) + 1;
 		}
 		else
 		{
@@ -555,7 +556,7 @@ bool BMSChart::Load( const std::string &chartPath )
 		if (channel == 2)
 		{
 			// special channel: time signature
-			BMSMeasure m = { StringToFloat(data) };
+			BMSMeasure m = { std::stof(data) };
 			this->measures[measure] = m;
 		}
 		else
@@ -874,7 +875,7 @@ void BMSChartReader::ReadHeaders()
 		}
 		else if( it.first == "#bpm" )
 		{
-			initialBPM = StringToFloat(it.second);
+			initialBPM = std::stof(it.second);
 		}
 		else if( it.first == "#lntype" )
 		{
@@ -891,12 +892,12 @@ void BMSChartReader::ReadHeaders()
 		}
 		else if( it.first == "#playlevel" )
 		{
-			out->SetMeter( StringToInt(it.second) );
+			out->SetMeter( std::stoi(it.second) );
 		}
 		else if( it.first == "#difficulty")
 		{
 			// only set the difficulty if the #difficulty tag is between 1 and 6 (beginner~edit)
-			int diff = StringToInt(it.second)-1; // BMS uses 1 to 6, SM uses 0 to 5
+			int diff = std::stoi(it.second)-1; // BMS uses 1 to 6, SM uses 0 to 5
 			if(diff>=0 && diff<NUM_Difficulty)
 			{
 				out->SetDifficulty( (Difficulty)diff );
@@ -914,7 +915,7 @@ void BMSChartReader::ReadHeaders()
 		else if (it.first == "#offset")
 		{
 			// This gets copied into the real timing data later.
-			out->m_Timing.m_fBeat0OffsetInSeconds = -StringToFloat(it.second);
+			out->m_Timing.m_fBeat0OffsetInSeconds = -std::stof(it.second);
 		}
 		else if (it.first == "#maker")
 		{
@@ -922,7 +923,7 @@ void BMSChartReader::ReadHeaders()
 		}
 		else if (it.first == "#previewpoint")
 		{
-			info.previewStart = StringToFloat(it.second);
+			info.previewStart = std::stof(it.second);
 		}
 	}
 }
@@ -1384,7 +1385,7 @@ bool BMSChartReader::ReadNoteData()
 			BMSHeaders::iterator it = in->headers.find( search );
 			if( it != in->headers.end() )
 			{
-				td.SetBPMAtRow( row, measureAdjust * (currentBPM = StringToFloat(it->second)) );
+				td.SetBPMAtRow( row, measureAdjust * (currentBPM = std::stof(it->second)) );
 			}
 			else
 			{
@@ -1397,7 +1398,7 @@ bool BMSChartReader::ReadNoteData()
 			BMSHeaders::iterator it = in->headers.find( search );
 			if( it != in->headers.end() )
 			{
-				td.SetStopAtRow( row, (StringToFloat(it->second) / 48.0f) * (60.0f / currentBPM) );
+				td.SetStopAtRow( row, (std::stof(it->second) / 48.0f) * (60.0f / currentBPM) );
 			}
 			else
 			{

--- a/src/NotesLoaderKSF.cpp
+++ b/src/NotesLoaderKSF.cpp
@@ -63,14 +63,14 @@ static bool LoadFromKSFFile( const std::string &sPath, Steps &out, Song &song, b
 		}
 		else if( sValueName=="BPM" )
 		{
-			BPM1 = StringToFloat(sParams[1]);
+			BPM1 = std::stof(sParams[1]);
 			stepsTiming.AddSegment( BPMSegment(0, BPM1) );
 		}
 		else if( sValueName=="BPM2" )
 		{
 			if (bKIUCompliant)
 			{
-				BPM2 = StringToFloat( sParams[1] );
+				BPM2 = std::stof( sParams[1] );
 			}
 			else
 			{
@@ -81,7 +81,7 @@ static bool LoadFromKSFFile( const std::string &sPath, Steps &out, Song &song, b
 		{
 			if (bKIUCompliant)
 			{
-				BPM3 = StringToFloat( sParams[1] );
+				BPM3 = std::stof( sParams[1] );
 			}
 			else
 			{
@@ -92,7 +92,7 @@ static bool LoadFromKSFFile( const std::string &sPath, Steps &out, Song &song, b
 		{
 			if (bKIUCompliant)
 			{
-				BPMPos2 = StringToFloat( sParams[1] ) / 100.0f;
+				BPMPos2 = std::stof( sParams[1] ) / 100.0f;
 			}
 			else
 			{
@@ -103,7 +103,7 @@ static bool LoadFromKSFFile( const std::string &sPath, Steps &out, Song &song, b
 		{
 			if (bKIUCompliant)
 			{
-				BPMPos3 = StringToFloat( sParams[1] ) / 100.0f;
+				BPMPos3 = std::stof( sParams[1] ) / 100.0f;
 			}
 			else
 			{
@@ -112,7 +112,7 @@ static bool LoadFromKSFFile( const std::string &sPath, Steps &out, Song &song, b
 		}
 		else if( sValueName=="STARTTIME" )
 		{
-			SMGap1 = -StringToFloat( sParams[1] )/100;
+			SMGap1 = -std::stof( sParams[1] )/100;
 			stepsTiming.m_fBeat0OffsetInSeconds = SMGap1;
 		}
 		// This is currently required for more accurate KIU BPM changes.
@@ -120,7 +120,7 @@ static bool LoadFromKSFFile( const std::string &sPath, Steps &out, Song &song, b
 		{
 			if (bKIUCompliant)
 			{
-				SMGap2 = -StringToFloat( sParams[1] )/100;
+				SMGap2 = -std::stof( sParams[1] )/100;
 			}
 			else
 			{
@@ -135,7 +135,7 @@ static bool LoadFromKSFFile( const std::string &sPath, Steps &out, Song &song, b
 
 		else if( sValueName=="TICKCOUNT" )
 		{
-			iTickCount = StringToInt( sParams[1] );
+			iTickCount = std::stoi( sParams[1] );
 			if( iTickCount <= 0 )
 			{
 				LOG->UserLog( "Song file", sPath, "has an invalid tick count: %d.", iTickCount );
@@ -146,7 +146,7 @@ static bool LoadFromKSFFile( const std::string &sPath, Steps &out, Song &song, b
 
 		else if( sValueName=="DIFFICULTY" )
 		{
-			out.SetMeter( max(StringToInt(sParams[1]), 1) );
+			out.SetMeter( max(std::stoi(sParams[1]), 1) );
 		}
 		// new cases from Aldo_MX's fork:
 		else if( sValueName=="PLAYER" )
@@ -350,7 +350,7 @@ static bool LoadFromKSFFile( const std::string &sPath, Steps &out, Song &song, b
 			//continue;
 
 			std::string temp = sRowString.substr(2,sRowString.size()-3);
-			float numTemp = StringToFloat(temp);
+			float numTemp = std::stof(temp);
 			if (Rage::starts_with(sRowString, "|T"))
 			{
 				// duh
@@ -522,12 +522,13 @@ static void ProcessTickcounts( const std::string & value, int & ticks, TimingDat
 	/* TICKCOUNT will be used below if there are DM compliant BPM changes
 	 * and stops. It will be called again in LoadFromKSFFile for the
 	 * actual steps. */
-	ticks = StringToInt( value );
+	ticks = std::stoi( value );
 	ticks = Rage::clamp( ticks, 0, ROWS_PER_BEAT );
 
 	if( ticks == 0 )
+	{
 		ticks = TickcountSegment::DEFAULT_TICK_COUNT;
-
+	}
 	timing.AddSegment( TickcountSegment(0, ticks) );
 }
 
@@ -569,39 +570,39 @@ static bool LoadGlobalData( const std::string &sPath, Song &out, bool &bKIUCompl
 			LoadTags(sParams[1], out);
 		else if( sValueName=="BPM" )
 		{
-			BPM1 = StringToFloat(sParams[1]);
+			BPM1 = std::stof(sParams[1]);
 			out.m_SongTiming.AddSegment( BPMSegment(0, BPM1) );
 		}
 		else if( sValueName=="BPM2" )
 		{
 			bKIUCompliant = true;
-			BPM2 = StringToFloat( sParams[1] );
+			BPM2 = std::stof( sParams[1] );
 		}
 		else if( sValueName=="BPM3" )
 		{
 			bKIUCompliant = true;
-			BPM3 = StringToFloat( sParams[1] );
+			BPM3 = std::stof( sParams[1] );
 		}
 		else if( sValueName=="BUNKI" )
 		{
 			bKIUCompliant = true;
-			BPMPos2 = StringToFloat( sParams[1] ) / 100.0f;
+			BPMPos2 = std::stof( sParams[1] ) / 100.0f;
 		}
 		else if( sValueName=="BUNKI2" )
 		{
 			bKIUCompliant = true;
-			BPMPos3 = StringToFloat( sParams[1] ) / 100.0f;
+			BPMPos3 = std::stof( sParams[1] ) / 100.0f;
 		}
 		else if( sValueName=="STARTTIME" )
 		{
-			SMGap1 = -StringToFloat( sParams[1] )/100;
+			SMGap1 = -std::stof( sParams[1] )/100;
 			out.m_SongTiming.m_fBeat0OffsetInSeconds = SMGap1;
 		}
 		// This is currently required for more accurate KIU BPM changes.
 		else if( sValueName=="STARTTIME2" )
 		{
 			bKIUCompliant = true;
-			SMGap2 = -StringToFloat( sParams[1] )/100;
+			SMGap2 = -std::stof( sParams[1] )/100;
 		}
 		else if ( sValueName=="STARTTIME3" )
 		{

--- a/src/NotesLoaderSM.cpp
+++ b/src/NotesLoaderSM.cpp
@@ -95,7 +95,7 @@ void SMSetMusic(SMSongTagInfo& info)
 }
 void SMSetOffset(SMSongTagInfo& info)
 {
-	info.song->m_SongTiming.m_fBeat0OffsetInSeconds = StringToFloat((*info.params)[1]);
+	info.song->m_SongTiming.m_fBeat0OffsetInSeconds = std::stof((*info.params)[1]);
 }
 void SMSetBPMs(SMSongTagInfo& info)
 {
@@ -139,11 +139,11 @@ void SMSetDisplayBPM(SMSongTagInfo& info)
 	else
 	{
 		info.song->m_DisplayBPMType = DISPLAY_BPM_SPECIFIED;
-		info.song->m_fSpecifiedBPMMin = StringToFloat((*info.params)[1]);
+		info.song->m_fSpecifiedBPMMin = std::stof((*info.params)[1]);
 		if((*info.params)[2].empty())
 		{ info.song->m_fSpecifiedBPMMax = info.song->m_fSpecifiedBPMMin; }
 		else
-		{ info.song->m_fSpecifiedBPMMax = StringToFloat((*info.params)[2]); }
+		{ info.song->m_fSpecifiedBPMMax = std::stof((*info.params)[2]); }
 	}
 }
 void SMSetSelectable(SMSongTagInfo& info)
@@ -170,7 +170,7 @@ void SMSetSelectable(SMSongTagInfo& info)
 	{ 
 		info.song->m_SelectionDisplay = info.song->SHOW_ALWAYS; 
 	}
-	else if(StringToInt((*info.params)[1]) > 0)
+	else if(std::stoi((*info.params)[1]) > 0)
 	{
 		info.song->m_SelectionDisplay = info.song->SHOW_ALWAYS;
 	}
@@ -293,12 +293,9 @@ float SMLoader::RowToBeat( std::string line, const int rowsPerBeat )
 	backup = Rage::trim(backup, "R");
 	if( backup != line )
 	{
-		return StringToFloat( line ) / rowsPerBeat;
+		return std::stof( line ) / rowsPerBeat;
 	}
-	else
-	{
-		return StringToFloat( line );
-	}
+	return std::stof( line );
 }
 
 void SMLoader::LoadFromTokens(
@@ -355,7 +352,7 @@ void SMLoader::LoadFromTokens(
 		// have a meter on certain steps. Make the meter 1 in these instances.
 		sMeter = "1";
 	}
-	out.SetMeter( StringToInt(sMeter) );
+	out.SetMeter( std::stoi(sMeter) );
 
 	out.SetSMNoteData( sNoteData );
 
@@ -479,7 +476,7 @@ void SMLoader::ParseBPMs( vector< std::pair<float, float> > &out, const std::str
 		}
 
 		const float fBeat = RowToBeat( arrayBPMChangeValues[0], rowsPerBeat );
-		const float fNewBPM = StringToFloat( arrayBPMChangeValues[1] );
+		const float fNewBPM = std::stof( arrayBPMChangeValues[1] );
 		if( fNewBPM == 0 ) {
 			LOG->UserLog("Song file", this->GetSongTitle(),
 				     "has a zero BPM; ignored.");
@@ -507,7 +504,7 @@ void SMLoader::ParseStops( vector< std::pair<float, float> > &out, const std::st
 		}
 
 		const float fFreezeBeat = RowToBeat( arrayFreezeValues[0], rowsPerBeat );
-		const float fFreezeSeconds = StringToFloat( arrayFreezeValues[1] );
+		const float fFreezeSeconds = std::stof( arrayFreezeValues[1] );
 		if( fFreezeSeconds == 0 ) {
 			LOG->UserLog("Song file", this->GetSongTitle(),
 				     "has a zero-length stop; ignored.");
@@ -770,7 +767,7 @@ void SMLoader::ProcessDelays( TimingData &out, const std::string line, const int
 			continue;
 		}
 		const float fFreezeBeat = RowToBeat( arrayDelayValues[0], rowsPerBeat );
-		const float fFreezeSeconds = StringToFloat( arrayDelayValues[1] );
+		const float fFreezeSeconds = std::stof( arrayDelayValues[1] );
 		// LOG->Trace( "Adding a delay segment: beat: %f, seconds = %f", new_seg.m_fStartBeat, new_seg.m_fStopSeconds );
 
 		if(fFreezeSeconds > 0.0f)
@@ -802,8 +799,8 @@ void SMLoader::ProcessTimeSignatures( TimingData &out, const std::string line, c
 		}
 
 		const float fBeat = RowToBeat( vs2[0], rowsPerBeat );
-		const int iNumerator = StringToInt( vs2[1] );
-		const int iDenominator = StringToInt( vs2[2] );
+		const int iNumerator = std::stoi( vs2[1] );
+		const int iDenominator = std::stoi( vs2[2] );
 
 		if( fBeat < 0 )
 		{
@@ -870,7 +867,7 @@ void SMLoader::ProcessSpeeds( TimingData &out, const std::string line, const int
 		if (vs2.size() == 2)
 		{
 			// Make sure we don't cast all the dang time. Also, first one almost always has 2.
-			if (StringToFloat(vs2[0]) == 0.f)
+			if (std::stof(vs2[0]) == 0.f)
 			{
 				vs2.push_back("0");
 			}
@@ -891,11 +888,11 @@ void SMLoader::ProcessSpeeds( TimingData &out, const std::string line, const int
 		}
 
 		const float fBeat = RowToBeat( vs2[0], rowsPerBeat );
-		const float fRatio = StringToFloat( vs2[1] );
-		const float fDelay = StringToFloat( vs2[2] );
+		const float fRatio = std::stof( vs2[1] );
+		const float fDelay = std::stof( vs2[2] );
 
 		// XXX: ugly...
-		int iUnit = StringToInt(vs2[3]);
+		int iUnit = std::stoi(vs2[3]);
 		SpeedSegment::BaseUnit unit = (iUnit == 0) ?
 			SpeedSegment::UNIT_BEATS : SpeedSegment::UNIT_SECONDS;
 
@@ -938,7 +935,7 @@ void SMLoader::ProcessFakes( TimingData &out, const std::string line, const int 
 		}
 
 		const float fBeat = RowToBeat( arrayFakeValues[0], rowsPerBeat );
-		const float fSkippedBeats = StringToFloat( arrayFakeValues[1] );
+		const float fSkippedBeats = std::stof( arrayFakeValues[1] );
 
 		if(fSkippedBeats > 0)
 		{
@@ -995,9 +992,19 @@ bool SMLoader::LoadFromBGChangesString( BackgroundChange &change, const std::str
 		// Backward compatibility:
 		if( change.m_def.m_sEffect.empty() )
 		{
-			bool bLoop = StringToInt( aBGChangeValues[5] ) != 0;
+			bool bLoop;
+			try
+			{
+				bLoop = std::stoi( aBGChangeValues[5] ) != 0;
+			}
+			catch (...)
+			{
+				bLoop = false;
+			}
 			if( !bLoop )
+			{
 				change.m_def.m_sEffect = SBE_StretchNoLoop;
+			}
 		}
 		// fall through
 	case 5:
@@ -1005,19 +1012,29 @@ bool SMLoader::LoadFromBGChangesString( BackgroundChange &change, const std::str
 		// Backward compatibility:
 		if( change.m_def.m_sEffect.empty() )
 		{
-			bool bRewindMovie = StringToInt( aBGChangeValues[4] ) != 0;
+			bool bRewindMovie;
+			try
+			{
+				bRewindMovie = std::stoi( aBGChangeValues[4] ) != 0;
+			}
+			catch (...)
+			{
+				bRewindMovie = false;
+			}
 			if( bRewindMovie )
+			{
 				change.m_def.m_sEffect = SBE_StretchRewind;
+			}
 		}
 		// fall through
 	case 4:
 		// param 9 overrides this.
 		// Backward compatibility:
 		if( change.m_sTransition.empty() )
-			change.m_sTransition = (StringToInt( aBGChangeValues[3] ) != 0) ? "CrossFade" : "";
+			change.m_sTransition = (std::stoi( aBGChangeValues[3] ) != 0) ? "CrossFade" : "";
 		// fall through
 	case 3:
-		change.m_fRate = StringToFloat( aBGChangeValues[2] );
+		change.m_fRate = std::stof( aBGChangeValues[2] );
 		// fall through
 	case 2:
 	{
@@ -1031,7 +1048,14 @@ bool SMLoader::LoadFromBGChangesString( BackgroundChange &change, const std::str
 		// fall through
 	}
 	case 1:
-		change.m_fStartBeat = StringToFloat( aBGChangeValues[0] );
+		try
+		{
+			change.m_fStartBeat = std::stof( aBGChangeValues[0] );
+		}
+		catch (...)
+		{
+			change.m_fStartBeat = 0.f;
+		}
 		// fall through
 	}
 

--- a/src/NotesLoaderSMA.cpp
+++ b/src/NotesLoaderSMA.cpp
@@ -33,11 +33,11 @@ void SMALoader::ProcessMultipliers( TimingData &out, const int iRowsPerBeat, con
 			continue;
 		}
 		const float fComboBeat = RowToBeat( arrayMultiplierValues[0], iRowsPerBeat );
-		const int iCombos = StringToInt( arrayMultiplierValues[1] ); // always true.
+		const int iCombos = std::stoi( arrayMultiplierValues[1] ); // always true.
 		// hoping I'm right here: SMA files can use 6 values after the row/beat.
 		const int iMisses = (size == 2 || size == 4 ?
 							 iCombos :
-							 StringToInt(arrayMultiplierValues[2]));
+							 std::stoi(arrayMultiplierValues[2]));
 		out.AddSegment( ComboSegment(BeatToNoteRow(fComboBeat), iCombos, iMisses) );
 	}
 }
@@ -58,8 +58,8 @@ void SMALoader::ProcessBeatsPerMeasure( TimingData &out, const std::string sPara
 				     static_cast<int>(vs2.size()) );
 			continue;
 		}
-		const float fBeat = StringToFloat( vs2[0] );
-		const int iNumerator = StringToInt( vs2[1] );
+		const float fBeat = std::stof( vs2[0] );
+		const int iNumerator = std::stoi( vs2[1] );
 
 		if( fBeat < 0 )
 		{
@@ -112,8 +112,8 @@ void SMALoader::ProcessSpeeds( TimingData &out, const std::string line, const in
 		vs2[2] = Rage::trim(vs2[2], "s");
 		vs2[2] = Rage::trim(vs2[2], "S");
 
-		const float fRatio = StringToFloat( vs2[1] );
-		const float fDelay = StringToFloat( vs2[2] );
+		const float fRatio = std::stof( vs2[1] );
+		const float fDelay = std::stof( vs2[2] );
 
 		SpeedSegment::BaseUnit unit = ((backup != vs2[2]) ?
 			SpeedSegment::UNIT_SECONDS : SpeedSegment::UNIT_BEATS);
@@ -262,11 +262,11 @@ bool SMALoader::LoadFromSimfile( const std::string &sPath, Song &out, bool )
 			else
 			{
 				out.m_DisplayBPMType = DISPLAY_BPM_SPECIFIED;
-				out.m_fSpecifiedBPMMin = StringToFloat( sParams[1] );
+				out.m_fSpecifiedBPMMin = std::stof( sParams[1] );
 				if( sParams[2].empty() )
 					out.m_fSpecifiedBPMMax = out.m_fSpecifiedBPMMin;
 				else
-					out.m_fSpecifiedBPMMax = StringToFloat( sParams[2] );
+					out.m_fSpecifiedBPMMax = std::stof( sParams[2] );
 			}
 		}
 
@@ -287,7 +287,7 @@ bool SMALoader::LoadFromSimfile( const std::string &sPath, Song &out, bool )
 				auto arrayBeatChangeExpressions = Rage::split(sParams[1], ",");
 
 				auto arrayBeatChangeValues = Rage::split(arrayBeatChangeExpressions[0], "=");
-				iRowsPerBeat = StringToInt(arrayBeatChangeValues[1]);
+				iRowsPerBeat = std::stoi(arrayBeatChangeValues[1]);
 			}
 			else
 			{
@@ -328,7 +328,7 @@ bool SMALoader::LoadFromSimfile( const std::string &sPath, Song &out, bool )
 			{
 				out.m_SelectionDisplay = out.SHOW_ALWAYS;
 			}
-			else if (StringToInt(sParams[1]) > 0)
+			else if (std::stoi(sParams[1]) > 0)
 				out.m_SelectionDisplay = out.SHOW_ALWAYS;
 			else
 				LOG->UserLog("Song file",
@@ -359,7 +359,7 @@ bool SMALoader::LoadFromSimfile( const std::string &sPath, Song &out, bool )
 		else if( sValueName=="OFFSET" )
 		{
 			TimingData &timing = ( pNewNotes ? pNewNotes->m_Timing : out.m_SongTiming);
-			timing.m_fBeat0OffsetInSeconds = StringToFloat( sParams[1] );
+			timing.m_fBeat0OffsetInSeconds = std::stof( sParams[1] );
 		}
 
 		else if( sValueName=="BPMS" )

--- a/src/NotesLoaderSSC.cpp
+++ b/src/NotesLoaderSSC.cpp
@@ -75,7 +75,7 @@ typedef void (*song_tag_func_t)(SongTagInfo& info);
 /****************************************************************/
 void SetVersion(SongTagInfo& info)
 {
-	info.song->m_fVersion = StringToFloat((*info.params)[1]);
+	info.song->m_fVersion = std::stof((*info.params)[1]);
 }
 void SetTitle(SongTagInfo& info)
 {
@@ -161,11 +161,11 @@ void SetInstrumentTrack(SongTagInfo& info)
 void SetMusicLength(SongTagInfo& info)
 {
 	if(info.from_cache)
-	info.song->m_fMusicLengthSeconds = StringToFloat((*info.params)[1]);
+	info.song->m_fMusicLengthSeconds = std::stof((*info.params)[1]);
 }
 void SetLastSecondHint(SongTagInfo& info)
 {
-	info.song->SetSpecifiedLastSecond(StringToFloat((*info.params)[1]));
+	info.song->SetSpecifiedLastSecond(std::stof((*info.params)[1]));
 }
 void SetSampleStart(SongTagInfo& info)
 {
@@ -183,11 +183,11 @@ void SetDisplayBPM(SongTagInfo& info)
 	else
 	{
 		info.song->m_DisplayBPMType = DISPLAY_BPM_SPECIFIED;
-		info.song->m_fSpecifiedBPMMin = StringToFloat((*info.params)[1]);
+		info.song->m_fSpecifiedBPMMin = std::stof((*info.params)[1]);
 		if((*info.params)[2].empty())
 		{ info.song->m_fSpecifiedBPMMax = info.song->m_fSpecifiedBPMMin; }
 		else
-		{ info.song->m_fSpecifiedBPMMax = StringToFloat((*info.params)[2]); }
+		{ info.song->m_fSpecifiedBPMMax = std::stof((*info.params)[2]); }
 	}
 }
 void SetSelectable(SongTagInfo& info)
@@ -212,7 +212,7 @@ void SetSelectable(SongTagInfo& info)
 	{ 
 		info.song->m_SelectionDisplay = info.song->SHOW_ALWAYS; 
 	}
-	else if(StringToInt((*info.params)[1]) > 0)
+	else if(std::stoi((*info.params)[1]) > 0)
 	{ 
 		info.song->m_SelectionDisplay = info.song->SHOW_ALWAYS; 
 	}
@@ -254,7 +254,7 @@ void SetAttacks(SongTagInfo& info)
 }
 void SetOffset(SongTagInfo& info)
 {
-	info.song->m_SongTiming.m_fBeat0OffsetInSeconds = StringToFloat((*info.params)[1]);
+	info.song->m_SongTiming.m_fBeat0OffsetInSeconds = std::stof((*info.params)[1]);
 }
 void SetSongStops(SongTagInfo& info)
 {
@@ -303,12 +303,12 @@ void SetSongFakes(SongTagInfo& info)
 void SetFirstSecond(SongTagInfo& info)
 {
 	if(info.from_cache)
-	{ info.song->SetFirstSecond(StringToFloat((*info.params)[1])); }
+	{ info.song->SetFirstSecond(std::stof((*info.params)[1])); }
 }
 void SetLastSecond(SongTagInfo& info)
 {
 	if(info.from_cache)
-	{ info.song->SetLastSecond(StringToFloat((*info.params)[1])); }
+	{ info.song->SetLastSecond(std::stof((*info.params)[1])); }
 }
 void SetSongFilename(SongTagInfo& info)
 {
@@ -318,19 +318,19 @@ void SetSongFilename(SongTagInfo& info)
 void SetHasMusic(SongTagInfo& info)
 {
 	if(info.from_cache)
-	{ info.song->m_bHasMusic = StringToInt((*info.params)[1]) != 0; }
+	{ info.song->m_bHasMusic = std::stoi((*info.params)[1]) != 0; }
 }
 void SetHasBanner(SongTagInfo& info)
 {
 	if(info.from_cache)
-	{ info.song->m_bHasBanner = StringToInt((*info.params)[1]) != 0; }
+	{ info.song->m_bHasBanner = std::stoi((*info.params)[1]) != 0; }
 }
 
 // Functions for steps tags go below this line. -Kyz
 /****************************************************************/
 void SetStepsVersion(StepsTagInfo& info)
 {
-	info.song->m_fVersion = StringToFloat((*info.params)[1]);
+	info.song->m_fVersion = std::stof((*info.params)[1]);
 }
 void SetChartName(StepsTagInfo& info)
 {
@@ -366,7 +366,7 @@ void SetDifficulty(StepsTagInfo& info)
 }
 void SetMeter(StepsTagInfo& info)
 {
-	info.steps->SetMeter(StringToInt((*info.params)[1]));
+	info.steps->SetMeter(std::stoi((*info.params)[1]));
 	info.ssc_format= true;
 }
 void SetRadarValues(StepsTagInfo& info)
@@ -383,7 +383,7 @@ void SetRadarValues(StepsTagInfo& info)
 		{
 			for(size_t i= 0; i < cats_per_player; ++i)
 			{
-				v[pn][i]= StringToFloat(values[pn * cats_per_player + i]);
+				v[pn][i]= std::stof(values[pn * cats_per_player + i]);
 			}
 		}
 		info.steps->SetCachedRadarValues(v);
@@ -514,7 +514,7 @@ void SetStepsOffset(StepsTagInfo& info)
 {
 	if(info.song->m_fVersion >= VERSION_SPLIT_TIMING || info.for_load_edit)
 	{
-		info.timing->m_fBeat0OffsetInSeconds = StringToFloat((*info.params)[1]);
+		info.timing->m_fBeat0OffsetInSeconds = std::stof((*info.params)[1]);
 		info.has_own_timing = true;
 	}
 }
@@ -526,12 +526,12 @@ void SetStepsDisplayBPM(StepsTagInfo& info)
 	else
 	{
 		info.steps->SetDisplayBPM(DISPLAY_BPM_SPECIFIED);
-		float min = StringToFloat((*info.params)[1]);
+		float min = std::stof((*info.params)[1]);
 		info.steps->SetMinBPM(min);
 		if((*info.params)[2].empty())
 		{ info.steps->SetMaxBPM(min); }
 		else
-		{ info.steps->SetMaxBPM(StringToFloat((*info.params)[2])); }
+		{ info.steps->SetMaxBPM(std::stof((*info.params)[2])); }
 	}
 }
 
@@ -672,8 +672,8 @@ void SSCLoader::ProcessBPMs( TimingData &out, const std::string sParam )
 			continue;
 		}
 
-		const float fBeat = StringToFloat( arrayBPMValues[0] );
-		const float fNewBPM = StringToFloat( arrayBPMValues[1] );
+		const float fBeat = std::stof( arrayBPMValues[0] );
+		const float fNewBPM = std::stof( arrayBPMValues[1] );
 		if( fBeat >= 0 && fNewBPM > 0 )
 		{
 			out.AddSegment( BPMSegment(BeatToNoteRow(fBeat), fNewBPM) );
@@ -704,8 +704,8 @@ void SSCLoader::ProcessStops( TimingData &out, const std::string sParam )
 			continue;
 		}
 
-		const float fBeat = StringToFloat( arrayStopValues[0] );
-		const float fNewStop = StringToFloat( arrayStopValues[1] );
+		const float fBeat = std::stof( arrayStopValues[0] );
+		const float fNewStop = std::stof( arrayStopValues[1] );
 		if( fBeat >= 0 && fNewStop > 0 )
 			out.AddSegment( StopSegment(BeatToNoteRow(fBeat), fNewStop) );
 		else
@@ -734,8 +734,8 @@ void SSCLoader::ProcessWarps( TimingData &out, const std::string sParam, const f
 			continue;
 		}
 
-		const float fBeat = StringToFloat( arrayWarpValues[0] );
-		const float fNewBeat = StringToFloat( arrayWarpValues[1] );
+		const float fBeat = std::stof( arrayWarpValues[0] );
+		const float fNewBeat = std::stof( arrayWarpValues[1] );
 		// Early versions were absolute in beats. They should be relative.
 		if( ( fVersion < VERSION_SPLIT_TIMING && fNewBeat > fBeat ) )
 		{
@@ -769,7 +769,7 @@ void SSCLoader::ProcessLabels( TimingData &out, const std::string sParam )
 			continue;
 		}
 
-		const float fBeat = StringToFloat( arrayLabelValues[0] );
+		const float fBeat = std::stof( arrayLabelValues[0] );
 		std::string sLabel = Rage::trim_right(arrayLabelValues[1]);
 		if( fBeat >= 0.0f )
 		{
@@ -802,9 +802,9 @@ void SSCLoader::ProcessCombos( TimingData &out, const std::string line, const in
 				     expression.c_str() );
 			continue;
 		}
-		const float fComboBeat = StringToFloat( arrayComboValues[0] );
-		const int iCombos = StringToInt( arrayComboValues[1] );
-		const int iMisses = (size == 2 ? iCombos : StringToInt(arrayComboValues[2]));
+		const float fComboBeat = std::stof( arrayComboValues[0] );
+		const int iCombos = std::stoi( arrayComboValues[1] );
+		const int iMisses = (size == 2 ? iCombos : std::stoi(arrayComboValues[2]));
 		out.AddSegment( ComboSegment( BeatToNoteRow(fComboBeat), iCombos, iMisses ) );
 	}
 }
@@ -826,8 +826,8 @@ void SSCLoader::ProcessScrolls( TimingData &out, const std::string sParam )
 			continue;
 		}
 
-		const float fBeat = StringToFloat( vs2[0] );
-		const float fRatio = StringToFloat( vs2[1] );
+		const float fBeat = std::stof( vs2[0] );
+		const float fRatio = std::stof( vs2[1] );
 
 		if( fBeat < 0 )
 		{
@@ -877,7 +877,7 @@ bool SSCLoader::LoadNoteDataFromSimfile( const std::string & cachePath, Steps &o
 					case LNDID_version:
 						// Note that version is in both switches.  Formerly, it was
 						// checked before the tryingSteps condition. -Kyz
-						storedVersion = StringToFloat(matcher);
+						storedVersion = std::stof(matcher);
 						break;
 					case LNDID_stepstype:
 						if(out.m_StepsType != GAMEMAN->StringToStepsType(matcher))
@@ -909,7 +909,7 @@ bool SSCLoader::LoadNoteDataFromSimfile( const std::string & cachePath, Steps &o
 						}
 						break;
 					case LNDID_meter:
-						if(out.GetMeter() != StringToInt(matcher))
+						if(out.GetMeter() != std::stoi(matcher))
 						{ tryingSteps = false; }
 						break;
 					case LNDID_credit:
@@ -932,7 +932,7 @@ bool SSCLoader::LoadNoteDataFromSimfile( const std::string & cachePath, Steps &o
 					case LNDID_version:
 						// Note that version is in both switches.  Formerly, it was
 						// checked before the tryingSteps condition. -Kyz
-						storedVersion = StringToFloat(matcher);
+						storedVersion = std::stof(matcher);
 						break;
 					case LNDID_notedata:
 						tryingSteps = true;

--- a/src/OptionRowHandler.cpp
+++ b/src/OptionRowHandler.cpp
@@ -164,7 +164,7 @@ public:
 
 			m_Def.m_bOneChoiceForAllPlayers = false;
 			ROW_INVALID_IF(lCmds.v[0].m_vsArgs.size() != 1, "Row command has invalid args to number of entries.", false);
-			const int NumCols = StringToInt( lCmds.v[0].m_vsArgs[0] );
+			const int NumCols = std::stoi( lCmds.v[0].m_vsArgs[0] );
 			ROW_INVALID_IF(NumCols < 1, "Not enough entries in list.", false);
 			for(size_t i= 1; i < lCmds.v.size(); ++i)
 			{
@@ -176,7 +176,7 @@ public:
 				else if( sName == "selectone" )		m_Def.m_selectType = SELECT_ONE;
 				else if( sName == "selectnone" )	m_Def.m_selectType = SELECT_NONE;
 				else if( sName == "showoneinrow" )	m_Def.m_layoutType = LAYOUT_SHOW_ONE_IN_ROW;
-				else if( sName == "default" )		m_Def.m_iDefault = StringToInt( cmd.GetArg(1).s ) - 1; // match ENTRY_MODE
+				else if( sName == "default" )		m_Def.m_iDefault = std::stoi( cmd.GetArg(1).s ) - 1; // match ENTRY_MODE
 				else if( sName == "reloadrowmessages" )
 				{
 					for( unsigned a=1; a<cmd.m_vsArgs.size(); a++ )
@@ -190,7 +190,7 @@ public:
 					for( unsigned a=1; a<cmd.m_vsArgs.size(); a++ )
 					{
 						std::string sArg = cmd.m_vsArgs[a];
-						PlayerNumber pn = (PlayerNumber)(StringToInt(sArg)-1);
+						PlayerNumber pn = (PlayerNumber)(std::stoi(sArg)-1);
 						ASSERT( pn >= 0 && pn < NUM_PLAYERS );
 						m_Def.m_vEnabledForPlayers.insert( pn );
 					}

--- a/src/PlayerOptions.cpp
+++ b/src/PlayerOptions.cpp
@@ -426,12 +426,12 @@ bool PlayerOptions::FromOneModString( std::string const &sOneMod, std::string &s
 			{
 				// XXX: We know what they want, is there any reason not to handle it?
 				// Yes. We should be strict in handling the format. -Chris
-				sErrorOut = fmt::sprintf("Invalid player options \"%s\"; did you mean '*%d'?", s.c_str(), StringToInt(s) );
+				sErrorOut = fmt::sprintf("Invalid player options \"%s\"; did you mean '*%d'?", s.c_str(), std::stoi(s) );
 				return false;
 			}
 			else
 			{
-				level = StringToFloat( s ) / 100.0f;
+				level = std::stof( s ) / 100.0f;
 			}
 		}
 		else if( s[0]=='*' )

--- a/src/Profile.cpp
+++ b/src/Profile.cpp
@@ -2684,7 +2684,7 @@ std::string Profile::MakeUniqueFileNameNoExtension( std::string sDir, std::strin
 			continue;
 
 		ASSERT( matches.size() == 1 );
-		iIndex = StringToInt( matches[0] )+1;
+		iIndex = std::stoi( matches[0] )+1;
 		break;
 	}
 

--- a/src/RadarValues.cpp
+++ b/src/RadarValues.cpp
@@ -101,7 +101,7 @@ void RadarValues::FromString( std::string sRadarValues )
 
 	FOREACH_ENUM( RadarCategory, rc )
 	{
-		(*this)[rc] = StringToFloat(saValues[rc]);
+		(*this)[rc] = std::stof(saValues[rc]);
 	}
 
 }

--- a/src/RageBitmapTexture.cpp
+++ b/src/RageBitmapTexture.cpp
@@ -29,15 +29,29 @@ static void GetResolutionFromFileName( std::string sPath, int &iWidth, int &iHei
 	if( !re.Compare(sPath, asMatches) )
 		return;
 
-	// Check for nonsense values.  Some people might not intend the hint. -Kyz
-	int maybe_width= StringToInt(asMatches[0]);
-	int maybe_height= StringToInt(asMatches[1]);
-	if(maybe_width <= 0 || maybe_height <= 0)
+	if (asMatches.size() < 2)
 	{
+		// Sanity check. Shouldn't be needed, but better safe than sorry.
 		return;
 	}
-	iWidth = maybe_width;
-	iHeight = maybe_height;
+	
+	// Check for nonsense values.  Some people might not intend the hint. -Kyz
+	try
+	{
+		int maybe_width= std::stoi(asMatches[0]);
+		int maybe_height= std::stoi(asMatches[1]);
+		if(maybe_width <= 0 || maybe_height <= 0)
+		{
+			return;
+		}
+		iWidth = maybe_width;
+		iHeight = maybe_height;
+	}
+	catch (...)
+	{
+		// Nonsense values did come in. Skip them.
+		LOG->Warn("Invalid resolution values came through. Please validate %s and %s.", asMatches[0], asMatches[1]);
+	}
 }
 
 RageBitmapTexture::RageBitmapTexture( RageTextureID name ) :

--- a/src/RageDisplay_OGL.cpp
+++ b/src/RageDisplay_OGL.cpp
@@ -684,10 +684,10 @@ static void CheckReversePackedPixels()
 
 void SetupExtensions()
 {
-	const float fGLVersion = StringToFloat( (const char *) glGetString(GL_VERSION) );
+	const float fGLVersion = std::stof( (const char *) glGetString(GL_VERSION) );
 	g_glVersion = std::lrint( fGLVersion * 10 );
 
-	const float fGLUVersion = StringToFloat( (const char *) gluGetString(GLU_VERSION) );
+	const float fGLUVersion = std::stof( (const char *) gluGetString(GLU_VERSION) );
 	g_gluVersion = std::lrint( fGLUVersion * 10 );
 
 #ifndef HAVE_X11 // LLW_X11 needs to init GLEW early for GLX exts

--- a/src/RageTexture.cpp
+++ b/src/RageTexture.cpp
@@ -1,6 +1,7 @@
 #include "global.h"
 
 #include "RageTexture.h"
+#include "RageLog.h"
 #include "RageUtil.h"
 #include "RageTextureManager.h"
 #include <cstring>
@@ -58,11 +59,22 @@ void RageTexture::GetFrameDimensionsFromFileName( std::string sPath, int* piFram
 		return;
 	}
 	// Check for nonsense values.  Some people might not intend the hint. -Kyz
-	int maybe_width= StringToInt(asMatch[0]);
-	int maybe_height= StringToInt(asMatch[1]);
-	if(maybe_width <= 0 || maybe_height <= 0)
+	int maybe_width;
+	int maybe_height;
+	try
 	{
-		*piFramesWide = *piFramesHigh = 1;
+		maybe_width= std::stoi(asMatch[0]);
+		maybe_height= std::stoi(asMatch[1]);
+		if(maybe_width <= 0 || maybe_height <= 0)
+		{
+			*piFramesWide = *piFramesHigh = 1;
+			return;
+		}
+	}
+	catch (...)
+	{
+		// Nonsense values did come in. Skip them.
+		LOG->Warn("Invalid resolution values came through. Please validate %s and %s.", asMatch[0], asMatch[1]);
 		return;
 	}
 	// Font.cpp uses this function, but can't pass in a texture size.  Other

--- a/src/RageUtil.cpp
+++ b/src/RageUtil.cpp
@@ -288,9 +288,9 @@ float HHMMSSToSeconds( const std::string &sHHMMSS )
 		arrayBits.insert(arrayBits.begin(), "0" );	// pad missing bits
 	}
 	float fSeconds = 0;
-	fSeconds += StringToInt( arrayBits[0] ) * 60 * 60;
-	fSeconds += StringToInt( arrayBits[1] ) * 60;
-	fSeconds += StringToFloat( arrayBits[2] );
+	fSeconds += std::stoi( arrayBits[0] ) * 60 * 60;
+	fSeconds += std::stoi( arrayBits[1] ) * 60;
+	fSeconds += std::stoi( arrayBits[2] );
 
 	return fSeconds;
 }
@@ -1294,46 +1294,6 @@ static int UnicodeDoUpper( char *p, size_t iLen, const unsigned char pMapping[25
 	return iStart;
 }
 
-int StringToInt( const std::string &sString )
-{
-	int ret;
-	istringstream ( sString ) >> ret;
-	return ret;
-}
-
-std::string IntToString( const int &iNum )
-{
-	stringstream ss;
-	ss << iNum;
-	return ss.str();
-}
-
-float StringToFloat( const std::string &sString )
-{
-	float ret = strtof( sString.c_str(), nullptr );
-
-	if( !isfinite(ret) )
-	{
-		ret = 0.0f;
-	}
-	return ret;
-}
-
-bool StringToFloat( const std::string &sString, float &fOut )
-{
-	char *endPtr;
-
-	fOut = strtof( sString.c_str(), &endPtr );
-	return sString.size() && *endPtr == '\0' && isfinite( fOut );
-}
-
-std::string FloatToString( const float &num )
-{
-	stringstream ss;
-	ss << num;
-	return ss.str();
-}
-
 wstring StringToWstring( const std::string &s )
 {
 	wstring ret;
@@ -1720,7 +1680,7 @@ namespace StringConversion
 		if( sValue.size() == 0 )
 			return false;
 
-		out = (StringToInt(sValue) != 0);
+		out = (std::stoi(sValue) != 0);
 		return true;
 	}
 

--- a/src/RageUtil.h
+++ b/src/RageUtil.h
@@ -355,20 +355,7 @@ bool FindFirstFilenameContaining(
 	std::vector<std::string> const & starts_with,
 	std::vector<std::string> const & contains, std::vector<std::string> const & ends_with);
 
-/**
- * @brief Have a standard way of converting Strings to integers.
- * @param sString the string to convert.
- * @return the integer we are after. */
-int StringToInt( const std::string &sString );
-/**
- * @brief Have a standard way of converting integers to Strings.
- * @param iNum the integer to convert.
- * @return the string we are after. */
-std::string IntToString( const int &iNum );
-float StringToFloat( const std::string &sString );
-std::string FloatToString( const float &num );
-bool StringToFloat( const std::string &sString, float &fOut );
-// Better than IntToString because you can check for success.
+// Potentially better than std::to_string because you can check for success.
 template<class T>
 inline bool operator>>(const std::string& lhs, T& rhs)
 {

--- a/src/ScreenEdit.cpp
+++ b/src/ScreenEdit.cpp
@@ -2872,7 +2872,7 @@ bool ScreenEdit::InputEdit( const InputEventPlus &input, EditButton EditB )
 
 			if( iAttack >= 0 )
 			{
-				const std::string sDuration = FloatToString(ce.attacks[iAttack].fSecsRemaining );
+				const std::string sDuration = std::to_string(ce.attacks[iAttack].fSecsRemaining );
 
 				g_InsertCourseAttack.rows[remove].bEnabled = true;
 				if( g_InsertCourseAttack.rows[duration].choices.size() == 9 )
@@ -3700,13 +3700,13 @@ void ScreenEdit::HandleScreenMessage( const ScreenMessage SM )
 	}
 	else if( SM == SM_BackFromDifficultyMeterChange )
 	{
-		int i = StringToInt( ScreenTextEntry::s_sLastAnswer );
+		int i = std::stoi( ScreenTextEntry::s_sLastAnswer );
 		GAMESTATE->m_pCurSteps[PLAYER_1]->SetMeter(i);
 		SetDirty( true );
 	}
 	else if( SM == SM_BackFromBeat0Change && !ScreenTextEntry::s_bCancelledLast )
 	{
-		float fBeat0 = StringToFloat( ScreenTextEntry::s_sLastAnswer );
+		float fBeat0 = std::stof( ScreenTextEntry::s_sLastAnswer );
 
 		TimingData &timing = GetAppropriateTimingForUpdate();
 		float old = timing.m_fBeat0OffsetInSeconds;
@@ -3727,7 +3727,7 @@ void ScreenEdit::HandleScreenMessage( const ScreenMessage SM )
 	}
 	else if( SM == SM_BackFromBPMChange && !ScreenTextEntry::s_bCancelledLast )
 	{
-		float fBPM = StringToFloat( ScreenTextEntry::s_sLastAnswer );
+		float fBPM = std::stof( ScreenTextEntry::s_sLastAnswer );
 
 		if( fBPM > 0 )
 			GetAppropriateTimingForUpdate().AddSegment( BPMSegment(GetRow(), fBPM) );
@@ -3736,7 +3736,7 @@ void ScreenEdit::HandleScreenMessage( const ScreenMessage SM )
 	}
 	else if( SM == SM_BackFromStopChange && !ScreenTextEntry::s_bCancelledLast )
 	{
-		float fStop = StringToFloat( ScreenTextEntry::s_sLastAnswer );
+		float fStop = std::stof( ScreenTextEntry::s_sLastAnswer );
 
 		if( fStop >= 0 )
 			GetAppropriateTimingForUpdate().AddSegment( StopSegment(GetRow(), fStop) );
@@ -3745,7 +3745,7 @@ void ScreenEdit::HandleScreenMessage( const ScreenMessage SM )
 	}
 	else if( SM == SM_BackFromDelayChange && !ScreenTextEntry::s_bCancelledLast )
 	{
-		float fDelay = StringToFloat( ScreenTextEntry::s_sLastAnswer );
+		float fDelay = std::stof( ScreenTextEntry::s_sLastAnswer );
 
 		if( fDelay >= 0 )
 			GetAppropriateTimingForUpdate().AddSegment( DelaySegment(GetRow(), fDelay) );
@@ -3754,11 +3754,12 @@ void ScreenEdit::HandleScreenMessage( const ScreenMessage SM )
 	}
 	else if ( SM == SM_BackFromTickcountChange && !ScreenTextEntry::s_bCancelledLast )
 	{
-		int iTick = StringToInt( ScreenTextEntry::s_sLastAnswer );
+		int iTick = std::stoi( ScreenTextEntry::s_sLastAnswer );
 
 		if ( iTick >= 0 && iTick <= ROWS_PER_BEAT )
+		{
 			GetAppropriateTimingForUpdate().AddSegment( TickcountSegment( GetRow(), iTick) );
-
+		}
 		SetDirty( true );
 	}
 	else if ( SM == SM_BackFromComboChange && !ScreenTextEntry::s_bCancelledLast )
@@ -3785,7 +3786,7 @@ void ScreenEdit::HandleScreenMessage( const ScreenMessage SM )
 	}
 	else if ( SM == SM_BackFromWarpChange && !ScreenTextEntry::s_bCancelledLast )
 	{
-		float fWarp = StringToFloat( ScreenTextEntry::s_sLastAnswer );
+		float fWarp = std::stof( ScreenTextEntry::s_sLastAnswer );
 		if( fWarp >= 0 ) // allow 0 to kill a warp.
 		{
 			GetAppropriateTimingForUpdate().SetWarpAtBeat( GetBeat(), fWarp );
@@ -3794,13 +3795,13 @@ void ScreenEdit::HandleScreenMessage( const ScreenMessage SM )
 	}
 	else if( SM == SM_BackFromSpeedPercentChange && !ScreenTextEntry::s_bCancelledLast )
 	{
-		float fNum = StringToFloat( ScreenTextEntry::s_sLastAnswer );
+		float fNum = std::stof( ScreenTextEntry::s_sLastAnswer );
 		GetAppropriateTimingForUpdate().SetSpeedPercentAtBeat( GetBeat(), fNum );
 		SetDirty( true );
 	}
 	else if ( SM == SM_BackFromSpeedWaitChange && !ScreenTextEntry::s_bCancelledLast )
 	{
-		float fDen = StringToFloat( ScreenTextEntry::s_sLastAnswer );
+		float fDen = std::stof( ScreenTextEntry::s_sLastAnswer );
 		if( fDen >= 0)
 		{
 			GetAppropriateTimingForUpdate().SetSpeedWaitAtBeat( GetBeat(), fDen );
@@ -3819,7 +3820,7 @@ void ScreenEdit::HandleScreenMessage( const ScreenMessage SM )
 		}
 		else
 		{
-			int tmp = StringToInt(ScreenTextEntry::s_sLastAnswer );
+			int tmp = std::stoi(ScreenTextEntry::s_sLastAnswer );
 
 			SpeedSegment::BaseUnit unit = (tmp == 0 ) ?
 			  SpeedSegment::UNIT_BEATS : SpeedSegment::UNIT_SECONDS;
@@ -3830,13 +3831,13 @@ void ScreenEdit::HandleScreenMessage( const ScreenMessage SM )
 	}
 	else if( SM == SM_BackFromScrollChange && !ScreenTextEntry::s_bCancelledLast )
 	{
-		float fNum = StringToFloat( ScreenTextEntry::s_sLastAnswer );
+		float fNum = std::stof( ScreenTextEntry::s_sLastAnswer );
 		GetAppropriateTimingForUpdate().SetScrollAtBeat( GetBeat(), fNum );
 		SetDirty( true );
 	}
 	else if ( SM == SM_BackFromFakeChange && !ScreenTextEntry::s_bCancelledLast )
 	{
-		float fFake = StringToFloat( ScreenTextEntry::s_sLastAnswer );
+		float fFake = std::stof( ScreenTextEntry::s_sLastAnswer );
 		if( fFake >= 0 ) // allow 0 to kill a fake.
 		{
 			GetAppropriateTimingForUpdate().AddSegment( FakeSegment(GetRow(), fFake) );
@@ -3976,7 +3977,7 @@ void ScreenEdit::HandleScreenMessage( const ScreenMessage SM )
 	else if( SM == SM_BackFromInsertTapAttack )
 	{
 		int iDurationChoice = ScreenMiniMenu::s_viLastAnswers[0];
-		g_fLastInsertAttackDurationSeconds = StringToFloat( g_InsertTapAttack.rows[0].choices[iDurationChoice] );
+		g_fLastInsertAttackDurationSeconds = std::stof( g_InsertTapAttack.rows[0].choices[iDurationChoice] );
 
 		SCREENMAN->AddNewScreenToTop( SET_MOD_SCREEN, SM_BackFromInsertTapAttackPlayerOptions );
 	}
@@ -4001,7 +4002,7 @@ void ScreenEdit::HandleScreenMessage( const ScreenMessage SM )
 	}
 	else if (SM == SM_BackFromEditingAttackStart && !ScreenTextEntry::s_bCancelledLast)
 	{
-		float time = StringToFloat(ScreenTextEntry::s_sLastAnswer);
+		float time = std::stof(ScreenTextEntry::s_sLastAnswer);
 		AttackArray &attacks =
 		(GAMESTATE->m_bIsUsingStepTiming ? m_pSteps->m_Attacks : m_pSong->m_Attacks);
 		Attack &attack = attacks[attackInProcess];
@@ -4010,7 +4011,7 @@ void ScreenEdit::HandleScreenMessage( const ScreenMessage SM )
 	}
 	else if (SM == SM_BackFromEditingAttackLength && !ScreenTextEntry::s_bCancelledLast)
 	{
-		float time = StringToFloat(ScreenTextEntry::s_sLastAnswer);
+		float time = std::stof(ScreenTextEntry::s_sLastAnswer);
 		AttackArray &attacks =
 		(GAMESTATE->m_bIsUsingStepTiming ? m_pSteps->m_Attacks : m_pSong->m_Attacks);
 		Attack &attack = attacks[attackInProcess];
@@ -4067,14 +4068,14 @@ void ScreenEdit::HandleScreenMessage( const ScreenMessage SM )
 		{
 			ScreenTextEntry::TextEntry(SM_BackFromEditingAttackStart,
 									   EDIT_ATTACK_START.GetValue(),
-									   FloatToString(attack.fStartSecond),
+									   std::to_string(attack.fStartSecond),
 									   10);
 		}
 		else if (option == 1) // adjusting the length of the attack
 		{
 			ScreenTextEntry::TextEntry(SM_BackFromEditingAttackLength,
 									   EDIT_ATTACK_LENGTH.GetValue(),
-									   FloatToString(attack.fSecsRemaining),
+									   std::to_string(attack.fSecsRemaining),
 									   10);
 		}
 		else if (option >= 2 + mods.size()) // adding a new mod
@@ -4145,7 +4146,7 @@ void ScreenEdit::HandleScreenMessage( const ScreenMessage SM )
 															 true,
 															 0,
 															 nullptr));
-				g_IndividualAttack.rows[0].SetOneUnthemedChoice(FloatToString(attack.fStartSecond));
+				g_IndividualAttack.rows[0].SetOneUnthemedChoice(std::to_string(attack.fStartSecond));
 				g_IndividualAttack.rows.push_back(MenuRowDef(1,
 															 "Secs Remaining",
 															 true,
@@ -4154,7 +4155,7 @@ void ScreenEdit::HandleScreenMessage( const ScreenMessage SM )
 															 true,
 															 0,
 															 nullptr));
-				g_IndividualAttack.rows[1].SetOneUnthemedChoice(FloatToString(attack.fSecsRemaining));
+				g_IndividualAttack.rows[1].SetOneUnthemedChoice(std::to_string(attack.fSecsRemaining));
 				auto mods = Rage::split(attack.sModifiers, ",");
 				for (unsigned i = 0; i < mods.size(); ++i)
 				{
@@ -4188,7 +4189,7 @@ void ScreenEdit::HandleScreenMessage( const ScreenMessage SM )
 		int iDurationChoice = ScreenMiniMenu::s_viLastAnswers[0];
 		const TimingData &timing = GetAppropriateTiming();
 		g_fLastInsertAttackPositionSeconds = timing.GetElapsedTimeFromBeat( GetBeat() );
-		g_fLastInsertAttackDurationSeconds = StringToFloat( g_InsertStepAttack.rows[0].choices[iDurationChoice] );
+		g_fLastInsertAttackDurationSeconds = std::stof( g_InsertStepAttack.rows[0].choices[iDurationChoice] );
 		AttackArray &attacks = GAMESTATE->m_bIsUsingStepTiming ? m_pSteps->m_Attacks : m_pSong->m_Attacks;
 		int iAttack = FindAttackAtTime(attacks, g_fLastInsertAttackPositionSeconds);
 
@@ -4220,7 +4221,7 @@ void ScreenEdit::HandleScreenMessage( const ScreenMessage SM )
 		// TODO: Handle Song/Step Timing functions/switches here?
 
 		g_fLastInsertAttackPositionSeconds = m_pSteps->GetTimingData()->GetElapsedTimeFromBeat( GAMESTATE->m_Position.m_fSongBeat );
-		g_fLastInsertAttackDurationSeconds = StringToFloat( g_InsertCourseAttack.rows[0].choices[iDurationChoice] );
+		g_fLastInsertAttackDurationSeconds = std::stof( g_InsertCourseAttack.rows[0].choices[iDurationChoice] );
 		iAttack = FindAttackAtTime( ce.attacks, g_fLastInsertAttackPositionSeconds );
 
 		if( ScreenMiniMenu::s_iLastRowCode == ScreenEdit::remove )
@@ -4581,7 +4582,7 @@ static void ChangeStepCredit( const std::string &sNew )
 static void ChangeStepMeter( const std::string &sNew )
 {
 	using std::max;
-	int diff = StringToInt(sNew);
+	int diff = std::stoi(sNew);
 	GAMESTATE->m_pCurSteps[PLAYER_1]->SetMeter(max(diff, 1));
 }
 
@@ -4666,39 +4667,39 @@ static void ChangeArtistTranslit( const std::string &sNew )
 static void ChangeLastSecondHint( const std::string &sNew )
 {
 	Song &s = *GAMESTATE->m_pCurSong;
-	s.SetSpecifiedLastSecond(StringToFloat(sNew));
+	s.SetSpecifiedLastSecond(std::stof(sNew));
 }
 
 static void ChangePreviewStart( const std::string &sNew )
 {
-	GAMESTATE->m_pCurSong->m_fMusicSampleStartSeconds = StringToFloat( sNew );
+	GAMESTATE->m_pCurSong->m_fMusicSampleStartSeconds = std::stof( sNew );
 }
 
 static void ChangePreviewLength( const std::string &sNew )
 {
-	GAMESTATE->m_pCurSong->m_fMusicSampleLengthSeconds = StringToFloat( sNew );
+	GAMESTATE->m_pCurSong->m_fMusicSampleLengthSeconds = std::stof( sNew );
 }
 
 static void ChangeMinBPM( const std::string &sNew )
 {
-	GAMESTATE->m_pCurSong->m_fSpecifiedBPMMin = StringToFloat( sNew );
+	GAMESTATE->m_pCurSong->m_fSpecifiedBPMMin = std::stof( sNew );
 }
 
 static void ChangeStepsMinBPM(const std::string &sNew)
 {
 	Steps *step = GAMESTATE->m_pCurSteps[PLAYER_1];
-	step->SetMinBPM(StringToFloat(sNew));
+	step->SetMinBPM(std::stof(sNew));
 }
 
 static void ChangeMaxBPM( const std::string &sNew )
 {
-	GAMESTATE->m_pCurSong->m_fSpecifiedBPMMax = StringToFloat( sNew );
+	GAMESTATE->m_pCurSong->m_fSpecifiedBPMMax = std::stof( sNew );
 }
 
 static void ChangeStepsMaxBPM(const std::string &sNew)
 {
 	Steps *step = GAMESTATE->m_pCurSteps[PLAYER_1];
-	step->SetMaxBPM(StringToFloat(sNew));
+	step->SetMaxBPM(std::stof(sNew));
 }
 
 const TimingData & ScreenEdit::GetAppropriateTiming() const
@@ -4767,25 +4768,25 @@ void ScreenEdit::DisplayTimingMenu()
 	// bool bIsSelecting = ( (m_NoteFieldEdit.m_iEndMarker != -1) && (m_NoteFieldEdit.m_iBeginMarker != -1) );
 
 
-	g_TimingDataInformation.rows[beat_0_offset].SetOneUnthemedChoice( FloatToString(pTime.m_fBeat0OffsetInSeconds) );
-	g_TimingDataInformation.rows[bpm].SetOneUnthemedChoice( FloatToString(pTime.GetBPMAtRow( row ) ) );
-	g_TimingDataInformation.rows[stop].SetOneUnthemedChoice( FloatToString(pTime.GetStopAtRow( row ) ) ) ;
-	g_TimingDataInformation.rows[delay].SetOneUnthemedChoice( FloatToString(pTime.GetDelayAtRow( row ) ) );
+	g_TimingDataInformation.rows[beat_0_offset].SetOneUnthemedChoice( std::to_string(pTime.m_fBeat0OffsetInSeconds) );
+	g_TimingDataInformation.rows[bpm].SetOneUnthemedChoice( std::to_string(pTime.GetBPMAtRow( row ) ) );
+	g_TimingDataInformation.rows[stop].SetOneUnthemedChoice( std::to_string(pTime.GetStopAtRow( row ) ) ) ;
+	g_TimingDataInformation.rows[delay].SetOneUnthemedChoice( std::to_string(pTime.GetDelayAtRow( row ) ) );
 
 	g_TimingDataInformation.rows[label].SetOneUnthemedChoice( pTime.GetLabelAtRow( row ).c_str() );
 	g_TimingDataInformation.rows[tickcount].SetOneUnthemedChoice( fmt::sprintf("%d", pTime.GetTickcountAtRow( row ) ) );
 	g_TimingDataInformation.rows[combo].SetOneUnthemedChoice( fmt::sprintf("%d / %d",
 																	   pTime.GetComboAtRow( row ),
 																	   pTime.GetMissComboAtRow( row ) ) );
-	g_TimingDataInformation.rows[warp].SetOneUnthemedChoice( FloatToString(pTime.GetWarpAtRow( row ) ) );
-	g_TimingDataInformation.rows[speed_percent].SetOneUnthemedChoice( bHasSpeedOnThisRow ? FloatToString(pTime.GetSpeedPercentAtRow( row ) ) : "---" );
-	g_TimingDataInformation.rows[speed_wait].SetOneUnthemedChoice( bHasSpeedOnThisRow ? FloatToString(pTime.GetSpeedWaitAtRow( row ) ) : "---" );
+	g_TimingDataInformation.rows[warp].SetOneUnthemedChoice( std::to_string(pTime.GetWarpAtRow( row ) ) );
+	g_TimingDataInformation.rows[speed_percent].SetOneUnthemedChoice( bHasSpeedOnThisRow ? std::to_string(pTime.GetSpeedPercentAtRow( row ) ) : "---" );
+	g_TimingDataInformation.rows[speed_wait].SetOneUnthemedChoice( bHasSpeedOnThisRow ? std::to_string(pTime.GetSpeedWaitAtRow( row ) ) : "---" );
 
 	std::string starting = ( pTime.GetSpeedModeAtRow( row ) == 1 ? "Seconds" : "Beats" );
 	g_TimingDataInformation.rows[speed_mode].SetOneUnthemedChoice( starting.c_str() );
 
-	g_TimingDataInformation.rows[scroll].SetOneUnthemedChoice( FloatToString(pTime.GetScrollAtRow( row ) ) );
-	g_TimingDataInformation.rows[fake].SetOneUnthemedChoice( FloatToString(pTime.GetFakeAtRow( row ) ) );
+	g_TimingDataInformation.rows[scroll].SetOneUnthemedChoice( std::to_string(pTime.GetScrollAtRow( row ) ) );
+	g_TimingDataInformation.rows[fake].SetOneUnthemedChoice( std::to_string(pTime.GetFakeAtRow( row ) ) );
 
 	// g_TimingDataInformation.rows[speed_percent].bEnabled = !bIsSelecting;
 	g_TimingDataInformation.rows[speed_wait].bEnabled = bHasSpeedOnThisRow;
@@ -4903,8 +4904,8 @@ void ScreenEdit::HandleMainMenuChoice( MainMenuChoice c, const vector<int> &iAns
 				g_StepsInformation.rows[step_credit].bEnabled = (EDIT_MODE.GetValue() >= EditMode_Full);
 				g_StepsInformation.rows[step_credit].SetOneUnthemedChoice( pSteps->GetCredit() );
 				g_StepsInformation.rows[step_display_bpm].iDefaultChoice = pSteps->GetDisplayBPM();
-				g_StepsInformation.rows[step_min_bpm].SetOneUnthemedChoice( FloatToString(pSteps->GetMinBPM()));
-				g_StepsInformation.rows[step_max_bpm].SetOneUnthemedChoice( FloatToString(pSteps->GetMaxBPM()));
+				g_StepsInformation.rows[step_min_bpm].SetOneUnthemedChoice( std::to_string(pSteps->GetMinBPM()));
+				g_StepsInformation.rows[step_max_bpm].SetOneUnthemedChoice( std::to_string(pSteps->GetMaxBPM()));
 				g_StepsInformation.rows[step_music].bEnabled = (EDIT_MODE.GetValue() >= EditMode_Full);
 				g_StepsInformation.rows[step_music].SetOneUnthemedChoice( pSteps->GetMusicFile() );
 				EditMiniMenu( &g_StepsInformation, SM_BackFromStepsInformation, SM_None );
@@ -4985,12 +4986,12 @@ void ScreenEdit::HandleMainMenuChoice( MainMenuChoice c, const vector<int> &iAns
 				g_SongInformation.rows[main_title_transliteration].SetOneUnthemedChoice( pSong->m_sMainTitleTranslit );
 				g_SongInformation.rows[sub_title_transliteration].SetOneUnthemedChoice( pSong->m_sSubTitleTranslit );
 				g_SongInformation.rows[artist_transliteration].SetOneUnthemedChoice( pSong->m_sArtistTranslit );
-				g_SongInformation.rows[last_second_hint].SetOneUnthemedChoice( FloatToString(pSong->GetSpecifiedLastSecond()) );
-				g_SongInformation.rows[preview_start].SetOneUnthemedChoice( FloatToString(pSong->m_fMusicSampleStartSeconds) );
-				g_SongInformation.rows[preview_length].SetOneUnthemedChoice( FloatToString(pSong->m_fMusicSampleLengthSeconds) );
+				g_SongInformation.rows[last_second_hint].SetOneUnthemedChoice( std::to_string(pSong->GetSpecifiedLastSecond()) );
+				g_SongInformation.rows[preview_start].SetOneUnthemedChoice( std::to_string(pSong->m_fMusicSampleStartSeconds) );
+				g_SongInformation.rows[preview_length].SetOneUnthemedChoice( std::to_string(pSong->m_fMusicSampleLengthSeconds) );
 				g_SongInformation.rows[display_bpm].iDefaultChoice = pSong->m_DisplayBPMType;
-				g_SongInformation.rows[min_bpm].SetOneUnthemedChoice( FloatToString(pSong->m_fSpecifiedBPMMin) );
-				g_SongInformation.rows[max_bpm].SetOneUnthemedChoice( FloatToString(pSong->m_fSpecifiedBPMMax) );
+				g_SongInformation.rows[min_bpm].SetOneUnthemedChoice( std::to_string(pSong->m_fSpecifiedBPMMin) );
+				g_SongInformation.rows[max_bpm].SetOneUnthemedChoice( std::to_string(pSong->m_fSpecifiedBPMMax) );
 
 				EditMiniMenu( &g_SongInformation, SM_BackFromSongInformation );
 			}
@@ -5677,7 +5678,7 @@ void ScreenEdit::HandleStepsInformationChoice( StepsInformationChoice c, const v
 		case step_min_bpm:
 		{
 			ScreenTextEntry::TextEntry(SM_None, ENTER_MIN_BPM.GetValue(),
-									   FloatToString(pSteps->GetMinBPM()), 20,
+									   std::to_string(pSteps->GetMinBPM()), 20,
 									   ScreenTextEntry::FloatValidate,
 									   ChangeStepsMinBPM, nullptr);
 			break;
@@ -5685,7 +5686,7 @@ void ScreenEdit::HandleStepsInformationChoice( StepsInformationChoice c, const v
 		case step_max_bpm:
 		{
 			ScreenTextEntry::TextEntry(SM_None, ENTER_MAX_BPM.GetValue(),
-									   FloatToString(pSteps->GetMaxBPM()), 20,
+									   std::to_string(pSteps->GetMaxBPM()), 20,
 									   ScreenTextEntry::FloatValidate,
 									   ChangeStepsMaxBPM, nullptr);
 			break;
@@ -5755,27 +5756,27 @@ void ScreenEdit::HandleSongInformationChoice( SongInformationChoice c, const vec
 		break;
 	case last_second_hint:
 		ScreenTextEntry::TextEntry( SM_None, ENTER_LAST_SECOND_HINT.GetValue(),
-					   FloatToString(pSong->GetSpecifiedLastSecond()), 20,
+					   std::to_string(pSong->GetSpecifiedLastSecond()), 20,
 					   ScreenTextEntry::FloatValidate, ChangeLastSecondHint, nullptr );
 		break;
 	case preview_start:
 		ScreenTextEntry::TextEntry( SM_None, ENTER_PREVIEW_START.GetValue(),
-					   FloatToString(pSong->m_fMusicSampleStartSeconds), 20,
+					   std::to_string(pSong->m_fMusicSampleStartSeconds), 20,
 					   ScreenTextEntry::FloatValidate, ChangePreviewStart, nullptr );
 		break;
 	case preview_length:
 		ScreenTextEntry::TextEntry( SM_None, ENTER_PREVIEW_LENGTH.GetValue(),
-					   FloatToString(pSong->m_fMusicSampleLengthSeconds), 20,
+					   std::to_string(pSong->m_fMusicSampleLengthSeconds), 20,
 					   ScreenTextEntry::FloatValidate, ChangePreviewLength, nullptr );
 		break;
 	case min_bpm:
 		ScreenTextEntry::TextEntry( SM_None, ENTER_MIN_BPM.GetValue(),
-					   FloatToString(pSong->m_fSpecifiedBPMMin), 20,
+					   std::to_string(pSong->m_fSpecifiedBPMMin), 20,
 					   ScreenTextEntry::FloatValidate, ChangeMinBPM, nullptr );
 		break;
 	case max_bpm:
 		ScreenTextEntry::TextEntry( SM_None, ENTER_MAX_BPM.GetValue(),
-					   FloatToString(pSong->m_fSpecifiedBPMMax), 20,
+					   std::to_string(pSong->m_fSpecifiedBPMMax), 20,
 					   ScreenTextEntry::FloatValidate, ChangeMaxBPM, nullptr );
 		break;
 	default: break;
@@ -5807,7 +5808,7 @@ void ScreenEdit::HandleTimingDataInformationChoice( TimingDataInformationChoice 
 		ScreenTextEntry::TextEntry(
 			SM_BackFromBeat0Change,
 			ENTER_BEAT_0_OFFSET.GetValue(),
-			FloatToString(GetAppropriateTiming().m_fBeat0OffsetInSeconds),
+			std::to_string(GetAppropriateTiming().m_fBeat0OffsetInSeconds),
 			20
 			);
 		break;
@@ -5815,7 +5816,7 @@ void ScreenEdit::HandleTimingDataInformationChoice( TimingDataInformationChoice 
 		ScreenTextEntry::TextEntry(
 			SM_BackFromBPMChange,
 			ENTER_BPM_VALUE.GetValue(),
-			FloatToString( GetAppropriateTiming().GetBPMAtBeat( GetBeat() ) ),
+			std::to_string( GetAppropriateTiming().GetBPMAtBeat( GetBeat() ) ),
 			10
 			);
 		break;
@@ -5823,7 +5824,7 @@ void ScreenEdit::HandleTimingDataInformationChoice( TimingDataInformationChoice 
 		ScreenTextEntry::TextEntry(
 			SM_BackFromStopChange,
 			ENTER_STOP_VALUE.GetValue(),
-			FloatToString( GetAppropriateTiming().GetStopAtBeat( GetBeat() ) ),
+			std::to_string( GetAppropriateTiming().GetStopAtBeat( GetBeat() ) ),
 			10
 			);
 		break;
@@ -5831,7 +5832,7 @@ void ScreenEdit::HandleTimingDataInformationChoice( TimingDataInformationChoice 
 		ScreenTextEntry::TextEntry(
 			SM_BackFromDelayChange,
 			ENTER_DELAY_VALUE.GetValue(),
-			FloatToString( GetAppropriateTiming().GetDelayAtBeat( GetBeat() ) ),
+			std::to_string( GetAppropriateTiming().GetDelayAtBeat( GetBeat() ) ),
 			10
 		);
 		break;
@@ -5866,7 +5867,7 @@ void ScreenEdit::HandleTimingDataInformationChoice( TimingDataInformationChoice 
 		ScreenTextEntry::TextEntry(
 		   SM_BackFromWarpChange,
 		   ENTER_WARP_VALUE.GetValue(),
-		   FloatToString( GetAppropriateTiming().GetWarpAtBeat( GetBeat() ) ),
+		   std::to_string( GetAppropriateTiming().GetWarpAtBeat( GetBeat() ) ),
 		   10
 		   );
 		break;
@@ -5874,7 +5875,7 @@ void ScreenEdit::HandleTimingDataInformationChoice( TimingDataInformationChoice 
 		ScreenTextEntry::TextEntry(
 		   SM_BackFromSpeedPercentChange,
 		   ENTER_SPEED_PERCENT_VALUE.GetValue(),
-		   FloatToString( GetAppropriateTiming().GetSpeedSegmentAtBeat( GetBeat() )->GetRatio() ),
+		   std::to_string( GetAppropriateTiming().GetSpeedSegmentAtBeat( GetBeat() )->GetRatio() ),
 		   10
 		   );
 		break;
@@ -5882,7 +5883,7 @@ void ScreenEdit::HandleTimingDataInformationChoice( TimingDataInformationChoice 
 		ScreenTextEntry::TextEntry(
 		   SM_BackFromScrollChange,
 		   ENTER_SCROLL_VALUE.GetValue(),
-		   FloatToString( GetAppropriateTiming().GetScrollSegmentAtBeat( GetBeat() )->GetRatio() ),
+		   std::to_string( GetAppropriateTiming().GetScrollSegmentAtBeat( GetBeat() )->GetRatio() ),
 		   10
 		   );
 		break;
@@ -5890,7 +5891,7 @@ void ScreenEdit::HandleTimingDataInformationChoice( TimingDataInformationChoice 
 		ScreenTextEntry::TextEntry(
 		   SM_BackFromSpeedWaitChange,
 		   ENTER_SPEED_WAIT_VALUE.GetValue(),
-		   FloatToString( GetAppropriateTiming().GetSpeedSegmentAtBeat( GetBeat() )->GetDelay() ),
+		   std::to_string( GetAppropriateTiming().GetSpeedSegmentAtBeat( GetBeat() )->GetDelay() ),
 		   10
 		   );
 		break;
@@ -5910,7 +5911,7 @@ void ScreenEdit::HandleTimingDataInformationChoice( TimingDataInformationChoice 
 			ScreenTextEntry::TextEntry(
 				SM_BackFromFakeChange,
 				ENTER_FAKE_VALUE.GetValue(),
-			        FloatToString(GetAppropriateTiming().GetFakeAtBeat( GetBeat() ) ),
+			        std::to_string(GetAppropriateTiming().GetFakeAtBeat( GetBeat() ) ),
 				10
 			);
 			break;
@@ -6048,7 +6049,7 @@ void ScreenEdit::HandleBGChangeChoice( BGChangeChoice c, const vector<int> &iAns
 	}
 
 	newChange.m_fStartBeat    = GAMESTATE->m_Position.m_fSongBeat;
-	newChange.m_fRate         = StringToFloat( g_BackgroundChange.rows[rate].choices[iAnswers[rate]] )/100.f;
+	newChange.m_fRate         = std::stof( g_BackgroundChange.rows[rate].choices[iAnswers[rate]] )/100.f;
 	newChange.m_sTransition   = iAnswers[transition] ? g_BackgroundChange.rows[transition].choices[iAnswers[transition]] : std::string();
 	newChange.m_def.m_sEffect = iAnswers[effect]     ? g_BackgroundChange.rows[effect].choices[iAnswers[effect]]         : std::string();
 	newChange.m_def.m_sColor1 = iAnswers[color1]     ? g_BackgroundChange.rows[color1].choices[iAnswers[color1]]         : std::string();

--- a/src/ScreenGameplay.cpp
+++ b/src/ScreenGameplay.cpp
@@ -3254,7 +3254,7 @@ void ScreenGameplay::SaveReplay()
 					continue;
 
 				ASSERT( matches.size() == 1 );
-				iIndex = StringToInt( matches[0] )+1;
+				iIndex = std::stoi( matches[0] )+1;
 				break;
 			}
 

--- a/src/ScreenMiniMenu.cpp
+++ b/src/ScreenMiniMenu.cpp
@@ -93,7 +93,7 @@ choices(), bThemeTitle(bTT), bThemeItems(bTI)
 {
 	for ( int i = low; i <= high; ++i )
 	{
-		choices.push_back(IntToString(i).c_str());
+		choices.push_back(std::to_string(i).c_str());
 	}
 }
 

--- a/src/ScreenPackages.cpp
+++ b/src/ScreenPackages.cpp
@@ -632,17 +632,20 @@ void ScreenPackages::HTTPUpdate()
 			m_sResponseName = "Malformed response.";
 			return;
 		}
-		m_iResponseCode = StringToInt(m_sBUFFER.substr(i+1,j-i));
+		m_iResponseCode = std::stoi(m_sBUFFER.substr(i+1,j-i));
 		m_sResponseName = m_sBUFFER.substr( j+1, k-j );
 
 		i = m_sBUFFER.find("Content-Length:");
 		j = m_sBUFFER.find("\n", i+1 );
 
 		if( i != string::npos )
-			m_iTotalBytes = StringToInt(m_sBUFFER.substr(i+16,j-i));
+		{
+			m_iTotalBytes = std::stoi(m_sBUFFER.substr(i+16,j-i));
+		}
 		else
+		{
 			m_iTotalBytes = -1;	//We don't know, so go until disconnect
-
+		}
 		m_bGotHeader = true;
 		m_sBUFFER.erase( 0, iHeaderEnd );
 	}
@@ -706,13 +709,16 @@ bool ScreenPackages::ParseHTTPAddress( const std::string &URL, std::string &sPro
 	sServer = asMatches[1];
 	if( asMatches[3] != "" )
 	{
-		iPort = StringToInt(asMatches[3]);
+		iPort = std::stoi(asMatches[3]);
 		if( iPort == 0 )
+		{
 			return false;
+		}
 	}
 	else
+	{
 		iPort = 80;
-
+	}
 	sAddress = asMatches[5];
 
 	return true;

--- a/src/ScreenTextEntry.cpp
+++ b/src/ScreenTextEntry.cpp
@@ -104,21 +104,31 @@ void ScreenTextEntry::TextEntry(
 static LocalizedString INVALID_FLOAT( "ScreenTextEntry", "\"%s\" is an invalid floating point value." );
 bool ScreenTextEntry::FloatValidate( const std::string &sAnswer, std::string &sErrorOut )
 {
-	float f;
-	if( StringToFloat(sAnswer, f) )
+	try
+	{
+		std::stof(sAnswer);
 		return true;
-	sErrorOut = fmt::sprintf( INVALID_FLOAT.GetValue().c_str(), sAnswer.c_str() );
-	return false;
+	}
+	catch (...)
+	{
+		sErrorOut = fmt::sprintf( INVALID_FLOAT.GetValue().c_str(), sAnswer.c_str() );
+		return false;
+	}
 }
 
 static LocalizedString INVALID_INT( "ScreenTextEntry", "\"%s\" is an invalid integer value." );
 bool ScreenTextEntry::IntValidate( const std::string &sAnswer, std::string &sErrorOut )
 {
-	int f;
-	if(sAnswer >> f)
+	try
+	{
+		std::stoi(sAnswer);
 		return true;
-	sErrorOut = fmt::sprintf( INVALID_INT.GetValue(), sAnswer.c_str() );
-	return false;
+	}
+	catch (...)
+	{
+		sErrorOut = fmt::sprintf( INVALID_INT.GetValue(), sAnswer.c_str() );
+		return false;
+	}
 }
 
 bool ScreenTextEntry::s_bCancelledLast = false;

--- a/src/SongOptions.cpp
+++ b/src/SongOptions.cpp
@@ -167,7 +167,7 @@ bool SongOptions::FromOneModString(const std::string &sOneMod)
 	vector<std::string> matches;
 	if( mult.Compare(sBit, matches) )
 	{
-		m_fMusicRate = StringToFloat( matches[0] );
+		m_fMusicRate = std::stof( matches[0] );
 		return true;
 	}
 

--- a/src/TimingSegments.cpp
+++ b/src/TimingSegments.cpp
@@ -123,8 +123,8 @@ void FakeSegment::DebugPrint() const
 
 std::string FakeSegment::ToString(int dec) const
 {
-	std::string str = "%.0" + IntToString(dec)
-	+ "f=%.0" + IntToString(dec) + "f";
+	std::string str = "%.0" + std::to_string(dec)
+	+ "f=%.0" + std::to_string(dec) + "f";
 	return fmt::sprintf(str.c_str(), GetBeat(), GetLength());
 }
 
@@ -140,8 +140,8 @@ void FakeSegment::Scale( int start, int length, int newLength )
 
 std::string WarpSegment::ToString(int dec) const
 {
-	std::string str = "%.0" + IntToString(dec)
-	+ "f=%.0" + IntToString(dec) + "f";
+	std::string str = "%.0" + std::to_string(dec)
+	+ "f=%.0" + std::to_string(dec) + "f";
 	return fmt::sprintf(str.c_str(), GetBeat(), GetLength());
 }
 
@@ -158,12 +158,12 @@ void WarpSegment::Scale( int start, int length, int newLength )
 
 std::string TickcountSegment::ToString(int dec) const
 {
-	const std::string str = "%.0" + IntToString(dec) + "f=%i";
+	const std::string str = "%.0" + std::to_string(dec) + "f=%i";
 	return fmt::sprintf(str.c_str(), GetBeat(), GetTicks());
 }
 std::string ComboSegment::ToString(int dec) const
 {
-	std::string str = "%.0" + IntToString(dec) + "f=%i";
+	std::string str = "%.0" + std::to_string(dec) + "f=%i";
 	if (GetCombo() == GetMissCombo())
 	{
 		return fmt::sprintf(str.c_str(), GetBeat(), GetCombo());
@@ -182,20 +182,20 @@ vector<float> ComboSegment::GetValues() const
 
 std::string LabelSegment::ToString(int dec) const
 {
-	const std::string str = "%.0" + IntToString(dec) + "f=%s";
+	const std::string str = "%.0" + std::to_string(dec) + "f=%s";
 	return fmt::sprintf(str.c_str(), GetBeat(), GetLabel().c_str());
 }
 
 std::string BPMSegment::ToString(int dec) const
 {
-	const std::string str = "%.0" + IntToString(dec)
-	+ "f=%.0" + IntToString(dec) + "f";
+	const std::string str = "%.0" + std::to_string(dec)
+	+ "f=%.0" + std::to_string(dec) + "f";
 	return fmt::sprintf(str.c_str(), GetBeat(), GetBPM());
 }
 
 std::string TimeSignatureSegment::ToString(int dec) const
 {
-	const std::string str = "%.0" + IntToString(dec) + "f=%i=%i";
+	const std::string str = "%.0" + std::to_string(dec) + "f=%i=%i";
 	return fmt::sprintf(str.c_str(), GetBeat(), GetNum(), GetDen());
 }
 
@@ -209,9 +209,9 @@ vector<float> TimeSignatureSegment::GetValues() const
 
 std::string SpeedSegment::ToString(int dec) const
 {
-	const std::string str = "%.0" + IntToString(dec)
-		+ "f=%.0" + IntToString(dec) + "f=%.0"
-		+ IntToString(dec) + "f=%u";
+	const std::string str = "%.0" + std::to_string(dec)
+		+ "f=%.0" + std::to_string(dec) + "f=%.0"
+		+ std::to_string(dec) + "f=%u";
 	return fmt::sprintf(str.c_str(), GetBeat(), GetRatio(),
 		GetDelay(), static_cast<unsigned int>(GetUnit()));
 }
@@ -247,22 +247,22 @@ void SpeedSegment::Scale( int start, int oldLength, int newLength )
 
 std::string ScrollSegment::ToString(int dec) const
 {
-	const std::string str = "%.0" + IntToString(dec)
-		+ "f=%.0" + IntToString(dec) + "f";
+	const std::string str = "%.0" + std::to_string(dec)
+		+ "f=%.0" + std::to_string(dec) + "f";
 	return fmt::sprintf(str.c_str(), GetBeat(), GetRatio());
 }
 
 std::string StopSegment::ToString(int dec) const
 {
-	const std::string str = "%.0" + IntToString(dec)
-	+ "f=%.0" + IntToString(dec) + "f";
+	const std::string str = "%.0" + std::to_string(dec)
+	+ "f=%.0" + std::to_string(dec) + "f";
 	return fmt::sprintf(str.c_str(), GetBeat(), GetPause());
 }
 
 std::string DelaySegment::ToString(int dec) const
 {
-	const std::string str = "%.0" + IntToString(dec)
-	+ "f=%.0" + IntToString(dec) + "f";
+	const std::string str = "%.0" + std::to_string(dec)
+	+ "f=%.0" + std::to_string(dec) + "f";
 	return fmt::sprintf(str.c_str(), GetBeat(), GetPause());
 }
 

--- a/src/TimingSegments.h
+++ b/src/TimingSegments.h
@@ -80,7 +80,7 @@ struct TimingSegment
 
 	virtual std::string ToString(int /* dec */) const
 	{
-		return FloatToString(GetBeat());
+		return std::to_string(GetBeat());
 	}
 
 	virtual std::vector<float> GetValues() const

--- a/src/XmlFile.cpp
+++ b/src/XmlFile.cpp
@@ -58,9 +58,9 @@ void XNode::Free()
 }
 
 void XNodeStringValue::GetValue( std::string &out ) const		{ out = m_sValue; }
-void XNodeStringValue::GetValue( int &out ) const		{ out = StringToInt(m_sValue); }
-void XNodeStringValue::GetValue( float &out ) const		{ out = StringToFloat(m_sValue); }
-void XNodeStringValue::GetValue( bool &out ) const		{ out = StringToInt(m_sValue) != 0; }
+void XNodeStringValue::GetValue( int &out ) const		{ out = std::stoi(m_sValue); }
+void XNodeStringValue::GetValue( float &out ) const		{ out = std::stof(m_sValue); }
+void XNodeStringValue::GetValue( bool &out ) const		{ out = std::stoi(m_sValue) != 0; }
 void XNodeStringValue::GetValue( unsigned &out ) const		{ out = strtoul(m_sValue.c_str(),nullptr,0); }
 void XNodeStringValue::PushValue( lua_State *L ) const
 {

--- a/src/XmlToLua.cpp
+++ b/src/XmlToLua.cpp
@@ -47,12 +47,12 @@ void convert_xmls_in_dir(std::string const& dirname)
 
 std::string convert_xpos(float x)
 {
-	return "SCREEN_CENTER_X + " + FloatToString(x - 320.0f);
+	return "SCREEN_CENTER_X + " + std::to_string(x - 320.0f);
 }
 
 std::string convert_ypos(float y)
 {
-	return "SCREEN_CENTER_Y + " + FloatToString(y - 240.0f);
+	return "SCREEN_CENTER_Y + " + std::to_string(y - 240.0f);
 }
 
 std::string maybe_conv_pos(std::string pos, std::string (*conv_func)(float p))
@@ -433,13 +433,13 @@ void actor_template_t::load_frames_from_file(std::string const& fname, std::stri
 			std::string field_type{ Rage::head(attr.first, 5) };
 			if(field_type == "Frame")
 			{
-				int id= StringToInt( Rage::tail(attr.first, -5) );
+				int id= std::stoi( Rage::tail(attr.first, -5) );
 				make_space_for_frame(id);
 				attr.second->GetValue(frames[id].frame);
 			}
 			else if(field_type == "Delay")
 			{
-				int id= StringToInt( Rage::tail(attr.first, -5) );
+				int id= std::stoi( Rage::tail(attr.first, -5) );
 				make_space_for_frame(id);
 				attr.second->GetValue(frames[id].delay);
 			}
@@ -668,8 +668,8 @@ void actor_template_t::output_to_file(RageFile* file, std::string const& indent)
 		for(vector<frame_t>::iterator frame= frames.begin();
 			frame != frames.end(); ++frame)
 		{
-			file->Write(frameindent + "{Frame= " + IntToString(frame->frame) +
-				", Delay= " + FloatToString(frame->delay) + "},\n");
+			file->Write(frameindent + "{Frame= " + std::to_string(frame->frame) +
+				", Delay= " + std::to_string(frame->delay) + "},\n");
 		}
 		file->Write(indent + "},\n");
 	}


### PR DESCRIPTION
Instead of rolling our own, use what the standard provides.

Exceptions have been added either where needed or where they appeared to make sense. A number of older simfiles would have crashed on load due to how inconsistent they were, especially with background animations.

It is possible that not all of the crash points have been found.