### PR TITLE
Use standard int/float conversion functions

### DIFF
--- a/src/BGAnimationLayer.cpp
+++ b/src/BGAnimationLayer.cpp
@@ -417,22 +417,25 @@ void BGAnimationLayer::LoadFromNode( const XNode* pNode )
 		{
 			m_Type = TYPE_TILES;
 		}
-		else if( StringToInt(type) == 1 )
-		{
-			m_Type = TYPE_SPRITE;
-			bStretch = true;
-		}
-		else if( StringToInt(type) == 2 )
-		{
-			m_Type = TYPE_PARTICLES;
-		}
-		else if( StringToInt(type) == 3 )
-		{
-			m_Type = TYPE_TILES;
-		}
 		else
 		{
-			m_Type = TYPE_SPRITE;
+			int typo= StringToInt(type);
+			switch(typo)
+			{
+				case 1:
+					m_Type = TYPE_SPRITE;
+					bStretch = true;
+					break;
+				case 2:
+					m_Type = TYPE_PARTICLES;
+					break;
+				case 3:
+					m_Type = TYPE_TILES;
+					break;
+				default:
+					m_Type = TYPE_SPRITE;
+					break;
+			}
 		}
 	}
 

--- a/src/RageUtil.cpp
+++ b/src/RageUtil.cpp
@@ -1294,40 +1294,50 @@ static int UnicodeDoUpper( char *p, size_t iLen, const unsigned char pMapping[25
 	return iStart;
 }
 
-int StringToInt( const std::string &sString )
+int StringToInt(const std::string &str)
 {
-	int ret;
-	istringstream ( sString ) >> ret;
-	return ret;
-}
-
-std::string IntToString( const int &iNum )
-{
-	stringstream ss;
-	ss << iNum;
-	return ss.str();
-}
-
-float StringToFloat( const std::string &sString )
-{
-	float ret = strtof( sString.c_str(), nullptr );
-
-	if( !isfinite(ret) )
+	try
 	{
-		ret = 0.0f;
+		return std::stoi(str);
 	}
-	return ret;
+	catch(...)
+	{
+		return 0;
+	}
 }
 
-bool StringToFloat( const std::string &sString, float &fOut )
+float StringToFloat(const std::string &str)
 {
-	char *endPtr;
-
-	fOut = strtof( sString.c_str(), &endPtr );
-	return sString.size() && *endPtr == '\0' && isfinite( fOut );
+	try
+	{
+		float ret= std::stof(str);
+		if(!isfinite(ret))
+		{
+			ret = 0.0f;
+		}
+		return ret;
+	}
+	catch(...)
+	{
+		return 0.0f;
+	}
 }
 
-std::string FloatToString( const float &num )
+bool StringToFloat(const std::string &str, float &ret)
+{
+	try
+	{
+		ret= std::stof(str);
+		return isfinite(ret);
+	}
+	catch(...)
+	{
+		ret= 0.0f;
+		return false;
+	}
+}
+
+std::string FloatToString(const float &num)
 {
 	stringstream ss;
 	ss << num;

--- a/src/RageUtil.h
+++ b/src/RageUtil.h
@@ -355,19 +355,21 @@ bool FindFirstFilenameContaining(
 	std::vector<std::string> const & starts_with,
 	std::vector<std::string> const & contains, std::vector<std::string> const & ends_with);
 
-/**
- * @brief Have a standard way of converting Strings to integers.
- * @param sString the string to convert.
- * @return the integer we are after. */
-int StringToInt( const std::string &sString );
-/**
- * @brief Have a standard way of converting integers to Strings.
- * @param iNum the integer to convert.
- * @return the string we are after. */
-std::string IntToString( const int &iNum );
-float StringToFloat( const std::string &sString );
-std::string FloatToString( const float &num );
-bool StringToFloat( const std::string &sString, float &fOut );
+// StringToInt and StringToFloat are wrappers around std::stoi and std::stof
+// which handle the exception by returning 0.  Reporting the exception would
+// be cumbersome, and there are probably a million things that rely on an
+// "invalid" string being silently converted to 0.  This includes cases where
+// someone uses an empty string and expects it to come out 0, probably
+// frequently used in metrics. -Kyz
+int StringToInt(const std::string &str);
+float StringToFloat(const std::string &str);
+// The variant of StringToFloat that returns a bool returns true if the float
+// was valid. -Kyz
+bool StringToFloat(const std::string &str, float &ret);
+// We can't use std::to_string to replaced FloatToString because
+// std::to_string has no way to control the precision.  If we used it, we
+// would have to add extra code to trim off trailing zeroes. -Kyz
+std::string FloatToString(const float &num);
 // Better than IntToString because you can check for success.
 template<class T>
 inline bool operator>>(const std::string& lhs, T& rhs)

--- a/src/ScreenMiniMenu.cpp
+++ b/src/ScreenMiniMenu.cpp
@@ -93,7 +93,7 @@ choices(), bThemeTitle(bTT), bThemeItems(bTI)
 {
 	for ( int i = low; i <= high; ++i )
 	{
-		choices.push_back(IntToString(i).c_str());
+		choices.push_back(std::to_string(i).c_str());
 	}
 }
 

--- a/src/TimingSegments.cpp
+++ b/src/TimingSegments.cpp
@@ -123,8 +123,8 @@ void FakeSegment::DebugPrint() const
 
 std::string FakeSegment::ToString(int dec) const
 {
-	std::string str = "%.0" + IntToString(dec)
-	+ "f=%.0" + IntToString(dec) + "f";
+	std::string str = "%.0" + std::to_string(dec)
+	+ "f=%.0" + std::to_string(dec) + "f";
 	return fmt::sprintf(str.c_str(), GetBeat(), GetLength());
 }
 
@@ -140,8 +140,8 @@ void FakeSegment::Scale( int start, int length, int newLength )
 
 std::string WarpSegment::ToString(int dec) const
 {
-	std::string str = "%.0" + IntToString(dec)
-	+ "f=%.0" + IntToString(dec) + "f";
+	std::string str = "%.0" + std::to_string(dec)
+	+ "f=%.0" + std::to_string(dec) + "f";
 	return fmt::sprintf(str.c_str(), GetBeat(), GetLength());
 }
 
@@ -158,12 +158,12 @@ void WarpSegment::Scale( int start, int length, int newLength )
 
 std::string TickcountSegment::ToString(int dec) const
 {
-	const std::string str = "%.0" + IntToString(dec) + "f=%i";
+	const std::string str = "%.0" + std::to_string(dec) + "f=%i";
 	return fmt::sprintf(str.c_str(), GetBeat(), GetTicks());
 }
 std::string ComboSegment::ToString(int dec) const
 {
-	std::string str = "%.0" + IntToString(dec) + "f=%i";
+	std::string str = "%.0" + std::to_string(dec) + "f=%i";
 	if (GetCombo() == GetMissCombo())
 	{
 		return fmt::sprintf(str.c_str(), GetBeat(), GetCombo());
@@ -182,20 +182,20 @@ vector<float> ComboSegment::GetValues() const
 
 std::string LabelSegment::ToString(int dec) const
 {
-	const std::string str = "%.0" + IntToString(dec) + "f=%s";
+	const std::string str = "%.0" + std::to_string(dec) + "f=%s";
 	return fmt::sprintf(str.c_str(), GetBeat(), GetLabel().c_str());
 }
 
 std::string BPMSegment::ToString(int dec) const
 {
-	const std::string str = "%.0" + IntToString(dec)
-	+ "f=%.0" + IntToString(dec) + "f";
+	const std::string str = "%.0" + std::to_string(dec)
+	+ "f=%.0" + std::to_string(dec) + "f";
 	return fmt::sprintf(str.c_str(), GetBeat(), GetBPM());
 }
 
 std::string TimeSignatureSegment::ToString(int dec) const
 {
-	const std::string str = "%.0" + IntToString(dec) + "f=%i=%i";
+	const std::string str = "%.0" + std::to_string(dec) + "f=%i=%i";
 	return fmt::sprintf(str.c_str(), GetBeat(), GetNum(), GetDen());
 }
 
@@ -209,9 +209,9 @@ vector<float> TimeSignatureSegment::GetValues() const
 
 std::string SpeedSegment::ToString(int dec) const
 {
-	const std::string str = "%.0" + IntToString(dec)
-		+ "f=%.0" + IntToString(dec) + "f=%.0"
-		+ IntToString(dec) + "f=%u";
+	const std::string str = "%.0" + std::to_string(dec)
+		+ "f=%.0" + std::to_string(dec) + "f=%.0"
+		+ std::to_string(dec) + "f=%u";
 	return fmt::sprintf(str.c_str(), GetBeat(), GetRatio(),
 		GetDelay(), static_cast<unsigned int>(GetUnit()));
 }
@@ -247,22 +247,22 @@ void SpeedSegment::Scale( int start, int oldLength, int newLength )
 
 std::string ScrollSegment::ToString(int dec) const
 {
-	const std::string str = "%.0" + IntToString(dec)
-		+ "f=%.0" + IntToString(dec) + "f";
+	const std::string str = "%.0" + std::to_string(dec)
+		+ "f=%.0" + std::to_string(dec) + "f";
 	return fmt::sprintf(str.c_str(), GetBeat(), GetRatio());
 }
 
 std::string StopSegment::ToString(int dec) const
 {
-	const std::string str = "%.0" + IntToString(dec)
-	+ "f=%.0" + IntToString(dec) + "f";
+	const std::string str = "%.0" + std::to_string(dec)
+	+ "f=%.0" + std::to_string(dec) + "f";
 	return fmt::sprintf(str.c_str(), GetBeat(), GetPause());
 }
 
 std::string DelaySegment::ToString(int dec) const
 {
-	const std::string str = "%.0" + IntToString(dec)
-	+ "f=%.0" + IntToString(dec) + "f";
+	const std::string str = "%.0" + std::to_string(dec)
+	+ "f=%.0" + std::to_string(dec) + "f";
 	return fmt::sprintf(str.c_str(), GetBeat(), GetPause());
 }
 

--- a/src/XmlToLua.cpp
+++ b/src/XmlToLua.cpp
@@ -668,7 +668,7 @@ void actor_template_t::output_to_file(RageFile* file, std::string const& indent)
 		for(vector<frame_t>::iterator frame= frames.begin();
 			frame != frames.end(); ++frame)
 		{
-			file->Write(frameindent + "{Frame= " + IntToString(frame->frame) +
+			file->Write(frameindent + "{Frame= " + std::to_string(frame->frame) +
 				", Delay= " + FloatToString(frame->delay) + "},\n");
 		}
 		file->Write(indent + "},\n");


### PR DESCRIPTION
Replaces #1181.  This approach is different because adding a thousand try blocks to handle exceptions everywhere would be bad in its own way.

There might be a substantial performance hit from having a try block even when an exception is not thrown.  Somebody on Windows should compare how long stepmania takes to start up to see if this change slows down startup time.  StringToInt is used in several places in NotesLoaderSSC, so if this version performs worse, startup time will be slower with a large song collection.