### PR TITLE
Proposed changes for new SextetStream work

### DIFF
--- a/src/CMakeData-sextets.cmake
+++ b/src/CMakeData-sextets.cmake
@@ -1,0 +1,66 @@
+# To determine what to put in this file, run the following from src:
+#	#!/bin/sh
+#	
+#	NETWORK_TEST=(-name '*EzSockets*')
+#	
+#	echo 'list(APPEND SMDATA_SEXTETS_SRC'
+#	find Sextets '(' -name '*.cpp' -a -not ${NETWORK_TEST[@]} ')' -exec echo '  "{}"' \; | sort
+#	echo ')'
+#	echo
+#	echo 'list(APPEND SMDATA_SEXTETS_HPP'
+#	find Sextets '(' -name '*.h' -a -not ${NETWORK_TEST[@]} ')' -exec echo '  "{}"' \; | sort
+#	echo ')'
+#	echo
+#	echo 'if(WITH_NETWORKING)'
+#	echo '  list(APPEND SMDATA_SEXTETS_SRC'
+#	find Sextets '(' -name '*.cpp' -a ${NETWORK_TEST[@]} ')' -exec echo '    "{}"' \; | sort
+#	echo '  )'
+#	echo '  list(APPEND SMDATA_SEXTETS_HPP'
+#	find Sextets '(' -name '*.h' -a ${NETWORK_TEST[@]} ')' -exec echo '    "{}"' \; | sort
+#	echo '  )'
+#	echo 'endif()'
+#	echo
+#	echo 'source_group("Sextets Support Library" FILES ${SMDATA_SEXTETS_SRC} ${SMDATA_SEXTETS_HPP})'
+
+list(APPEND SMDATA_SEXTETS_SRC
+  "Sextets/Data.cpp"
+  "Sextets/IO/NoopPacketWriter.cpp"
+  "Sextets/IO/PacketReaderEventGenerator.cpp"
+  "Sextets/IO/RageFilePacketWriter.cpp"
+  "Sextets/IO/StdCFilePacketReader.cpp"
+  "Sextets/PacketBuffer.cpp"
+  "Sextets/Packet.cpp"
+)
+
+list(APPEND SMDATA_SEXTETS_HPP
+  "Sextets/Data.h"
+  "Sextets/IO/NoopPacketWriter.h"
+  "Sextets/IO/PacketReaderEventGenerator.h"
+  "Sextets/IO/PacketReader.h"
+  "Sextets/IO/PacketWriter.h"
+  "Sextets/IO/RageFilePacketWriter.h"
+  "Sextets/IO/StdCFilePacketReader.h"
+  "Sextets/PacketBuffer.h"
+  "Sextets/Packet.h"
+)
+
+if(NOT WIN32)
+  list(APPEND SMDATA_SEXTETS_SRC
+    "Sextets/IO/SelectFilePacketReader.cpp"
+  )
+  list(APPEND SMDATA_SEXTETS_HPP
+    "Sextets/IO/SelectFilePacketReader.h"
+  )
+endif()
+
+if(WITH_NETWORKING)
+  list(APPEND SMDATA_SEXTETS_SRC
+    "Sextets/IO/EzSocketsPacketReader.cpp"
+  )
+  list(APPEND SMDATA_SEXTETS_HPP
+    "Sextets/IO/EzSocketsPacketReader.h"
+  )
+endif()
+
+source_group("Sextets Support Library" FILES ${SMDATA_SEXTETS_SRC} ${SMDATA_SEXTETS_HPP})
+

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -26,6 +26,7 @@ include(CMakeData-gtk.cmake)
 include(CMakeData-file-types.cmake)
 include(CMakeData-globals.cmake)
 include(CMakeData-singletons.cmake)
+include(CMakeData-sextets.cmake)
 
 list(APPEND SMDATA_ALL_FILES_SRC
   ${SMDATA_GLOBAL_FILES_SRC}
@@ -37,6 +38,7 @@ list(APPEND SMDATA_ALL_FILES_SRC
   ${SMDATA_ALL_SCREENS_SRC}
   ${SMDATA_OS_SRC}
   ${SMDATA_FILE_TYPES_SRC}
+  ${SMDATA_SEXTETS_SRC}
 )
 list(APPEND SMDATA_ALL_FILES_HPP
   ${SMDATA_GLOBAL_FILES_HPP}
@@ -48,6 +50,7 @@ list(APPEND SMDATA_ALL_FILES_HPP
   ${SMDATA_ALL_SCREENS_HPP}
   ${SMDATA_OS_HPP}
   ${SMDATA_FILE_TYPES_HPP}
+  ${SMDATA_SEXTETS_HPP}
 )
 
 if(NOT APPLE)

--- a/src/Sextets/Data.cpp
+++ b/src/Sextets/Data.cpp
@@ -1,0 +1,378 @@
+
+#include "Sextets/Data.h"
+#include "RageLog.h"
+#include "LightsManager.h"
+
+// Number of printable characters used to encode lights
+static const size_t CABINET_SEXTET_COUNT = 1;
+static const size_t CONTROLLER_SEXTET_COUNT = 6;
+
+// Number of bytes to contain the full pack
+static const size_t FULL_SEXTET_COUNT = CABINET_SEXTET_COUNT + (NUM_GameController * CONTROLLER_SEXTET_COUNT);
+
+#define SEXTET_PART(n) ((n) & 0x3F)
+#define SEXTET_PART_XOR(a,b) SEXTET_PART((a)^(b))
+#define SEXTET_PART_EQUALS_ZERO(n) (SEXTET_PART(n) == 0)
+#define SEXTET_PARTS_EQUAL(a,b) SEXTET_PART_EQUALS_ZERO((a)^(b))
+
+#define SWAP_VIA(tmp, a, b) { tmp = a; a = b; b = tmp; }
+
+// In so many words, ceil(n/6).
+#define NUMBER_OF_SEXTETS_FOR_BIT_COUNT(n) (((n) + 5) / 6)
+
+namespace
+{
+		inline size_t min(size_t a, size_t b) {
+			return (a < b) ? a : b;
+		}
+
+		bool IsValidSextetByte(uint8_t value)
+		{
+			return (value >= 0x30) && (value <= 0x6F);
+		}
+
+		// Encodes the low 6 bits of a byte as a printable, non-space ASCII
+		// character (i.e., within the range 0x21-0x7E) such that the low 6 bits of
+		// the character are the same as the input.
+		uint8_t ApplyArmor(uint8_t data)
+		{
+			// Maps the 6-bit value into the range 0x30-0x6F, wrapped in such a way
+			// that the low 6 bits of the result are the same as the data (so
+			// decoding is trivial).
+			//
+			//	00nnnn	->	0100nnnn (0x4n)
+			//	01nnnn	->	0101nnnn (0x5n)
+			//	10nnnn	->	0110nnnn (0x6n)
+			//	11nnnn	->	0011nnnn (0x3n)
+
+			// Put another way, the top 4 bits H of the output are determined from
+			// the top two bits T of the input like so:
+			// 	H = ((T + 1) mod 4) + 3
+
+			return ((data + (uint8_t)0x10) & (uint8_t)0x3F) + (uint8_t)0x30;
+		}
+
+		void TrimTrailingNewlines(RString& str)
+		{
+			size_t found = str.find_last_not_of("\x0A\x0D");
+			if(found != RString::npos) {
+				str.erase(found + 1);
+			} else {
+				str.clear();
+			}
+		}
+
+		size_t IndexOfTrimmableNewlines(const RString& str)
+		{
+			// Find index of last non-newline char.
+			size_t found = str.find_last_not_of("\x0A\x0D");
+
+			if(found == RString::npos) {
+				// No non-newline character was found
+				return 0;
+			} else {
+				// Found the last non-newline character
+				return found + 1;
+			}
+		}
+
+		inline void XorPacketsSameLength(RString& dest, const RString& other)
+		{
+			size_t size = dest.length();
+			for(size_t i = 0; i < size; ++i) {
+				dest[i] = ApplyArmor(dest[i] ^ other[i]);
+			}
+		}
+
+		void XorPackets(RString& dest, const RString& a, const RString& b)
+		{
+			const RString * longSource;
+			const RString * shortSource;
+
+			if(a.length() > b.length()) {
+				longSource = &a;
+				shortSource = &b;
+			}
+			else {
+				longSource = &b;
+				shortSource = &a;
+			}
+			
+			dest = *shortSource;
+			dest.resize(longSource->length(), ApplyArmor(0));
+			XorPacketsSameLength(dest, *longSource);
+		}
+
+		// Packs 6 booleans into a 6-bit value
+		inline uint8_t PackPlainSextet(bool b0, bool b1, bool b2, bool b3, bool b4, bool b5)
+		{
+			return (uint8_t)(
+					   (b0 ? 0x01 : 0) |
+					   (b1 ? 0x02 : 0) |
+					   (b2 ? 0x04 : 0) |
+					   (b3 ? 0x08 : 0) |
+					   (b4 ? 0x10 : 0) |
+					   (b5 ? 0x20 : 0));
+		}
+
+		// Packs 6 booleans into a printable sextet
+		inline uint8_t PackArmoredSextet(bool b0, bool b1, bool b2, bool b3, bool b4, bool b5)
+		{
+			return ApplyArmor(PackPlainSextet(b0, b1, b2, b3, b4, b5));
+		}
+
+		// Packs the cabinet lights into a printable sextet and adds it to a buffer
+		inline size_t AppendCabinetLights(uint8_t * buffer, const LightsState * ls)
+		{
+			buffer[0] = PackArmoredSextet(
+							ls->m_bCabinetLights[LIGHT_MARQUEE_UP_LEFT],
+							ls->m_bCabinetLights[LIGHT_MARQUEE_UP_RIGHT],
+							ls->m_bCabinetLights[LIGHT_MARQUEE_LR_LEFT],
+							ls->m_bCabinetLights[LIGHT_MARQUEE_LR_RIGHT],
+							ls->m_bCabinetLights[LIGHT_BASS_LEFT],
+							ls->m_bCabinetLights[LIGHT_BASS_RIGHT]);
+			return CABINET_SEXTET_COUNT;
+		}
+
+		// Packs the button lights for a controller into 6 printable sextets and
+		// adds them to a buffer
+		inline size_t AppendControllerLights(uint8_t * buffer, const LightsState * ls, GameController gc)
+		{
+			// Menu buttons
+			buffer[0] = PackArmoredSextet(
+							ls->m_bGameButtonLights[gc][GAME_BUTTON_MENULEFT],
+							ls->m_bGameButtonLights[gc][GAME_BUTTON_MENURIGHT],
+							ls->m_bGameButtonLights[gc][GAME_BUTTON_MENUUP],
+							ls->m_bGameButtonLights[gc][GAME_BUTTON_MENUDOWN],
+							ls->m_bGameButtonLights[gc][GAME_BUTTON_START],
+							ls->m_bGameButtonLights[gc][GAME_BUTTON_SELECT]);
+
+			// Other non-sensors
+			buffer[1] = PackArmoredSextet(
+							ls->m_bGameButtonLights[gc][GAME_BUTTON_BACK],
+							ls->m_bGameButtonLights[gc][GAME_BUTTON_COIN],
+							ls->m_bGameButtonLights[gc][GAME_BUTTON_OPERATOR],
+							ls->m_bGameButtonLights[gc][GAME_BUTTON_EFFECT_UP],
+							ls->m_bGameButtonLights[gc][GAME_BUTTON_EFFECT_DOWN],
+							false);
+
+			// Sensors
+			buffer[2] = PackArmoredSextet(
+							ls->m_bGameButtonLights[gc][GAME_BUTTON_CUSTOM_01],
+							ls->m_bGameButtonLights[gc][GAME_BUTTON_CUSTOM_02],
+							ls->m_bGameButtonLights[gc][GAME_BUTTON_CUSTOM_03],
+							ls->m_bGameButtonLights[gc][GAME_BUTTON_CUSTOM_04],
+							ls->m_bGameButtonLights[gc][GAME_BUTTON_CUSTOM_05],
+							ls->m_bGameButtonLights[gc][GAME_BUTTON_CUSTOM_06]);
+			buffer[3] = PackArmoredSextet(
+							ls->m_bGameButtonLights[gc][GAME_BUTTON_CUSTOM_07],
+							ls->m_bGameButtonLights[gc][GAME_BUTTON_CUSTOM_08],
+							ls->m_bGameButtonLights[gc][GAME_BUTTON_CUSTOM_09],
+							ls->m_bGameButtonLights[gc][GAME_BUTTON_CUSTOM_10],
+							ls->m_bGameButtonLights[gc][GAME_BUTTON_CUSTOM_11],
+							ls->m_bGameButtonLights[gc][GAME_BUTTON_CUSTOM_12]);
+			buffer[4] = PackArmoredSextet(
+							ls->m_bGameButtonLights[gc][GAME_BUTTON_CUSTOM_13],
+							ls->m_bGameButtonLights[gc][GAME_BUTTON_CUSTOM_14],
+							ls->m_bGameButtonLights[gc][GAME_BUTTON_CUSTOM_15],
+							ls->m_bGameButtonLights[gc][GAME_BUTTON_CUSTOM_16],
+							ls->m_bGameButtonLights[gc][GAME_BUTTON_CUSTOM_17],
+							ls->m_bGameButtonLights[gc][GAME_BUTTON_CUSTOM_18]);
+			buffer[5] = PackArmoredSextet(
+							ls->m_bGameButtonLights[gc][GAME_BUTTON_CUSTOM_19],
+							false,
+							false,
+							false,
+							false,
+							false);
+
+			return CONTROLLER_SEXTET_COUNT;
+		}
+
+		inline size_t AppendAllLights(uint8_t * buffer, const LightsState* ls)
+		{
+			size_t index = 0;
+
+			index += AppendCabinetLights(&(buffer[index]), ls);
+
+			FOREACH_ENUM(GameController, gc) {
+				index += AppendControllerLights(&(buffer[index]), ls, gc);
+			}
+
+			return index;
+		}
+
+		RString BytesToPacket(const void * buffer, size_t sizeInBytes)
+		{
+			const char * charBuffer = (const char *) buffer;
+			RString dest = RString(sizeInBytes, ApplyArmor(0));
+
+			for(size_t i = 0; i < sizeInBytes; ++i) {
+				dest[i] = ApplyArmor(charBuffer[i]);
+			}
+			
+			return RString(charBuffer, sizeInBytes);
+		}
+
+		inline bool BuffersEqualAsSextets(const char * a, size_t aLength, const char * b, size_t bLength)
+		{
+			const char * sbuf = a;
+			const char * lbuf = b;
+			size_t slen = aLength;
+			size_t llen = bLength;
+
+			if(slen >= llen) {
+				// slen must be no longer than llen.
+				// Swap the buffers and lengths before comparing.
+				const char * tmpbuf;
+				size_t tmplen;
+
+				SWAP_VIA(tmpbuf, sbuf, lbuf);
+				SWAP_VIA(tmplen, slen, llen);
+			}
+
+
+			size_t i = 0;
+
+			// Compare the existing portions
+			while(i < slen) {
+				if(!SEXTET_PARTS_EQUAL(sbuf[i], lbuf[i])) {
+					return false;
+				}
+				++i;
+			}
+
+			// If one buffer is longer, pretend the shorter buffer has
+			// infinite trailing zeros
+			while(i < llen) {
+				if(!SEXTET_PART_EQUALS_ZERO(lbuf[i])) {
+					return false;
+				}
+				++i;
+			}
+
+			return true;
+		}
+}
+
+namespace Sextets
+{
+	namespace Data
+	{
+		RString CleanPacketCopy(const RString& str)
+		{
+			size_t left = 0;
+			size_t right;
+			size_t end = IndexOfTrimmableNewlines(str);
+
+			// Find first valid byte
+			while(left < end) {
+				if(IsValidSextetByte(str[left])) {
+					break;
+				}
+				++left;
+			}
+
+			if(left > 0) {
+				LOG->Trace("CleanPacketCopy skipped %u leading excess byte(s)", (unsigned)left);
+			}
+
+			// Find first invalid byte after that
+			right = left;
+			while(right < end) {
+				if(!IsValidSextetByte(str[right])) {
+					break;
+				}
+				++right;
+			}
+
+			if(right < end) {
+				LOG->Trace("CleanPacketCopy truncated after %u byte(s); stopped at non-sextet char 0x%02x", (unsigned)right, (unsigned)(str[right]));
+			}
+
+			return str.substr(left, right - left);
+		}
+
+		RString XorPacketsCopy(const RString& a, const RString& b)
+		{
+			RString dest;
+			XorPackets(dest, a, b);
+			return dest;
+		}
+
+#define BIT_IN_BYTE_BUFFER(buffer, byteIndex, subBitIndex) (buffer[byteIndex] & (1 << subBitIndex))
+
+		void ProcessPacketChanges(const RString& statePacket, const RString& changedPacket, size_t numberOfStateBits, void * context, void updateButton(void * context, size_t index, bool value))
+		{
+			RString fallbackStatePacket;
+
+			// The max number of bytes numberOfStateBits covers or the size
+			// of the changes packet, whichever is smaller
+			size_t bufferSize = min(
+					NUMBER_OF_SEXTETS_FOR_BIT_COUNT(numberOfStateBits),
+					changedPacket.length());
+
+			// If the state packet is smaller than the range we wish to
+			// scan, pad out the state with zeroed sextets.
+			const RString * sp;
+			if(statePacket.length() < bufferSize) {
+				fallbackStatePacket = statePacket;
+				fallbackStatePacket.resize(bufferSize, ApplyArmor(0));
+				sp = &fallbackStatePacket;
+			}
+			else {
+				sp = &statePacket;
+			}
+
+			for(size_t byteIndex = 0; byteIndex < bufferSize; ++byteIndex) {
+				for(size_t subBitIndex = 0; subBitIndex < 6; ++subBitIndex) {
+					size_t stateBitIndex = (byteIndex * 6) + subBitIndex;
+					if(stateBitIndex < numberOfStateBits) {
+						if(BIT_IN_BYTE_BUFFER(changedPacket, byteIndex, subBitIndex)) {
+							bool value = BIT_IN_BYTE_BUFFER((*sp), byteIndex, subBitIndex);
+							updateButton(context, stateBitIndex, value);
+						}
+					} else {
+						// numberOfStateBits reached
+						break;
+					}
+				}
+			}
+		}
+
+		RString GetLightsStateAsPacket(const LightsState* ls)
+		{
+			uint8_t buffer[FULL_SEXTET_COUNT];
+			size_t len = AppendAllLights(buffer, ls);
+			return BytesToPacket(buffer, len);
+		}
+
+		bool RStringSextetsEqual(const RString& a, const RString& b)
+		{
+			return BuffersEqualAsSextets(a.data(), a.length(), b.data(), b.length());
+		}
+	}
+}
+
+/*
+ * Copyright © 2016 Peter S. May
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to permit
+ * persons to whom the Software is furnished to do so, subject to the
+ * following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+ * NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+ * USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */

--- a/src/Sextets/Data.h
+++ b/src/Sextets/Data.h
@@ -1,0 +1,66 @@
+#ifndef Sextets_Data_h
+#define Sextets_Data_h
+
+#include "global.h"
+
+// Needed for GetLightsStateAsPacket
+struct LightsState;
+
+namespace Sextets
+{
+	namespace Data
+	{
+		// Retrieves the first span of valid sextet characters
+		// (`IsValidSextetByte()`) within the string. All characters before
+		// the first valid character, and all characters starting with the
+		// first invalid character after the first valid character, are
+		// discarded.
+		RString CleanPacketCopy(const RString& str);
+
+		// Performs XOR on a pair of packets in RString form, re-armoring
+		// the result.
+		// If either packet is shorter than the other, the shorter packet is
+		// extended 
+		RString XorPacketsCopy(const RString& a, const RString& b);
+
+		// Examines the bits that have changed in a state and calls a
+		// callback for each change.
+		void ProcessPacketChanges(const RString& statePacket, const RString& changedPacket, size_t numberOfStateBits, void * context, void updateButton(void * context, size_t index, bool value));
+
+		// Compares two RStrings and determines whether their contents would
+		// be equal as sextet packets. The top two bits of each character
+		// are discarded before comparing, but no excess characters are
+		// trimmed. If one string is longer than the other, they are
+		// compared as if both had infinite trailing zeros.
+		bool RStringSextetsEqual(const RString& a, const RString& b);
+
+		// Retrieves a sextet packet containing the information from a
+		// LightsState.
+		RString GetLightsStateAsPacket(const LightsState* ls);
+	}
+}
+
+#endif
+
+/*
+ * Copyright © 2016 Peter S. May
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to permit
+ * persons to whom the Software is furnished to do so, subject to the
+ * following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+ * NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+ * USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */

--- a/src/Sextets/IO/EzSocketsPacketReader.cpp
+++ b/src/Sextets/IO/EzSocketsPacketReader.cpp
@@ -1,0 +1,220 @@
+
+#include "Sextets/IO/EzSocketsPacketReader.h"
+
+#if !defined(WITHOUT_NETWORKING)
+
+#include "Sextets/PacketBuffer.h"
+#include "ezsockets.h"
+#include "RageLog.h"
+
+namespace
+{
+	EzSockets * OpenSocket(const RString& host, unsigned short port)
+	{
+		EzSockets * sock = new EzSockets;
+		sock->close();
+		sock->create();
+		sock->blocking = false;
+
+		if(!sock->connect(host, port)) {
+			delete sock;
+			return NULL;
+		}
+
+		return sock;
+	}
+
+	static const unsigned int TIMEOUT_MS = 1000;
+}
+
+namespace
+{
+	using namespace Sextets;
+	using namespace Sextets::IO;
+
+	class Impl: public EzSocketsPacketReader
+	{
+	private:
+		// This buffer's size isn't critical since it is only used to
+		// receive data from C APIs. The resulting data is copied
+		// directly into a PacketBuffer; which will simply be extended
+		// as needed.
+		static const size_t BUFFER_SIZE = 64;
+		char buffer[BUFFER_SIZE];
+		PacketBuffer * const pb;
+
+		EzSockets * sock;
+
+		inline bool shouldReadSocket()
+		{
+			if(sock == NULL) {
+				LOG->Warn(
+					"Problem with socket: Socket reference is NULL (socket "
+					"may already have been disposed)");
+				return false;
+			} else if(sock->state == EzSockets::skDISCONNECTED) {
+				LOG->Warn("Problem with socket: Socket is disconnected");
+				return false;
+			} else if(sock->IsError()) {
+				LOG->Warn("Problem with socket: Socket has error status");
+				return false;
+			}
+			return true;
+		}
+
+	public:
+		Impl(const RString& host, unsigned short port)
+			: pb(PacketBuffer::Create())
+		{
+			LOG->Info(
+				"Sextets packet reader opening EzSockets connection to "
+				"'%s:%u' for input", host.c_str(), (unsigned)port);
+
+			sock = OpenSocket(host, port);
+
+			if(sock == NULL) {
+				LOG->Warn(
+					"Sextets packet reader could not open EzSockets "
+					"connection to '%s:%u' for input",
+					host.c_str(), (unsigned)port);
+			}
+		}
+
+		bool HasSocket()
+		{
+			return (sock != NULL);
+		}
+
+		void Close()
+		{
+			pb->DiscardUnfinished();
+			if(sock != NULL) {
+				LOG->Info("Sextets packet reader closing EzSockets connection");
+				sock->close();
+				delete sock;
+				sock = NULL;
+			}
+		}
+
+		void CloseDueToSocketProblem()
+		{
+			LOG->Warn("EzSocketsPacketReader: Closing due to socket problem");
+			Close();
+		}
+
+		~Impl()
+		{
+			Close();
+			delete pb;
+		}
+
+		virtual bool IsReady()
+		{
+			return shouldReadSocket() || pb->HasPacket();
+		}
+
+		virtual bool ReadPacket(Packet& packet)
+		{
+			// Ensure there isn't already a line in the packet buffer.
+			// (Even if this object has been closed, there may still be
+			// leftover unused data in the packet buffer.)
+			if(pb->GetPacket(packet)) {
+				// Got a waiting line from the packet buffer
+				return true;
+			}
+
+			// No complete line from buffer yet. Can we read more?
+			if(!shouldReadSocket()) {
+				// EOF or unrecoverable error.
+				CloseDueToSocketProblem();
+				return false;
+			}
+
+			// Try reading more.
+
+			// sock->DataAvailable() and sock->ReadData() combine
+			// here as a "slightly blocking" read. If there is no
+			// data, it will wait up to timeout ms for data to come
+			// in. If any data has been received, it is then read.
+			// If no data has been received, the read length is 0.
+			// Therefore, this ReadPacket() implementation returns
+			// in a finite (and small) amount of time.
+			size_t readLen = sock->DataAvailable(TIMEOUT_MS) ?
+							 sock->ReadData(buffer, BUFFER_SIZE) :
+							 0;
+
+			if(readLen == 0) {
+				// Nothing read. If the socket is now no longer OK, close.
+				// Otherwise, this has been simply an empty read.
+
+				if(!shouldReadSocket()) {
+					// EOF or unrecoverable error.
+					CloseDueToSocketProblem();
+					return false;
+				}
+
+				// No new data, but socket still healthy.
+				packet.Clear();
+				return true;
+			} else {
+				// Nonzero read; add to the packet buffer.
+				pb->Add(buffer, readLen);
+
+				// Now, see if a packet became available due to this read.
+				if(pb->GetPacket(packet)) {
+					// Retrieved a waiting line from the packet buffer.
+					return true;
+				} else {
+					// No full line from buffer, but let the caller know
+					// that there might still be one later.
+					packet.Clear();
+					return true;
+				}
+			}
+		}
+	};
+}
+
+
+namespace Sextets
+{
+	namespace IO
+	{
+		EzSocketsPacketReader* EzSocketsPacketReader::Create(const RString& host, unsigned short port)
+		{
+			Impl * obj = new Impl(host, port);
+			if(!obj->HasSocket()) {
+				delete obj;
+				return NULL;
+			}
+			return obj;
+		}
+
+		EzSocketsPacketReader::~EzSocketsPacketReader() {}
+	}
+}
+
+#endif // !defined(WITHOUT_NETWORKING)
+
+/*
+ * Copyright © 2016 Peter S. May
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to permit
+ * persons to whom the Software is furnished to do so, subject to the
+ * following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+ * NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+ * USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */

--- a/src/Sextets/IO/EzSocketsPacketReader.h
+++ b/src/Sextets/IO/EzSocketsPacketReader.h
@@ -1,45 +1,31 @@
-#ifndef LightsDriver_SextetStream_H
-#define LightsDriver_SextetStream_H
+#ifndef Sextets_IO_EzSocketsPacketReader_h
+#define Sextets_IO_EzSocketsPacketReader_h
+
+#include "global.h"
+#if !defined(WITHOUT_NETWORKING)
+
+#include "Sextets/IO/PacketReader.h"
+
+namespace Sextets
+{
+	namespace IO
+	{
+		// PacketReader implementation using ezsockets
+		class EzSocketsPacketReader : public PacketReader
+		{
+			public:
+				virtual ~EzSocketsPacketReader();
+				static EzSocketsPacketReader* Create(const RString& host, unsigned short port);
+		};
+	}
+}
+
+#endif // !defined(WITHOUT_NETWORKING)
+
+#endif
 
 /*
- * `LightsDriver_SextetStream` (abstract): Streams the light data (in
- * ASCII-safe sextets) to some output stream.
- *
- * *   `LightsDriver_SextetStreamToFile`: Streams the light data to an
- *     output file.
- *     *   The specified file may be a named pipe (Windows)/named fifo
- *         (Linux, others). This makes it possible to implement an
- *         out-of-process light controller without touching the StepMania
- *         source and without using C++. See the included notes for
- *         details.
- */
-
-#include "LightsDriver.h"
-#include "RageFile.h"
-
-class LightsDriver_SextetStream : public LightsDriver
-{
-public:
-	LightsDriver_SextetStream();
-	virtual ~LightsDriver_SextetStream();
-	virtual void Set(const LightsState *ls);
-
-public:
-	class Impl;
-protected:
-	Impl * _impl;
-};
-
-class LightsDriver_SextetStreamToFile : public LightsDriver_SextetStream
-{
-public:
-	LightsDriver_SextetStreamToFile();
-};
-
-#endif // H
-
-/*
- * Copyright © 2014-2016 Peter S. May
+ * Copyright © 2016 Peter S. May
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the

--- a/src/Sextets/IO/NoopPacketWriter.cpp
+++ b/src/Sextets/IO/NoopPacketWriter.cpp
@@ -1,42 +1,31 @@
-#ifndef LightsDriver_SextetStream_H
-#define LightsDriver_SextetStream_H
 
-/*
- * `LightsDriver_SextetStream` (abstract): Streams the light data (in
- * ASCII-safe sextets) to some output stream.
- *
- * *   `LightsDriver_SextetStreamToFile`: Streams the light data to an
- *     output file.
- *     *   The specified file may be a named pipe (Windows)/named fifo
- *         (Linux, others). This makes it possible to implement an
- *         out-of-process light controller without touching the StepMania
- *         source and without using C++. See the included notes for
- *         details.
- */
+#include "Sextets/IO/NoopPacketWriter.h"
+#include "RageLog.h"
 
-#include "LightsDriver.h"
-#include "RageFile.h"
-
-class LightsDriver_SextetStream : public LightsDriver
+namespace Sextets
 {
-public:
-	LightsDriver_SextetStream();
-	virtual ~LightsDriver_SextetStream();
-	virtual void Set(const LightsState *ls);
-
-public:
-	class Impl;
-protected:
-	Impl * _impl;
-};
-
-class LightsDriver_SextetStreamToFile : public LightsDriver_SextetStream
-{
-public:
-	LightsDriver_SextetStreamToFile();
-};
-
-#endif // H
+	namespace IO
+	{
+		NoopPacketWriter::NoopPacketWriter()
+		{
+			LOG->Info("NoopPacketWriter ctor");
+			LOG->Flush();
+		}
+		NoopPacketWriter::~NoopPacketWriter()
+		{
+			LOG->Info("NoopPacketWriter dtor");
+			LOG->Flush();
+		}
+		bool NoopPacketWriter::IsReady()
+		{
+			return false;
+		}
+		bool NoopPacketWriter::WritePacket(const Packet& packet)
+		{
+			return false;
+		}
+	}
+}
 
 /*
  * Copyright © 2014-2016 Peter S. May

--- a/src/Sextets/IO/NoopPacketWriter.h
+++ b/src/Sextets/IO/NoopPacketWriter.h
@@ -1,42 +1,24 @@
-#ifndef LightsDriver_SextetStream_H
-#define LightsDriver_SextetStream_H
+#ifndef Sextets_IO_NoopPacketWriter_h
+#define Sextets_IO_NoopPacketWriter_h
 
-/*
- * `LightsDriver_SextetStream` (abstract): Streams the light data (in
- * ASCII-safe sextets) to some output stream.
- *
- * *   `LightsDriver_SextetStreamToFile`: Streams the light data to an
- *     output file.
- *     *   The specified file may be a named pipe (Windows)/named fifo
- *         (Linux, others). This makes it possible to implement an
- *         out-of-process light controller without touching the StepMania
- *         source and without using C++. See the included notes for
- *         details.
- */
+#include "Sextets/IO/PacketWriter.h"
 
-#include "LightsDriver.h"
-#include "RageFile.h"
-
-class LightsDriver_SextetStream : public LightsDriver
+namespace Sextets
 {
-public:
-	LightsDriver_SextetStream();
-	virtual ~LightsDriver_SextetStream();
-	virtual void Set(const LightsState *ls);
+	namespace IO
+	{
+		class NoopPacketWriter : public PacketWriter
+		{
+		public:
+			NoopPacketWriter();
+			virtual ~NoopPacketWriter();
+			virtual bool IsReady();
+			virtual bool WritePacket(const Packet& packet);
+		};
+	}
+}
 
-public:
-	class Impl;
-protected:
-	Impl * _impl;
-};
-
-class LightsDriver_SextetStreamToFile : public LightsDriver_SextetStream
-{
-public:
-	LightsDriver_SextetStreamToFile();
-};
-
-#endif // H
+#endif
 
 /*
  * Copyright © 2014-2016 Peter S. May

--- a/src/Sextets/IO/PacketReader.h
+++ b/src/Sextets/IO/PacketReader.h
@@ -1,0 +1,79 @@
+#ifndef Sextets_IO_PacketReader_h
+#define Sextets_IO_PacketReader_h
+
+#include "global.h"
+#include "Sextets/Packet.h"
+
+namespace Sextets
+{
+	namespace IO
+	{
+		// Interface for classes that implement the PacketReader protocol
+		// for Sextets.
+		class PacketReader
+		{
+			public:
+				virtual ~PacketReader() {}
+
+				// Returns true if this stream is currently in such a state
+				// that ReadPacket() will return a valid response. A false
+				// value may indicate that an underlying stream is closed or
+				// has encountered an unrecoverable error condition. Do not
+				// call ReadPacket() unless this returns true. Once false
+				// has been returned, this method will not return true for
+				// the same object.
+				virtual bool IsReady() = 0;
+
+				// Retrieves the next packet available from the stream.
+				//
+				// Returns true with packet set to a non-empty string if a
+				// whole packet is immediately available for read.
+				//
+				// Returns false with packet undefined if the stream can no
+				// longer be read due to EOF or an unrecoverable error
+				// condition.
+				//
+				// Returns true with packet set to "" if the stream is open
+				// but a non-blocking read has not read an entire packet
+				// yet.
+				//
+				// Whenever possible, this should be implemented on a
+				// non-blocking read. If this method blocks, the loop that
+				// checks continueInputThread may be paused indefinitely,
+				// which can cause the application to hang, especially while
+				// closing. To mitigate this effect, make sure the stream is
+				// never idle: have the far side of the connection repeat
+				// its most recent message at a small interval (for example,
+				// every second) in order to allow the check at least that
+				// often. Closing the far side of the connection will also
+				// end the blocking, but this is only really useful while
+				// closing.
+				virtual bool ReadPacket(Packet& packet) = 0;
+		};
+	}
+}
+
+#endif
+
+/*
+ * Copyright © 2016 Peter S. May
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to permit
+ * persons to whom the Software is furnished to do so, subject to the
+ * following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+ * NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+ * USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */

--- a/src/Sextets/IO/PacketReaderEventGenerator.cpp
+++ b/src/Sextets/IO/PacketReaderEventGenerator.cpp
@@ -1,0 +1,182 @@
+
+#include "Sextets/IO/PacketReaderEventGenerator.h"
+#include "RageThreads.h"
+#include "RageLog.h"
+
+namespace
+{
+	using namespace Sextets;
+	using namespace Sextets::IO;
+
+	class PacketReaderEventGeneratorImpl : public PacketReaderEventGenerator
+	{
+		private:
+			PacketReader * packetReader;
+			void * context;
+			PacketReaderEventGenerator::PacketReaderEventCallback * onReadPacket;
+			bool continueThread;
+			volatile bool threadStarted;
+			volatile bool threadEnded;
+			RageThread thread;
+
+			inline void CallOnReadPacket(const Packet& packet)
+			{
+				onReadPacket(context, packet);
+			}
+
+			inline void CreateThread()
+			{
+				continueThread = true;
+				thread.SetName("Sextets PacketReaderEventGenerator thread");
+				thread.Create(StartThread, this);
+			}
+
+			static int StartThread(void * p)
+			{
+				((PacketReaderEventGeneratorImpl *) p)->RunThread();
+				return 0;
+			}
+
+			void Invalidate()
+			{
+				LOG->Trace("Disposing Sextets PacketReaderEventGenerator");
+
+				if(packetReader != NULL) {
+					LOG->Trace("Deleting packet reader");
+					delete packetReader;
+					packetReader = NULL;
+				}
+
+				context = NULL;
+
+				onReadPacket = NULL;
+
+			}
+
+			void RunThread()
+			{
+				threadStarted = true;
+
+				LOG->Info("Sextets PacketReaderEventGenerator thread started");
+				
+				while(continueThread) {
+					Packet packet;
+
+					LOG->Trace("Reading packet");
+
+					if(packetReader->ReadPacket(packet)) {
+						LOG->Trace("Got packet: '%s'", packet.GetLine().c_str());
+						if(packet.IsEmpty()) {
+							LOG->Trace("Packet was blank; not calling callback");
+							LOG->Trace("Read packet length: %u", (unsigned) packet.SextetCount());
+						}
+						else {
+							LOG->Trace("Calling callback");
+							CallOnReadPacket(packet);
+						}
+					}
+					else {
+						// Error or EOF
+						LOG->Info("Sextets PacketReader input ended");
+						continueThread = false;
+					}
+				}
+
+				LOG->Info("Sextets PacketReaderEventGenerator thread ending");
+				Invalidate();
+
+				threadEnded = true;
+			}
+
+
+		public:
+			PacketReaderEventGeneratorImpl(
+				PacketReader * packetReader,
+				void * context,
+				PacketReaderEventGenerator::PacketReaderEventCallback *	onReadPacket)
+			{
+				// Checks already performed in Create().
+				this->packetReader = packetReader;
+				this->context = context;
+				this->onReadPacket = onReadPacket;
+				continueThread = false;
+				threadStarted = false;
+				threadEnded = false;
+				CreateThread();
+			}
+
+			~PacketReaderEventGeneratorImpl()
+			{
+				if(thread.IsCreated()) {
+					continueThread = false;
+					LOG->Trace("Event generator waiting for thread to end");
+					thread.Wait();
+				}
+				Invalidate();
+			}
+
+			bool HasStarted()
+			{
+				return threadStarted;
+			}
+
+			bool HasEnded()
+			{
+				return threadEnded;
+			}
+
+			void RequestStop()
+			{
+				continueThread = false;
+			}
+	};
+}
+
+namespace Sextets
+{
+	namespace IO
+	{
+		PacketReaderEventGenerator * PacketReaderEventGenerator::Create(
+				PacketReader * packetReader,
+				void * context,
+				PacketReaderEventGenerator::PacketReaderEventCallback * onReadPacket)
+		{
+
+			if(packetReader == NULL) {
+				LOG->Warn("Cannot create event generator: packetReader cannot be NULL.");
+				return NULL;
+			}
+			else if(onReadPacket == NULL) {
+				LOG->Warn("Cannot create event generator: onReadPacket cannot be NULL. Destroying packet reader.");
+				delete packetReader;
+				return NULL;
+			}
+			else {
+				return new PacketReaderEventGeneratorImpl(packetReader, context, onReadPacket);
+			}
+		}
+	}
+}
+
+/*
+ * Copyright © 2016 Peter S. May
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to permit
+ * persons to whom the Software is furnished to do so, subject to the
+ * following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+ * NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+ * USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */

--- a/src/Sextets/IO/PacketReaderEventGenerator.h
+++ b/src/Sextets/IO/PacketReaderEventGenerator.h
@@ -1,0 +1,68 @@
+#ifndef Sextets_IO_PacketReaderEventGenerator_h
+#define Sextets_IO_PacketReaderEventGenerator_h
+
+#include "Sextets/IO/PacketReader.h"
+
+namespace Sextets
+{
+	namespace IO
+	{
+		// Class that spawns a thread to read from a PacketReader and relay
+		// the results to a callback. The given PacketReader is destroyed when
+		// this object is destroyed.
+		class PacketReaderEventGenerator
+		{
+			public:
+				typedef void PacketReaderEventCallback(void * context, const Packet& packet);
+
+				// Creates a new PacketReaderEventGenerator with the given
+				// parameters. packetReader and onChange must be specified;
+				// otherwise, NULL is returned. If packetReader is specified
+				// but onChange is NULL, packetReader is deleted before this
+				// returns NULL.
+				static PacketReaderEventGenerator * Create(
+						PacketReader * packetReader,
+						void * context,
+						PacketReaderEventCallback * onChange);
+
+				// Returns false if the thread has not started yet, or true
+				// if it did start. If HasEnded() is true, then this must be
+				// true also.
+				virtual bool HasStarted() = 0;
+
+				// Returns true if the thread has already started and ended.
+				virtual bool HasEnded() = 0;
+
+				// If the thread is currently running, calling this will
+				// cause the read loop to stop after the current iteration.
+				// If the thread is not yet started, having called this will
+				// prevent the loop from starting its first iteration.
+				virtual void RequestStop() = 0;
+		};
+	}
+}
+
+#endif
+
+/*
+ * Copyright © 2016 Peter S. May
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to permit
+ * persons to whom the Software is furnished to do so, subject to the
+ * following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+ * NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+ * USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */

--- a/src/Sextets/IO/PacketWriter.h
+++ b/src/Sextets/IO/PacketWriter.h
@@ -1,42 +1,35 @@
-#ifndef LightsDriver_SextetStream_H
-#define LightsDriver_SextetStream_H
+#ifndef Sextets_IO_PacketWriter_h
+#define Sextets_IO_PacketWriter_h
 
-/*
- * `LightsDriver_SextetStream` (abstract): Streams the light data (in
- * ASCII-safe sextets) to some output stream.
- *
- * *   `LightsDriver_SextetStreamToFile`: Streams the light data to an
- *     output file.
- *     *   The specified file may be a named pipe (Windows)/named fifo
- *         (Linux, others). This makes it possible to implement an
- *         out-of-process light controller without touching the StepMania
- *         source and without using C++. See the included notes for
- *         details.
- */
+#include "global.h"
+#include "Sextets/Packet.h"
 
-#include "LightsDriver.h"
-#include "RageFile.h"
-
-class LightsDriver_SextetStream : public LightsDriver
+// Sextets/IO/PacketWriter.h
+namespace Sextets
 {
-public:
-	LightsDriver_SextetStream();
-	virtual ~LightsDriver_SextetStream();
-	virtual void Set(const LightsState *ls);
+	namespace IO
+	{
+		class PacketWriter
+		{
+		public:
+			PacketWriter()
+			{
+			}
+			virtual ~PacketWriter()
+			{
+			}
 
-public:
-	class Impl;
-protected:
-	Impl * _impl;
-};
+			// Returns whether this stream can currently write.
+			virtual bool IsReady() = 0;
 
-class LightsDriver_SextetStreamToFile : public LightsDriver_SextetStream
-{
-public:
-	LightsDriver_SextetStreamToFile();
-};
+			// Writes the provided packet (and generally also an LF or CRLF,
+			// depending on the intended receiver) to this packet writer.
+			virtual bool WritePacket(const Packet& packet) = 0;
+		};
+	}
+}
 
-#endif // H
+#endif
 
 /*
  * Copyright © 2014-2016 Peter S. May

--- a/src/Sextets/IO/RageFilePacketWriter.cpp
+++ b/src/Sextets/IO/RageFilePacketWriter.cpp
@@ -1,0 +1,97 @@
+
+#include "Sextets/IO/RageFilePacketWriter.h"
+#include "RageLog.h"
+#include "RageUtil.h"
+
+namespace
+{
+	using namespace Sextets;
+	using namespace Sextets::IO;
+
+	class PwImpl : public RageFilePacketWriter
+	{
+	private:
+		RageFile * out;
+
+	public:
+		PwImpl(RageFile * stream)
+		{
+			out = stream;
+		}
+
+		~PwImpl()
+		{
+			if(out != NULL) {
+				out->Flush();
+				out->Close();
+				SAFE_DELETE(out);
+			}
+		}
+
+		bool IsReady()
+		{
+			return out != NULL;
+		}
+
+		bool WritePacket(const Packet& packet)
+		{
+			if(out != NULL) {
+				RString line = packet.GetLine();
+				out->PutLine(line);
+				out->Flush();
+			}
+		}
+	};
+}
+
+namespace Sextets
+{
+	namespace IO
+	{
+		RageFilePacketWriter* RageFilePacketWriter::Create(const RString& filename)
+		{
+			RageFile * file = new RageFile;
+
+			if(!file->Open(filename, RageFile::WRITE|RageFile::STREAMED)) {
+				LOG->Warn("Error opening file '%s' for output: %s", filename.c_str(), file->GetError().c_str());
+				SAFE_DELETE(file);
+				return NULL;
+			}
+
+			return RageFilePacketWriter::Create(file);
+		}
+
+		RageFilePacketWriter* RageFilePacketWriter::Create(RageFile * stream)
+		{
+			if(stream == NULL) {
+				return NULL;
+			}
+			return new PwImpl(stream);
+		}
+
+		RageFilePacketWriter::~RageFilePacketWriter() {}
+	}
+}
+
+/*
+ * Copyright © 2014-2016 Peter S. May
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to permit
+ * persons to whom the Software is furnished to do so, subject to the
+ * following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+ * NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+ * USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */

--- a/src/Sextets/IO/RageFilePacketWriter.cpp
+++ b/src/Sextets/IO/RageFilePacketWriter.cpp
@@ -39,7 +39,10 @@ namespace
 				RString line = packet.GetLine();
 				out->PutLine(line);
 				out->Flush();
+
+				return true;
 			}
+			return false;
 		}
 	};
 }

--- a/src/Sextets/IO/RageFilePacketWriter.h
+++ b/src/Sextets/IO/RageFilePacketWriter.h
@@ -1,42 +1,35 @@
-#ifndef LightsDriver_SextetStream_H
-#define LightsDriver_SextetStream_H
+#ifndef Sextets_IO_RageFilePacketWriter_h
+#define Sextets_IO_RageFilePacketWriter_h
 
-/*
- * `LightsDriver_SextetStream` (abstract): Streams the light data (in
- * ASCII-safe sextets) to some output stream.
- *
- * *   `LightsDriver_SextetStreamToFile`: Streams the light data to an
- *     output file.
- *     *   The specified file may be a named pipe (Windows)/named fifo
- *         (Linux, others). This makes it possible to implement an
- *         out-of-process light controller without touching the StepMania
- *         source and without using C++. See the included notes for
- *         details.
- */
-
-#include "LightsDriver.h"
+#include "Sextets/IO/PacketWriter.h"
 #include "RageFile.h"
 
-class LightsDriver_SextetStream : public LightsDriver
+namespace Sextets
 {
-public:
-	LightsDriver_SextetStream();
-	virtual ~LightsDriver_SextetStream();
-	virtual void Set(const LightsState *ls);
+	namespace IO
+	{
+		class RageFilePacketWriter : public PacketWriter
+		{
+		public:
+			virtual ~RageFilePacketWriter();
 
-public:
-	class Impl;
-protected:
-	Impl * _impl;
-};
+			// Note: If there is a problem opening the file, returns
+			// NULL.
+			static RageFilePacketWriter * Create(const RString& filename);
 
-class LightsDriver_SextetStreamToFile : public LightsDriver_SextetStream
-{
-public:
-	LightsDriver_SextetStreamToFile();
-};
+			// Note: If `stream` is `NULL`, returns `NULL`.
+			// When using this method, the RageFile should have been
+			// opened with the modes
+			// `RageFile::WRITE|RageFile::STREAMED` set. (This is not
+			// checked.) Additionally, the provided RageFile will be
+			// properly closed, flushed, and deleted when this packet
+			// writer is deleted.
+			static RageFilePacketWriter * Create(RageFile * stream);
+		};
+	}
+}
 
-#endif // H
+#endif
 
 /*
  * Copyright © 2014-2016 Peter S. May

--- a/src/Sextets/IO/SelectFilePacketReader.cpp
+++ b/src/Sextets/IO/SelectFilePacketReader.cpp
@@ -1,0 +1,252 @@
+
+#include "Sextets/IO/SelectFilePacketReader.h"
+
+// TODO: Determine which of these are actually necessary
+#include <sys/time.h>
+#include <sys/types.h>
+#include <sys/select.h>
+#include <cerrno>
+#include <cstdlib>
+#include <cstdio>
+#include <fcntl.h>
+#include <unistd.h>
+
+#include "Sextets/PacketBuffer.h"
+#include "RageLog.h"
+
+namespace
+{
+	int OpenFd(const RString& filename)
+	{
+		int fd = open(filename.c_str(), O_RDONLY | O_NONBLOCK);
+
+		if(fd < 0) {
+			return -1;
+		}
+
+		return fd;
+	}
+
+	// Timeout in ms
+	static const size_t timeout = 1000;
+}
+
+namespace
+{
+	using namespace Sextets;
+	using namespace Sextets::IO;
+
+	class Impl: public SelectFilePacketReader
+	{
+	private:
+		// This buffer's size isn't critical since it is only used to
+		// receive data from C APIs. The resulting data is copied
+		// directly into a PacketBuffer; which will simply be extended
+		// as needed.
+		static const size_t BUFFER_SIZE = 64;
+		char buffer[BUFFER_SIZE];
+		PacketBuffer * const pb;
+
+		int fd;
+		bool seenEof;
+		bool seenError;
+
+		inline bool shouldRead()
+		{
+			if(seenEof) {
+				// EOF
+				return false;
+			}
+			else if(seenError) {
+				LOG->Warn(
+					"Problem with file: Stream experienced error");
+				return false;
+			}
+			else if(fd < 0) {
+				LOG->Warn(
+					"Problem with file: Stream is invalid or disposed");
+				return false;
+			}
+			return true;
+		}
+
+	public:
+		Impl(const RString& filename)
+			: pb(PacketBuffer::Create())
+		{
+			LOG->Info(
+				"Sextets packet select()/file reader opening stream from file '%s' for input", filename.c_str());
+
+			fd = OpenFd(filename);
+			seenEof = false;
+			seenError = false;
+
+			if(!HasStream()) {
+				LOG->Warn(
+					"Sextets packet select()/file reader could not open stream from file '%s' for input", filename.c_str());
+				return;
+			}
+		}
+
+		bool HasStream()
+		{
+			return fd >= 0;
+		}
+
+		void Close()
+		{
+			pb->DiscardUnfinished();
+			if(HasStream()) {
+				LOG->Info("Sextets packet select()/file reader closing stream");
+				close(fd); // This is close() with a lower-case c
+				fd = -1;
+			}
+		}
+
+		void CloseDueToStreamUnreadable()
+		{
+			LOG->Warn("SelectFilePacketReader: Closing because stream can no longer be read");
+			Close();
+		}
+
+		~Impl()
+		{
+			Close();
+			delete pb;
+		}
+
+		virtual bool IsReady()
+		{
+			return shouldRead() || pb->HasPacket();
+		}
+		
+		virtual bool ReadPacket(Packet& packet)
+		{
+			// Ensure there isn't already a line in the packet buffer.
+			// (Even if this object has been closed, there may still be
+			// leftover unused data in the packet buffer.)
+			if(pb->GetPacket(packet)) {
+				// Got a waiting line from the packet buffer
+				return true;
+			}
+
+			// No complete line from buffer yet. Can we read more?
+			if(!shouldRead()) {
+				// EOF or unrecoverable error.
+				CloseDueToStreamUnreadable();
+				return false;
+			}
+
+			// Try reading more.
+
+			// select() and read() on an O_NONBLOCK stream combine
+			// here as a "slightly blocking" read. If there is no
+			// data, it will wait up to timeout ms for data to come
+			// in. If any data has been received, it is then read.
+			// If no data has been received, the read length is 0.
+			// Therefore, this ReadPacket() implementation returns
+			// in a finite (and small) amount of time.
+			struct timeval timeoutval = { 0, timeout * 1000 };
+			fd_set set;
+			FD_ZERO(&set);
+			FD_SET(fd, &set);
+			int event_count = select(fd + 1, &set, NULL, NULL, &timeoutval);
+
+			size_t readLen = 0;
+
+			if(event_count == 0) {
+				// Timed out
+				readLen = 0;
+			}
+			else if(event_count < 0) {
+				// Select call error
+				LOG->Warn("Problem waiting for input on stream: %s", strerror(errno));
+				seenError = true;
+			}
+			else if(FD_ISSET(fd, &set)) {
+				// Change seen on our stream
+				ssize_t bytes = read(fd, buffer, BUFFER_SIZE);
+
+				if(bytes > 0) {
+					readLen = (size_t) bytes;
+				}
+				else if(bytes == 0) {
+					// EOF
+					seenEof = true;
+				}
+				else if((errno == EWOULDBLOCK) || (errno == EAGAIN)) {
+					// Temporarily no more to read
+					readLen = 0;
+				}
+				else {
+					LOG->Warn("Problem reading input on stream: %s", strerror(errno));
+					seenError = true;
+				}
+			}
+			else {
+				// Nothing to report
+				readLen = 0;
+			}
+
+			if(seenEof || seenError) {
+				CloseDueToStreamUnreadable();
+				return false;
+			}
+
+			if(readLen == 0) {
+				packet.Clear();
+			}
+			else {
+				// Nonzero read; add to the packet buffer.
+				pb->Add(buffer, readLen);
+
+				// Now, see if a packet became available due to this read.
+				if(!pb->GetPacket(packet)) {
+					// No full line from buffer, but let the caller know
+					// that there might still be one later.
+					packet.Clear();
+				}
+				// Otherwise, a new packet is in packet.
+			}
+
+			return true;
+		}
+	};
+}
+
+
+namespace Sextets
+{
+	namespace IO
+	{
+		SelectFilePacketReader* SelectFilePacketReader::Create(const RString& filename)
+		{
+			return new Impl(filename);
+		}
+		
+		SelectFilePacketReader::~SelectFilePacketReader() {}
+	}
+}
+
+/*
+ * Copyright © 2016 Peter S. May
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to permit
+ * persons to whom the Software is furnished to do so, subject to the
+ * following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+ * NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+ * USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */

--- a/src/Sextets/IO/SelectFilePacketReader.h
+++ b/src/Sextets/IO/SelectFilePacketReader.h
@@ -1,45 +1,32 @@
-#ifndef LightsDriver_SextetStream_H
-#define LightsDriver_SextetStream_H
+#ifndef Sextets_IO_SelectFilePacketReader_h
+#define Sextets_IO_SelectFilePacketReader_h
+
+#include "global.h"
+
+#if !defined(_WINDOWS)
+
+#include "Sextets/IO/PacketReader.h"
+
+namespace Sextets
+{
+	namespace IO
+	{
+		// PacketReader implementation using POSIX read() and select()
+		class SelectFilePacketReader : public PacketReader
+		{
+			public:
+				virtual ~SelectFilePacketReader();
+				static SelectFilePacketReader* Create(const RString& filename);
+		};
+	}
+}
+
+#endif // !defined(_WINDOWS)
+
+#endif
 
 /*
- * `LightsDriver_SextetStream` (abstract): Streams the light data (in
- * ASCII-safe sextets) to some output stream.
- *
- * *   `LightsDriver_SextetStreamToFile`: Streams the light data to an
- *     output file.
- *     *   The specified file may be a named pipe (Windows)/named fifo
- *         (Linux, others). This makes it possible to implement an
- *         out-of-process light controller without touching the StepMania
- *         source and without using C++. See the included notes for
- *         details.
- */
-
-#include "LightsDriver.h"
-#include "RageFile.h"
-
-class LightsDriver_SextetStream : public LightsDriver
-{
-public:
-	LightsDriver_SextetStream();
-	virtual ~LightsDriver_SextetStream();
-	virtual void Set(const LightsState *ls);
-
-public:
-	class Impl;
-protected:
-	Impl * _impl;
-};
-
-class LightsDriver_SextetStreamToFile : public LightsDriver_SextetStream
-{
-public:
-	LightsDriver_SextetStreamToFile();
-};
-
-#endif // H
-
-/*
- * Copyright © 2014-2016 Peter S. May
+ * Copyright © 2016 Peter S. May
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the

--- a/src/Sextets/IO/StdCFilePacketReader.cpp
+++ b/src/Sextets/IO/StdCFilePacketReader.cpp
@@ -1,0 +1,124 @@
+
+#include "Sextets/IO/StdCFilePacketReader.h"
+#include "RageLog.h"
+#include <cerrno>
+
+namespace
+{
+	using namespace Sextets;
+	using namespace Sextets::IO;
+
+	class Impl: public StdCFilePacketReader
+	{
+		private:
+			// The buffer size isn't critical; the RString will simply be
+			// extended until the packet is done.
+			static const size_t BUFFER_SIZE = 64;
+			char buffer[BUFFER_SIZE];
+		protected:
+			std::FILE * file;
+
+		public:
+			Impl(std::FILE * file)
+			{
+				LOG->Info("Starting Sextets packet reader from open std::FILE");
+				this->file = file;
+			}
+
+			Impl(const RString& filename)
+			{
+				LOG->Info("Starting Sextets packet reader from std::FILE with filename '%s'",
+					filename.c_str());
+				file = std::fopen(filename.c_str(), "rb");
+
+				if(file == NULL) {
+					LOG->Warn("Error opening file '%s' for input (cstdio): %s", filename.c_str(),
+						std::strerror(errno));
+				}
+				else {
+					LOG->Info("File opened");
+					// Disable buffering on the file
+					std::setbuf(file, NULL);
+				}
+			}
+
+			~Impl()
+			{
+				if(file != NULL) {
+					std::fclose(file);
+				}
+			}
+
+			virtual bool IsReady()
+			{
+				return file != NULL;
+			}
+
+			virtual bool ReadPacket(Packet& packet)
+			{
+				bool afterFirst = false;
+
+				if(file != NULL) {
+					RString line;
+
+					while(fgets(buffer, BUFFER_SIZE, file) != NULL) {
+						afterFirst = true;
+						line += buffer;
+						size_t lineLength = line.length();
+						if(lineLength > 0) {
+							int lastChar = line[lineLength - 1];
+							if(lastChar == 0xD || lastChar == 0xA) {
+								break;
+							}
+						}
+					}
+
+					packet.SetToLine(line);
+				}
+
+				return afterFirst;
+			}
+	};
+}
+
+namespace Sextets
+{
+	namespace IO
+	{
+		StdCFilePacketReader* StdCFilePacketReader::Create(std::FILE * file)
+		{
+			return new Impl(file);
+		}
+
+		StdCFilePacketReader* StdCFilePacketReader::Create(const RString& filename)
+		{
+			return new Impl(filename);
+		}
+		
+		StdCFilePacketReader::~StdCFilePacketReader() {}
+	}
+}
+
+
+/*
+ * Copyright © 2016 Peter S. May
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to permit
+ * persons to whom the Software is furnished to do so, subject to the
+ * following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+ * NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+ * USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */

--- a/src/Sextets/IO/StdCFilePacketReader.h
+++ b/src/Sextets/IO/StdCFilePacketReader.h
@@ -1,45 +1,28 @@
-#ifndef LightsDriver_SextetStream_H
-#define LightsDriver_SextetStream_H
+#ifndef Sextets_IO_StdCFilePacketReader_h
+#define Sextets_IO_StdCFilePacketReader_h
+
+#include "Sextets/IO/PacketReader.h"
+#include <cstdio>
+
+namespace Sextets
+{
+	namespace IO
+	{
+		// PacketReader implementation using std::FILE from <cstdio>
+		class StdCFilePacketReader : public PacketReader
+		{
+			public:
+				virtual ~StdCFilePacketReader();
+				static StdCFilePacketReader* Create(std::FILE * file);
+				static StdCFilePacketReader* Create(const RString& filename);
+		};
+	}
+}
+
+#endif
 
 /*
- * `LightsDriver_SextetStream` (abstract): Streams the light data (in
- * ASCII-safe sextets) to some output stream.
- *
- * *   `LightsDriver_SextetStreamToFile`: Streams the light data to an
- *     output file.
- *     *   The specified file may be a named pipe (Windows)/named fifo
- *         (Linux, others). This makes it possible to implement an
- *         out-of-process light controller without touching the StepMania
- *         source and without using C++. See the included notes for
- *         details.
- */
-
-#include "LightsDriver.h"
-#include "RageFile.h"
-
-class LightsDriver_SextetStream : public LightsDriver
-{
-public:
-	LightsDriver_SextetStream();
-	virtual ~LightsDriver_SextetStream();
-	virtual void Set(const LightsState *ls);
-
-public:
-	class Impl;
-protected:
-	Impl * _impl;
-};
-
-class LightsDriver_SextetStreamToFile : public LightsDriver_SextetStream
-{
-public:
-	LightsDriver_SextetStreamToFile();
-};
-
-#endif // H
-
-/*
- * Copyright © 2014-2016 Peter S. May
+ * Copyright © 2016 Peter S. May
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the

--- a/src/Sextets/Packet.cpp
+++ b/src/Sextets/Packet.cpp
@@ -440,7 +440,7 @@ namespace Sextets
 			}
 
 			RString bs;
-			for(size_t bi; bi < bits.size(); ++bi) {
+			for(size_t bi = 0; bi < bits.size(); ++bi) {
 				bs += (bits[bi] ? "1" : "0");
 			}
 

--- a/src/Sextets/Packet.cpp
+++ b/src/Sextets/Packet.cpp
@@ -484,7 +484,7 @@ namespace Sextets
 
 		bool Equals(const Packet& b) const
 		{
-			VectorsEqual(sextets, b._impl->sextets);
+			return VectorsEqual(sextets, b._impl->sextets);
 		}
 
 		void GetUntrimmedLine(RString& line)

--- a/src/Sextets/Packet.cpp
+++ b/src/Sextets/Packet.cpp
@@ -1,0 +1,701 @@
+
+#include "Sextets/Packet.h"
+#include "RageLog.h"
+#include "global.h"
+#include "LightsManager.h"
+
+#include <vector>
+
+#define PUSH(i) bits.push_back(bitArray[i])
+#define PUSH0() bits.push_back(false)
+
+typedef RString::value_type RChr;
+typedef std::vector<RChr> RVector;
+typedef Sextets::Packet::ProcessEventCallback ProcessEventCallback;
+
+namespace
+{
+	void RStringFromRVector(RString& result, size_t resultLeft, const RVector& source, size_t sourceLeft, size_t length);
+
+	inline size_t smax(size_t a, size_t b)
+	{
+		return (a > b) ? a : b;
+	}
+
+	inline size_t smin(size_t a, size_t b)
+	{
+		return (a < b) ? a : b;
+	}
+
+	inline size_t smin(size_t a, size_t b, size_t c)
+	{
+		return smin(smin(a, b), c);
+	}
+
+	inline RChr Armored(RChr x)
+	{
+		return ((x + 0x10) & 0x3F) + 0x30;
+	}
+
+	const RChr ARMORED_0 = Armored(0);
+
+	inline bool IsArmored(RChr x)
+	{
+		return (x >= 0x30) && (x <= 0x6F);
+	}
+
+	inline size_t FindCleanPacketLeft(const RString& line)
+	{
+		size_t left = 0;
+		size_t end = line.length();
+
+		while(left < end) {
+			if(IsArmored(line[left])) {
+				break;
+			}
+			++left;
+		}
+
+		return left;
+	}
+
+	inline size_t FindCleanPacketRight(const RString& line, size_t left)
+	{
+		size_t right = left;
+		size_t end = line.length();
+
+		while(right < end) {
+			if(!IsArmored(line[right])) {
+				break;
+			}
+			++right;
+		}
+
+		return right;
+	}
+
+	// Does a = a ^ b for entire RVectors.
+	inline void XorVectors(RVector& a, const RVector& b)
+	{
+		size_t alen = a.size();
+		size_t blen = b.size();
+
+		size_t len = smin(alen, blen);
+
+		// Only perform actual XOR on the common length.
+		for(size_t i = 0; i < len; ++i) {
+			a[i] = Armored(a[i] ^ b[i]);
+		}
+
+		// If this packet is shorter, the rest of the result is zero XOR b = b.
+		// So, the rest is copied directly from b.
+		if(alen < blen) {
+			a.reserve(blen);
+			for(size_t i = alen; i < blen; ++i) {
+				a.push_back(b[i]);
+			}
+		}
+
+		// If the packets are the same length, the XOR is already complete.
+		// If this packet is longer, the rest of the result is zero XOR this = this.
+		// Since this is the result, no copying is necessary.
+	}
+
+	inline void XorVectors(RVector& result, const RVector& a, const RVector& b)
+	{
+		// result will start as a copy of a or b, whichever is not shorter
+		// than the other, since a shorter destination involves more work.
+		if(a.size() > b.size()) {
+			result = a;
+			XorVectors(result, b);
+		} else {
+			result = b;
+			XorVectors(result, a);
+		}
+	}
+
+	inline bool VectorRangeAllArmored0(RVector::const_iterator& it, RVector::const_iterator& end)
+	{
+		while(it != end) {
+			if(*it != ARMORED_0) {
+				return false;
+			}
+			it++;
+		}
+		return true;
+	}
+
+	inline bool VectorsEqual(const RVector& a, const RVector& b)
+	{
+		RVector::const_iterator ait = a.begin();
+		RVector::const_iterator aend = a.end();
+		RVector::const_iterator bit = b.begin();
+		RVector::const_iterator bend = b.end();
+
+		while((ait != aend) && (bit != bend)) {
+			if(*ait != *bit) {
+				return false;
+			}
+			++ait;
+			++bit;
+		}
+
+		return
+			(ait != aend) ? VectorRangeAllArmored0(ait, aend) :
+			(bit != bend) ? VectorRangeAllArmored0(bit, bend) : true;
+	}
+
+
+
+	class ProcessEventCallbackDispatcher
+	{
+	private:
+		const RVector& eventSextets;
+		const RVector& valueSextets;
+		const size_t bitCount;
+		void * const context;
+		ProcessEventCallback const callback;
+
+		void CallCallback(size_t bitIndex, bool value)
+		{
+			callback(context, bitIndex, value);
+		}
+
+		inline void ProcessOneSextet(RChr eventSextet, RChr valueSextet, size_t bitStartIndex, size_t turns)
+		{
+			for(size_t subIndex = 0; subIndex < turns; ++subIndex) {
+				RChr mask = 1 << subIndex;
+				if(eventSextet & mask) {
+					size_t bitIndex = bitStartIndex + subIndex;
+					int maskedValue = valueSextet & mask;
+					bool bitValue = maskedValue != 0;
+					CallCallback(bitIndex, bitValue);
+				}
+			}
+		}
+
+		void ProcessAll()
+		{
+			size_t eventSextetCount = eventSextets.size();
+			size_t valueSextetCount = valueSextets.size();
+
+			for(size_t sextetIndex = 0, bitStartIndex = 0; sextetIndex < eventSextetCount; ++sextetIndex, bitStartIndex += 6) {
+				RChr eventSextet = eventSextets[sextetIndex];
+
+				if(eventSextet == 0) {
+					// No 1 bits this sextet.
+					continue;
+				}
+
+				size_t turns = smin(6, bitCount - bitStartIndex);
+
+				RChr valueSextet = (sextetIndex < valueSextetCount) ? valueSextets[sextetIndex] : 0;
+
+				if(turns > 0) {
+					ProcessOneSextet(eventSextet, valueSextet, bitStartIndex, turns);
+				}
+
+				if(turns < 6) {
+					// bitCount has been reached.
+					break;
+				}
+			}
+		}
+
+
+	public:
+		ProcessEventCallbackDispatcher(
+			const RVector& eventSextets,
+			const RVector& valueSextets,
+			const size_t bitCount,
+			void * const context,
+			ProcessEventCallback const callback
+		) :
+			eventSextets(eventSextets),
+			valueSextets(valueSextets),
+			bitCount(smin(bitCount, eventSextets.size() * 6)),
+			context(context),
+			callback(callback)
+		{
+		}
+
+		void RunEvents()
+		{
+			ProcessAll();
+		}
+	};
+
+	// sourceLeft + length must be less than source.length().
+	// result is automatically expanded.
+	void RVectorFromRString(RVector& result, size_t resultLeft, const RString& source, size_t sourceLeft, size_t length)
+	{
+		RString::const_iterator sourceIt, sourceEnd;
+		RVector::iterator resultIt;
+
+		// Expand result if needed
+		size_t resultRight = resultLeft + length;
+		if(resultRight > result.size()) {
+			result.resize(sourceLeft + length, ARMORED_0);
+		}
+
+		sourceIt = source.begin();
+		std::advance(sourceIt, sourceLeft);
+
+		sourceEnd = sourceIt;
+		std::advance(sourceEnd, length);
+
+		resultIt = result.begin();
+
+		for(; sourceIt != sourceEnd; ++sourceIt, ++resultIt) {
+			*resultIt = Armored(*sourceIt);
+		}
+	}
+
+	// sourceLeft + length must be less than source.size().
+	// result is automatically expanded.
+	void RStringFromRVector(RString& result, size_t resultLeft, const RVector& source, size_t sourceLeft, size_t length)
+	{
+		RVector::const_iterator sourceIt, sourceEnd;
+		RString::iterator resultIt;
+
+		// Expand result if needed
+		size_t resultRight = resultLeft + length;
+		if(resultRight > result.length()) {
+			result.resize(sourceLeft + length, ARMORED_0);
+		}
+
+		sourceIt = source.begin();
+		std::advance(sourceIt, sourceLeft);
+
+		sourceEnd = sourceIt;
+		std::advance(sourceEnd, length);
+
+		resultIt = result.begin();
+
+		for(; sourceIt != sourceEnd; ++sourceIt, ++resultIt) {
+			*resultIt = Armored(*sourceIt);
+		}
+	}
+
+	inline void ProcessEventDataVectors(const RVector& eventSextets, const RVector& valueSextets, size_t bitCount, void * context, ProcessEventCallback callback)
+	{
+		ProcessEventCallbackDispatcher d(eventSextets, valueSextets, bitCount, context, callback);
+		d.RunEvents();
+	}
+}
+
+namespace Sextets
+{
+	class Packet::Impl
+	{
+	private:
+		RVector sextets;
+
+		void SetToSextetDataLine(const RString& line, size_t left, size_t right)
+		{
+			size_t length = right - left;
+			RVectorFromRString(sextets, 0, line, left, length);
+		}
+
+	public:
+		Impl()
+		{
+		}
+
+		~Impl() {}
+
+		size_t SextetCount() const
+		{
+			return sextets.size();
+		}
+
+		void Clear()
+		{
+			sextets.clear();
+		}
+
+		void Copy(const Packet& packet)
+		{
+			sextets = packet._impl->sextets;
+		}
+
+		void SetToLine(const RString& line)
+		{
+			size_t left = FindCleanPacketLeft(line);
+			size_t right = FindCleanPacketRight(line, left);
+			SetToSextetDataLine(line, left, right);
+		}
+
+		void SetToBitVector(const std::vector<bool> bits)
+		{
+			size_t bitCount = bits.size();
+			size_t sextetCount = (bitCount + 5) / 6;
+
+			sextets.resize(sextetCount, ARMORED_0);
+
+			size_t sextetIndex = 0;
+			size_t bitIndex = 0;
+			while(bitIndex < bitCount) {
+				RChr s = 0;
+				size_t bitsUsed = smin(bitCount - bitIndex, 6);
+
+				
+
+				switch(bitsUsed) {
+				case 6:
+					s |= (bits[bitIndex + 5] ? 0x20 : 0);
+				case 5:
+					s |= (bits[bitIndex + 4] ? 0x10 : 0);
+				case 4:
+					s |= (bits[bitIndex + 3] ? 0x08 : 0);
+				case 3:
+					s |= (bits[bitIndex + 2] ? 0x04 : 0);
+				case 2:
+					s |= (bits[bitIndex + 1] ? 0x02 : 0);
+				case 1:
+					s |= (bits[bitIndex + 0] ? 0x01 : 0);
+				case 0:
+					break;
+				}
+
+				sextets[sextetIndex] = Armored(s);
+				bitIndex += bitsUsed;
+				sextetIndex++;
+			}
+		}
+
+
+		void SetToLightsState(const LightsState * ls)
+		{
+			std::vector<bool> bits;
+			const bool * bitArray;
+
+			size_t toReserve = 6; // cabinet lights are 1 sextet, or 6 bits
+			// TODO: Make this non-iterative
+			FOREACH_ENUM(GameController, gc) {
+				// Each controller takes 6 sextets, which is 36 bits.
+				toReserve += (6 * 6);
+			}
+			bits.clear();
+			bits.reserve(toReserve);
+
+			// cabinet lights
+			bitArray = ls->m_bCabinetLights;
+
+			PUSH(LIGHT_MARQUEE_UP_LEFT);
+			PUSH(LIGHT_MARQUEE_UP_RIGHT);
+			PUSH(LIGHT_MARQUEE_LR_LEFT);
+			PUSH(LIGHT_MARQUEE_LR_RIGHT);
+			PUSH(LIGHT_BASS_LEFT);
+			PUSH(LIGHT_BASS_RIGHT);
+
+			// Game controller lights
+			FOREACH_ENUM(GameController, gc) {
+				bitArray = ls->m_bGameButtonLights[gc];
+
+				// Menu buttons
+				PUSH(GAME_BUTTON_MENULEFT);
+				PUSH(GAME_BUTTON_MENURIGHT);
+				PUSH(GAME_BUTTON_MENUUP);
+				PUSH(GAME_BUTTON_MENUDOWN);
+				PUSH(GAME_BUTTON_START);
+				PUSH(GAME_BUTTON_SELECT);
+
+				// Other non-sensors
+				PUSH(GAME_BUTTON_BACK);
+				PUSH(GAME_BUTTON_COIN);
+				PUSH(GAME_BUTTON_OPERATOR);
+				PUSH(GAME_BUTTON_EFFECT_UP);
+				PUSH(GAME_BUTTON_EFFECT_DOWN);
+				PUSH0();
+
+				// Sensors
+				PUSH(GAME_BUTTON_CUSTOM_01);
+				PUSH(GAME_BUTTON_CUSTOM_02);
+				PUSH(GAME_BUTTON_CUSTOM_03);
+				PUSH(GAME_BUTTON_CUSTOM_04);
+				PUSH(GAME_BUTTON_CUSTOM_05);
+				PUSH(GAME_BUTTON_CUSTOM_06);
+
+				PUSH(GAME_BUTTON_CUSTOM_07);
+				PUSH(GAME_BUTTON_CUSTOM_08);
+				PUSH(GAME_BUTTON_CUSTOM_09);
+				PUSH(GAME_BUTTON_CUSTOM_10);
+				PUSH(GAME_BUTTON_CUSTOM_11);
+				PUSH(GAME_BUTTON_CUSTOM_12);
+
+				PUSH(GAME_BUTTON_CUSTOM_13);
+				PUSH(GAME_BUTTON_CUSTOM_14);
+				PUSH(GAME_BUTTON_CUSTOM_15);
+				PUSH(GAME_BUTTON_CUSTOM_16);
+				PUSH(GAME_BUTTON_CUSTOM_17);
+				PUSH(GAME_BUTTON_CUSTOM_18);
+
+				PUSH(GAME_BUTTON_CUSTOM_19);
+				PUSH0();
+				PUSH0();
+				PUSH0();
+				PUSH0();
+				PUSH0();
+			}
+
+			RString bs;
+			for(size_t bi; bi < bits.size(); ++bi) {
+				bs += (bits[bi] ? "1" : "0");
+			}
+
+			SetToBitVector(bits);
+		}
+
+		void SetToXor(const Packet& b)
+		{
+			XorVectors(sextets, b._impl->sextets);
+		}
+
+		void SetToXor(const Packet& a, const Packet& b)
+		{
+			XorVectors(sextets, a._impl->sextets, b._impl->sextets);
+		}
+
+		void ProcessEventData(const Packet& eventData, size_t bitCount, void * context, ProcessEventCallback callback)
+		{
+			ProcessEventDataVectors(eventData._impl->sextets, sextets, bitCount, context, callback);
+		}
+
+		void ProcessEachBit(size_t bitCount, void * context, ProcessEventCallback callback) const
+		{
+			size_t sextetCount = sextets.size();
+			size_t bitIndex = 0;
+
+			for(size_t sextetIndex = 0; sextetIndex < sextetCount; ++sextetIndex) {
+				for(size_t subBitIndex = 0; subBitIndex < 6; ++subBitIndex, ++bitIndex) {
+					if(bitIndex >= bitCount) {
+						return;
+					}
+					callback(context, bitIndex, (sextets[sextetIndex] & (1 << subBitIndex)) != 0);
+				}
+			}
+
+			while(bitIndex < bitCount) {
+				callback(context, bitIndex, false);
+				++bitIndex;
+			}
+		}
+
+		bool Equals(const Packet& b) const
+		{
+			VectorsEqual(sextets, b._impl->sextets);
+		}
+
+		void GetUntrimmedLine(RString& line)
+		{
+			RStringFromRVector(line, 0, sextets, 0, sextets.size());
+		}
+
+		RString GetUntrimmedLine()
+		{
+			RString line;
+			GetUntrimmedLine(line);
+			return line;
+		}
+
+		void GetLine(RString& line)
+		{
+			GetUntrimmedLine(line);
+
+			// An empty line stays empty.
+			if(line.empty()) {
+				return;
+			}
+
+			// Find the last non-trimmable character.
+			size_t i = line.find_last_not_of(ARMORED_0);
+			if(i == RString::npos) {
+				// There are no non-trimmable characters.
+				// The canonical form of this is a single armored 0.
+				line.replace(0, RString::npos, 1, ARMORED_0);
+			}
+			else {
+				// The first trailing zero character to erase, if any, is at
+				// i + 1.
+				line.erase(i + 1);
+			}
+		}
+
+		RString GetLine()
+		{
+			RString line;
+			GetLine(line);
+			return line;
+		}
+
+		void Trim()
+		{
+			RString line;
+			GetLine(line);
+			SetToSextetDataLine(line, 0, line.length());
+		}
+
+		bool IsEmpty() const
+		{
+			return sextets.size() == 0;
+		}
+
+		bool IsZeroed() const
+		{
+			RVector::const_iterator it = sextets.begin();
+			RVector::const_iterator end = sextets.end();
+
+			for(; it != end; ++it) {
+				if(*it != ARMORED_0) {
+					return false;
+				}
+			}
+			return true;
+		}
+	};
+
+	Packet::Packet()
+	{
+		_impl = new Packet::Impl();
+	}
+
+	Packet::Packet(const Packet& packet)
+	{
+		_impl = new Packet::Impl();
+		_impl->Copy(packet);
+	}
+
+	Packet::~Packet()
+	{
+		delete _impl;
+	}
+
+	size_t Packet::SextetCount() const
+	{
+		return _impl->SextetCount();
+	}
+
+	void Packet::Clear()
+	{
+		_impl->Clear();
+	}
+
+	void Packet::Copy(const Packet& packet)
+	{
+		_impl->Copy(packet);
+	}
+
+	Packet& Packet::operator=(const Packet& other)
+	{
+		Copy(other);
+		return *this;
+	}
+
+	void Packet::SetToLine(const RString& line)
+	{
+		_impl->SetToLine(line);
+	}
+
+	void Packet::SetToLightsState(const LightsState * ls)
+	{
+		_impl->SetToLightsState(ls);
+	}
+
+	void Packet::SetToXor(const Packet& b)
+	{
+		_impl->SetToXor(b);
+	}
+
+	Packet& Packet::operator^=(const Packet& other)
+	{
+		SetToXor(other);
+		return *this;
+	}
+
+	void Packet::SetToXor(const Packet& a, const Packet& b)
+	{
+		_impl->SetToXor(a, b);
+	}
+
+	// This is a non-member
+	Packet operator^(const Packet& a, const Packet& b)
+	{
+		Packet result;
+		result.SetToXor(a, b);
+		return result;
+	}
+
+	void Packet::ProcessEachBit(size_t bitCount, void * context, ProcessEventCallback callback) const
+	{
+		_impl->ProcessEachBit(bitCount, context, callback);
+	}
+
+	void Packet::ProcessEventData(const Packet& eventData, size_t bitCount, void * context, ProcessEventCallback callback) const
+	{
+		_impl->ProcessEventData(eventData, bitCount, context, callback);
+	}
+
+	bool Packet::Equals(const Packet& b) const
+	{
+		return _impl->Equals(b);
+	}
+
+	bool Packet::operator==(const Packet& other) const
+	{
+		return Equals(other);
+	}
+
+	RString Packet::GetUntrimmedLine() const
+	{
+		return _impl->GetUntrimmedLine();
+	}
+
+	void Packet::GetUntrimmedLine(RString& line) const
+	{
+		_impl->GetUntrimmedLine(line);
+	}
+
+	RString Packet::GetLine() const
+	{
+		return _impl->GetLine();
+	}
+
+	void Packet::GetLine(RString& line) const
+	{
+		_impl->GetLine(line);
+	}
+
+	bool Packet::IsEmpty() const
+	{
+		return _impl->IsEmpty();
+	}
+
+	bool Packet::IsZeroed() const
+	{
+		return _impl->IsZeroed();
+	}
+}
+
+/*
+ * Copyright © 2016 Peter S. May
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to permit
+ * persons to whom the Software is furnished to do so, subject to the
+ * following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+ * NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+ * USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */

--- a/src/Sextets/Packet.h
+++ b/src/Sextets/Packet.h
@@ -1,0 +1,121 @@
+#ifndef Sextets_Packet_h
+#define Sextets_Packet_h
+
+#include "global.h"
+
+// Needed for GetLightsStateAsPacket
+struct LightsState;
+
+namespace Sextets
+{
+	class Packet
+	{
+	public:
+		Packet();
+		Packet(const Packet& packet);
+		~Packet();
+
+		size_t SextetCount() const;
+
+		void Clear();
+
+		void Canonicalize();
+
+		void Copy(const Packet& packet);
+		Packet& operator=(const Packet& other);
+
+		// Sets this packet to the first span of valid sextet characters
+		// within the string. All characters before the first valid
+		// character, and all characters starting with the first invalid
+		// character after the first valid character, are discarded.
+		void SetToLine(const RString& line);
+
+		// Sets this packet to the values corresponding to the given lights
+		// state.
+		void SetToLightsState(const LightsState * ls);
+
+		// Calculates this XOR b, then assigns the result to this
+		// packet.
+		void SetToXor(const Packet& b);
+		Packet& operator^=(const Packet& other);
+
+		// Calculates a XOR b, then assigns the result to this packet.
+		void SetToXor(const Packet& a, const Packet& b);
+
+		typedef void (*ProcessEventCallback)(void * context,
+											 size_t bitIndex, bool value);
+
+		// Examines the low `bitCount` bits of `eventData` and, for each
+		// `1` bit found, calls a callback with the bit index and value
+		// of the bit at the same index of this packet.
+		void ProcessEventData(const Packet& eventData, size_t bitCount,
+							  void * context, ProcessEventCallback callback) const;
+
+		// Iterates over the low `bitCount` bits of this packet, calling the
+		// callback with the index and value of each.
+		void ProcessEachBit(size_t bitCount, void * context,
+				ProcessEventCallback callback) const;
+
+		// Gets whether this packet is equal to another packet if all
+		// `0` bits are trimmed off the right of both.
+		bool Equals(const Packet& b) const;
+		bool operator==(const Packet& other) const;
+
+		// Retrieves a line reflecting the state of the current buffer
+		// as-is.
+		RString GetUntrimmedLine() const;
+		void GetUntrimmedLine(RString& line) const;
+
+		// Retrieves a line reflecting the state of the current buffer:
+		//
+		// If IsEmpty(), the result is an empty string ("").
+		//
+		// If IsZeroed() and not IsEmpty(), the result is a single armored
+		// zero ("@").
+		//
+		// Otherwise, the result is the state of the current buffer with all
+		// trailing zeroes removed.
+		RString GetLine() const;
+		void GetLine(RString& line) const;
+
+		// Replace the buffer with the trimmed form returned by GetLine().
+		void Trim();
+
+		// true if the buffer contains no data.
+		bool IsEmpty() const;
+
+		// true if the buffer contains only (armored) zeroed sextets.
+		bool IsZeroed() const;
+
+	private:
+		class Impl;
+		Impl * _impl;
+	};
+
+	Packet operator^(const Packet& a, const Packet& b);
+}
+
+#endif
+
+/*
+ * Copyright © 2016 Peter S. May
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to permit
+ * persons to whom the Software is furnished to do so, subject to the
+ * following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+ * NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+ * USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */

--- a/src/Sextets/PacketBuffer.cpp
+++ b/src/Sextets/PacketBuffer.cpp
@@ -1,0 +1,227 @@
+
+#include "Sextets/PacketBuffer.h"
+#include "RageLog.h"
+#include "RageUtil.h"
+
+#include <queue>
+
+typedef RString::value_type RChr;
+
+namespace
+{
+	static const size_t LINE_MAX_LENGTH = 4096;
+
+#define ASCII_NEWLINE_CHARS "\x0a\x0d"
+#define ASCII_PRINTABLE_CHARS \
+	"\x20\x21\x22\x23\x24\x25\x26\x27" \
+	"\x28\x29\x2a\x2b\x2c\x2d\x2e\x2f" \
+	"\x30\x31\x32\x33\x34\x35\x36\x37" \
+	"\x38\x39\x3a\x3b\x3c\x3d\x3e\x3f" \
+	"\x40\x41\x42\x43\x44\x45\x46\x47" \
+	"\x48\x49\x4a\x4b\x4c\x4d\x4e\x4f" \
+	"\x50\x51\x52\x53\x54\x55\x56\x57" \
+	"\x58\x59\x5a\x5b\x5c\x5d\x5e\x5f" \
+	"\x60\x61\x62\x63\x64\x65\x66\x67" \
+	"\x68\x69\x6a\x6b\x6c\x6d\x6e\x6f" \
+	"\x70\x71\x72\x73\x74\x75\x76\x77" \
+	"\x78\x79\x7a\x7b\x7c\x7d\x7e"
+#define SIMPLE_CHARS ASCII_PRINTABLE_CHARS ASCII_NEWLINE_CHARS
+
+	using namespace Sextets;
+
+	inline bool EraseTo(RString& str, size_t index, size_t additional = 0)
+	{
+		if(index == RString::npos) {
+			return false;
+		}
+		str.erase(0, index + additional);
+		return true;
+	}
+
+	inline bool EraseToFirstOf(RString& str, const RChr * chars, size_t additional = 0)
+	{
+		size_t i = str.find_first_of(chars);
+		return EraseTo(str, i, additional);
+	}
+
+	class ActualPacketBuffer : public PacketBuffer
+	{
+	private:
+		std::queue<RString> lines;
+		RString buffer;
+
+		// If true, all data through the next newline will be discarded.
+		// This is set where continuing a line after a mid-line error would
+		// ruin the alignment of the data on the line.
+		bool needsResync;
+
+		void RequestResync()
+		{
+			needsResync = true;
+		}
+
+		// If needsResync, attempts to find and erase to the first newline
+		// character in the buffer. If successful, needsResync is set to
+		// false. Returns whether the buffer is now synced (which is
+		// !needsResync).
+		bool SyncBuffer()
+		{
+			if(needsResync) {
+				if(EraseToFirstOf(buffer, ASCII_NEWLINE_CHARS)) {
+					// Newline found; buffer erased up to newline to sync
+					needsResync = false;
+					return true;
+				} else {
+					// No newline found
+					buffer.clear();
+					return false;
+				}
+			}
+			return true;
+		}
+
+		void PushLine(const RString& line)
+		{
+			if(!line.empty()) {
+				lines.push(line);
+			}
+		}
+
+		// Splits the buffer into lines.
+		void BreakBuffer()
+		{
+			while(!buffer.empty() && SyncBuffer()) {
+
+				// First newline
+				size_t newlineIndex = buffer.find_first_of(ASCII_NEWLINE_CHARS);
+				// First invalid char
+				size_t invalidIndex = buffer.find_first_not_of(SIMPLE_CHARS);
+
+				size_t len = (newlineIndex != RString::npos) ? newlineIndex : buffer.length();
+
+				// An invalid character is seen within the current line's
+				// portion of the buffer.
+				if(invalidIndex != RString::npos && (invalidIndex < len))
+				{
+					// Discard line in progress up to next newline
+					RequestResync();
+					LOG->Warn(
+						"Sextets PacketBuffer encountered a line "
+						"that contains an invalid character. "
+						"The current line will be discarded.");
+					continue;
+				}
+
+				// The current line's portion of the buffer is too long.
+				if(len > LINE_MAX_LENGTH) {
+					// Take the beginning, then discard the rest of the line
+					PushLine(buffer.substr(0, LINE_MAX_LENGTH));
+							RequestResync();
+							buffer.clear();
+							LOG->Warn(
+								"Sextets PacketBuffer encountered a line "
+								"that is longer than the allowed maximum "
+								"length (%d). The current line has been "
+								"truncated.", (unsigned)LINE_MAX_LENGTH);
+							continue;
+				}
+
+				// The buffer contains a newline and otherwise looks OK.
+				if(newlineIndex != RString::npos) {
+					PushLine(buffer.substr(0, newlineIndex));
+					EraseTo(buffer, newlineIndex, 1);
+					continue;
+				}
+
+				// The buffer doesn't contain a newline.
+				return;
+			}
+		}
+
+	public:
+		ActualPacketBuffer() : needsResync(false)
+		{
+		}
+
+		~ActualPacketBuffer()
+		{
+		}
+
+		void Add(const RChr * data, size_t length)
+		{
+			buffer.append(data, length);
+			BreakBuffer();
+		}
+
+		void Add(const RString& data)
+		{
+			buffer.append(data);
+			BreakBuffer();
+		}
+
+		void Add(const uint8_t * data, size_t length)
+		{
+			size_t start = buffer.length();
+			buffer.resize(start + length);
+			for(size_t i = 0; i < length; ++i) {
+				buffer[start + i] = (RChr)(data[i]);
+			}
+			BreakBuffer();
+		}
+
+		bool HasPacket()
+		{
+			return !lines.empty();
+		}
+
+		bool GetPacket(Packet& packet)
+		{
+			if(lines.empty()) {
+				return false;
+			}
+
+			packet.SetToLine(lines.front());
+			lines.pop();
+
+			return true;
+		}
+
+		void DiscardUnfinished()
+		{
+			RequestResync();
+		}
+	};
+}
+
+namespace Sextets
+{
+	PacketBuffer* PacketBuffer::Create()
+	{
+		return new ActualPacketBuffer();
+	}
+
+	PacketBuffer::~PacketBuffer() {}
+}
+
+/*
+ * Copyright © 2016 Peter S. May
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to permit
+ * persons to whom the Software is furnished to do so, subject to the
+ * following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+ * NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+ * USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */

--- a/src/Sextets/PacketBuffer.h
+++ b/src/Sextets/PacketBuffer.h
@@ -1,0 +1,64 @@
+#ifndef Sextets_PacketBuffer_h
+#define Sextets_PacketBuffer_h
+
+#include "Sextets/Packet.h"
+#include "global.h"
+
+namespace Sextets
+{
+	class PacketBuffer
+	{
+	public:
+		virtual ~PacketBuffer();
+
+		static PacketBuffer * Create();
+
+		// Adds data to this buffer. Returns true iff the buffer, after
+		// adding the new data, contains at least one newline.
+		virtual void Add(const RString& data) = 0;
+		virtual void Add(const RString::value_type * data, size_t length) = 0;
+		virtual void Add(const uint8_t * data, size_t length) = 0;
+
+		// If the input buffer contains an unfinished packet, clear it and
+		// wait for the next newline to resume buffering.
+		virtual void DiscardUnfinished() = 0;
+
+		// Returns whether this buffer may contain data that can be
+		// retrieved from GetPacket(). False positives may be possible in a
+		// future implementation, so be sure to check the value returned by
+		// GetPacket() after it is called.
+		virtual bool HasPacket() = 0;
+
+		// Attempts to retrieve a line from the buffer. Returns true iff a
+		// line is successfully retrieved and converted to a non-empty
+		// packet. Note the returned value from this method; even if the
+		// most recent Add() returned true, the data in the buffer may
+		// contain an empty or invalid line that cannot be converted.
+		virtual bool GetPacket(Packet& packet) = 0;
+	};
+}
+
+#endif
+
+/*
+ * Copyright © 2016 Peter S. May
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to permit
+ * persons to whom the Software is furnished to do so, subject to the
+ * following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+ * NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+ * USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */

--- a/src/Sextets/SextetStream.md
+++ b/src/Sextets/SextetStream.md
@@ -1,0 +1,132 @@
+SextetStream
+============
+
+Description
+-----------
+
+SextetStream is a stream encoding for finite- but arbitrary-length
+vectors of boolean values.
+
+SextetStream-encoded data is made up of characters, not strictly bytes,
+and is suited for use by platforms that prefer to treat strings as text
+instead of binary data.
+
+Motivation
+----------
+
+SextetStream has been developed as a way to make it possible for
+hobbyists, scripters, and programmers who can't muster the patience for
+C++ to develop their own InputHandler and LightsDriver machinery without
+needing to set up the entire build system for StepMania. Instead,
+InputHandler and LightsDriver are boiled down to an extremely simple
+text stream protocol over stdio, named pipes, and/or TCP sockets.
+
+Refer to `src/arch/InputHandler/InputHandler_SextetStream.md` and
+`src/arch/Lights/LightsDriver_SextetStream.md` for more information
+about those drivers and how to use them.
+
+Stream syntax
+-------------
+
+    SEXTET : 0x30 .. 0x6F               # ASCII '0' through 'o'
+    NEWLINE : 0x0D 0x0A | 0x0A | 0x0D   # ASCII CRLF, CR, or LF
+    INVALID : ~(SEXTET | NEWLINE)       # Everything except
+                                        # SEXTET or NEWLINE
+
+    entireTransmission : (packet | invalidLine)*
+
+    packet : noopPacket | normalPacket
+
+    noopPacket : NEWLINE
+
+    normalPacket : SEXTET+ NEWLINE
+
+    invalidLine : SEXTET* INVALID (SEXTET | INVALID)* NEWLINE
+
+Packets are constructed of sequences of sextet characters followed by a
+newline.
+
+### Noop packet
+
+A noop packet (or blank packet, or empty packet; the terminology needs
+alignment) is a packet that consists of no sextets followed by a newline
+character.
+
+When a noop packet is received, the receiver is not to change its state.
+
+These might be inserted among other data into the stream by the sender
+to test the status of the connection, encourage the receiver to recheck
+its loop condition, and so forth.
+
+They also appear when the receiver treats a CRLF as two separate
+characters. This is intentionally harmless.
+
+### Normal packet
+
+A normal packet is a packet that consists of one or more sextets
+followed by a newline character.
+
+When a normal packet is received, the receiver is to update its state to
+reflect the new data.
+
+The packet must be at least one sextet long (otherwise, it is read as a
+noop packet). Otherwise, the packet data can be as short as desired as
+long as all of its true values are expressed; a packet extends
+infinitely to the right with false values.
+
+For example, the following packets express the same value:
+
+    @@@@A@B@C@@@@@@@@@@@@
+    @@@@A@B@C@@@@@@
+    @@@@A@B@C
+
+#### Encoding sextets
+
+A sextet is encoded by starting with a six-bit integer and then
+selecting the seventh bit so that the result falls in the range
+`0x30 .. 0x6F`:
+
+    encoded = ((raw + 0x10) & 0x3F) + 0x30
+
+(This range was selected in preference to `0x20 .. 0x5F` and
+`0x40 .. 0x7F` due to the former containing a whitespace character and
+the latter containing a control character.)
+
+#### Decoding sextets
+
+An encoded sextet actually contains the original six bits, so for most
+purposes it is enough just to ignore the bits above the low six. If it
+is necessary to clear those bits, simply use AND:
+
+    decoded = encoded & 0x3F
+
+### Invalid input
+
+When input that would normally be a packet contains invalid (non-sextet,
+non-newline) data, it should be discarded all the way through the next
+newline. The processor may resume waiting for valid packets or, at its
+discretion, do something else.
+
+License
+=======
+
+Copyright © 2014-2016 Peter S. May
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/arch/InputHandler/InputHandler_SextetStream.cpp
+++ b/src/arch/InputHandler/InputHandler_SextetStream.cpp
@@ -5,11 +5,18 @@
 #include "RageThreads.h"
 #include "RageUtil.h"
 
+#include "Sextets/IO/PacketReader.h"
+#include "Sextets/IO/StdCFilePacketReader.h"
+#include "Sextets/IO/SelectFilePacketReader.h"
+#include "Sextets/Data.h"
+
 #include <cerrno>
 #include <cstdio>
 #include <cstring>
 
 using namespace std;
+using namespace Sextets;
+using namespace Sextets::IO;
 
 // In so many words, ceil(n/6).
 #define NUMBER_OF_SEXTETS_FOR_BIT_COUNT(n) (((n) + 5) / 6)
@@ -29,241 +36,121 @@ using namespace std;
 #define DEFAULT_TIMEOUT_MS 1000
 #define STATE_BUFFER_SIZE NUMBER_OF_SEXTETS_FOR_BIT_COUNT(BUTTON_COUNT)
 
+
 namespace
 {
-	class LineReader
+	// Gets the DeviceButton that corresponds with the given index.
+	//
+	// The first COUNT_JOY_BUTTON indices are mapped to the range starting
+	// with FIRST_JOY_BUTTON.
+	//
+	// The next COUNT_KEY indices are mapped to the range starting with
+	// FIRST_KEY.
+	//
+	// Any indices after these are mapped to DeviceButton_Invalid.
+	inline DeviceButton ButtonAtIndex(size_t index)
 	{
-		protected:
-			int timeout_ms;
-
-		public:
-			LineReader()
-			{
-				timeout_ms = DEFAULT_TIMEOUT_MS;
-			}
-
-			virtual ~LineReader()
-			{
-			}
-
-			virtual bool IsValid()
-			{
-				return false;
-			}
-
-			// Ideally, this method should return if timeout_ms passes
-			// before a line becomes available. Actually doing this may
-			// require some platform-specific non-blocking read capability.
-			// This sort of thing could be implemented using e.g. POSIX
-			// select() and Windows GetOverlappedResultEx(), both of which
-			// have timeout parameters. (I get the sense that the
-			// RageFileDriverTimeout class could be convinced to work, but
-			// there isn't a lot of code using it, so I'm lacking the proper
-			// examples.)
-			//
-			// If this method does block, almost everything will still work,
-			// but the blocking may prevent the loop from checking
-			// continueInputThread in a timely fashion. If the stream ceases
-			// to produce new data before this object is destroyed, the
-			// current thread will hang until the other side of the
-			// connection closes the stream (or produces a line of data). A
-			// workaround for that would be to have the far side of the
-			// connection repeat its last line every second or so as a
-			// keepalive.
-			//
-			// false (line undefined) if there is an error or EOF condition,
-			// true (line = next line from stream) if a whole line is available,
-			// true (line = "") if no error but still waiting for next line.
-			virtual bool ReadLine(RString& line) = 0;
-	};
+		if(index < COUNT_JOY_BUTTON) {
+			return enum_add2(FIRST_JOY_BUTTON, index);
+		} else if(index < COUNT_JOY_BUTTON + COUNT_KEY) {
+			return enum_add2(FIRST_KEY, index - COUNT_JOY_BUTTON);
+		} else {
+			return DeviceButton_Invalid;
+		}
+	}
 }
 
 class InputHandler_SextetStream::Impl
 {
-	private:
-		InputHandler_SextetStream * handler;
+private:
+	Packet currentStatePacket, nextStatePacket;
+	InputHandler_SextetStream * handler;
+	PacketReaderEventGenerator * eventGenerator;
+	InputDevice id;
+	RageMutex statePacketsLock;
 
-	protected:
-		void ButtonPressed(const DeviceInput& di)
-		{
-			handler->ButtonPressed(di);
+	static void TriggerSetButtonState(void * p, size_t index, bool value)
+	{
+		((Impl*)p)->SetButtonState(index, value);
+	}
+
+	static void TriggerOnReadPacket(void * p, const Packet& packet)
+	{
+		((Impl*)p)->OnReadPacket(packet);
+	}
+
+	void SetButtonState(size_t index, bool value)
+	{
+		DeviceInput di = DeviceInput(id, ButtonAtIndex(index), value ? 1 : 0);
+		handler->ButtonPressed(di);
+	}
+
+	void OnReadPacket(const Packet& newStatePacket)
+	{
+		statePacketsLock.Lock();
+		nextStatePacket = newStatePacket;
+		statePacketsLock.Unlock();
+	}
+
+	inline void Update0()
+	{
+		Packet changesPacket;
+
+		changesPacket.SetToXor(currentStatePacket, nextStatePacket);
+
+		if(changesPacket.IsEmpty()) {
+			// No updates needed
+			return;
 		}
 
-		uint8_t stateBuffer[STATE_BUFFER_SIZE];
-		size_t timeout_ms;
-		RageThread inputThread;
-		bool continueInputThread;
+		// Trigger button updates
+		nextStatePacket.ProcessEventData(changesPacket, BUTTON_COUNT, this, TriggerSetButtonState);
 
-		// Construct and return the LineReader that makes sense for this
-		// object. getLineReader() calls this; if the returned object claims
-		// it is valid, it is returned. Otherwise, it is destroyed and NULL
-		// is returned.
-		virtual LineReader * getUnvalidatedLineReader() = 0;
+		// Must be called at end of Update (cargo cult style).
+		handler->InputHandler::UpdateTimer();
 
-		inline void clearStateBuffer()
-		{
-			memset(stateBuffer, 0, STATE_BUFFER_SIZE);
+		currentStatePacket = nextStatePacket;
+	}
+
+public:
+	Impl(InputHandler_SextetStream * handler, PacketReader * packetReader) :
+		statePacketsLock("InputHandler_SextetStream")
+	{
+		LOG->Info("Number of button states supported by current InputHandler_SextetStream: %u",
+				  (unsigned)BUTTON_COUNT);
+
+		this->handler = handler;
+
+		eventGenerator = PacketReaderEventGenerator::Create(packetReader, (void*) this, TriggerOnReadPacket);
+
+		if(eventGenerator == NULL) {
+			LOG->Warn("Failed to get PacketReader event generator; this input handler is disabled.");
 		}
 
-		inline void createThread()
-		{
-			continueInputThread = true;
-			inputThread.SetName("SextetStream input thread");
-			inputThread.Create(StartInputThread, this);
+		id = InputDevice(FIRST_DEVICE);
+	}
+
+	virtual ~Impl()
+	{
+		if(eventGenerator != NULL) {
+			delete eventGenerator;
+			eventGenerator = NULL;
 		}
+	}
 
-		LineReader * getLineReader()
-		{
-			LineReader * linereader = getUnvalidatedLineReader();
-			if(linereader != NULL) {
-				if(!linereader->IsValid()) {
-					delete linereader;
-					linereader = NULL;
-				}
-			}
-			return linereader;
-		}
 
-	public:
-		Impl(InputHandler_SextetStream * _this)
-		{
-			LOG->Info("Number of button states supported by current InputHandler_SextetStream: %u",
-				(unsigned)BUTTON_COUNT);
-			continueInputThread = false;
-			timeout_ms = DEFAULT_TIMEOUT_MS;
+	void Update()
+	{
+		statePacketsLock.Lock();
+		Update0();
+		statePacketsLock.Unlock();
+	}
 
-			handler = _this;
-			clearStateBuffer();
-			createThread();
-		}
-
-		virtual ~Impl()
-		{
-			if(inputThread.IsCreated()) {
-				continueInputThread = false;
-				inputThread.Wait();
-			}
-		}
-
-		virtual void GetDevicesAndDescriptions(vector<InputDeviceInfo>& vDevicesOut)
-		{
-			vDevicesOut.push_back(InputDeviceInfo(FIRST_DEVICE, "SextetStream"));
-		}
-
-		static int StartInputThread(void * p)
-		{
-			((Impl*) p)->RunInputThread();
-			return 0;
-		}
-
-		inline void GetNewState(uint8_t * buffer, RString& line)
-		{
-			size_t lineLen = line.length();
-			size_t i, cursor;
-			cursor = 0;
-			memset(buffer, 0, STATE_BUFFER_SIZE);
-
-			// Copy from line to buffer until either it is full or we've run out
-			// of characters. Characters outside the sextet code range
-			// (0x30..0x6F) are skipped; the remaining characters have their two
-			// high bits cleared.
-			for(i = 0; i < lineLen; ++i) {
-				char b = line[i];
-				if((b >= 0x30) && (b <= 0x6F)) {
-					buffer[cursor] = b & 0x3F;
-					++cursor;
-					if(cursor >= STATE_BUFFER_SIZE) {
-						break;
-					}
-				}
-			}
-		}
-
-		inline DeviceButton ButtonAtIndex(size_t index)
-		{
-			if(index < COUNT_JOY_BUTTON) {
-				return enum_add2(FIRST_JOY_BUTTON, index);
-			}
-			else if(index < COUNT_JOY_BUTTON + COUNT_KEY) {
-				return enum_add2(FIRST_KEY, index - COUNT_JOY_BUTTON);
-			}
-			else {
-				return DeviceButton_Invalid;
-			}
-		}
-
-		inline void ReactToChanges(const uint8_t * newStateBuffer)
-		{
-			InputDevice id = InputDevice(FIRST_DEVICE);
-			uint8_t changes[STATE_BUFFER_SIZE];
-			RageTimer now;
-
-			// XOR to find differences
-			for(size_t i = 0; i < STATE_BUFFER_SIZE; ++i) {
-				changes[i] = stateBuffer[i] ^ newStateBuffer[i];
-			}
-
-			// Report on changes
-			for(size_t m = 0; m < STATE_BUFFER_SIZE; ++m) {
-				for(size_t n = 0; n < 6; ++n) {
-					size_t bi = (m * 6) + n;
-					if(bi < BUTTON_COUNT) {
-						if(changes[m] & (1 << n)) {
-							bool value = newStateBuffer[m] & (1 << n);
-							LOG->Trace("SS button index %zu %s", bi, value ? "pressed" : "released");
-							DeviceInput di = DeviceInput(id, ButtonAtIndex(bi), value, now);
-							ButtonPressed(di);
-						}
-					}
-				}
-			}
-
-			// Update current state
-			memcpy(stateBuffer, newStateBuffer, STATE_BUFFER_SIZE);
-		}
-
-		void RunInputThread()
-		{
-			RString line;
-			LineReader * linereader;
-
-			LOG->Trace("Input thread started; getting line reader");
-			linereader = getLineReader();
-
-			if(linereader == NULL) {
-				LOG->Warn("Could not open line reader for SextetStream input");
-			}
-			else {
-				LOG->Trace("Got line reader");
-				while(continueInputThread) {
-					LOG->Trace("Reading line");
-					if(linereader->ReadLine(line)) {
-						LOG->Trace("Got line: '%s'", line.c_str());
-						if(line.length() > 0) {
-							uint8_t newStateBuffer[STATE_BUFFER_SIZE];
-							GetNewState(newStateBuffer, line);
-							ReactToChanges(newStateBuffer);
-						}
-					}
-					else {
-						// Error or EOF condition.
-						LOG->Trace("Reached end of SextetStream input");
-						continueInputThread = false;
-					}
-				}
-				LOG->Info("SextetStream input stopped");
-				delete linereader;
-			}
-		}
 };
 
-void InputHandler_SextetStream::GetDevicesAndDescriptions(vector<InputDeviceInfo>& vDevicesOut)
-{
-	if(_impl != NULL) {
-		_impl->GetDevicesAndDescriptions(vDevicesOut);
-	}
-}
-
+// ctor and dtor of InputHandler_SextetStream.
+// If _impl is non-NULL at dtor time, it will be deleted.
+//
 InputHandler_SextetStream::InputHandler_SextetStream()
 {
 	_impl = NULL;
@@ -276,9 +163,19 @@ InputHandler_SextetStream::~InputHandler_SextetStream()
 	}
 }
 
+void InputHandler_SextetStream::GetDevicesAndDescriptions(vector<InputDeviceInfo>& vDevicesOut)
+{
+	vDevicesOut.push_back(InputDeviceInfo(FIRST_DEVICE, "SextetStream"));
+}
+
+void InputHandler_SextetStream::Update()
+{
+	_impl->Update();
+}
+
 // SextetStreamFromFile
 
-REGISTER_INPUT_HANDLER_CLASS (SextetStreamFromFile);
+REGISTER_INPUT_HANDLER_CLASS(SextetStreamFromFile);
 
 #if defined(_WINDOWS)
 	#define DEFAULT_INPUT_FILENAME "\\\\.\\pipe\\StepMania-Input-SextetStream"
@@ -287,141 +184,64 @@ REGISTER_INPUT_HANDLER_CLASS (SextetStreamFromFile);
 #endif
 static Preference<RString> g_sSextetStreamInputFilename("SextetStreamInputFilename", DEFAULT_INPUT_FILENAME);
 
-namespace
-{
-	class StdCFileLineReader: public LineReader
-	{
-		private:
-			// The buffer size isn't critical; the RString will simply be
-			// extended until the line is done.
-			static const size_t BUFFER_SIZE = 64;
-			char buffer[BUFFER_SIZE];
-		protected:
-			std::FILE * file;
-
-		public:
-			StdCFileLineReader(std::FILE * file)
-			{
-				LOG->Info("Starting InputHandler_SextetStreamFromFile from open std::FILE");
-				this->file = file;
-			}
-
-			StdCFileLineReader(const RString& filename)
-			{
-				LOG->Info("Starting InputHandler_SextetStreamFromFile from std::FILE with filename '%s'",
-					filename.c_str());
-				file = std::fopen(filename.c_str(), "rb");
-
-				if(file == NULL) {
-					LOG->Warn("Error opening file '%s' for input (cstdio): %s", filename.c_str(),
-						std::strerror(errno));
-				}
-				else {
-					LOG->Info("File opened");
-					// Disable buffering on the file
-					std::setbuf(file, NULL);
-				}
-			}
-
-			~StdCFileLineReader()
-			{
-				if(file != NULL) {
-					std::fclose(file);
-				}
-			}
-
-			virtual bool IsValid()
-			{
-				return file != NULL;
-			}
-
-			virtual bool ReadLine(RString& line)
-			{
-				bool afterFirst = false;
-				size_t len;
-
-				line = "";
-
-				if(file != NULL) {
-					while(fgets(buffer, BUFFER_SIZE, file) != NULL) {
-						afterFirst = true;
-						line += buffer;
-						len = line.length();
-						if(len > 0 && line[len - 1] == 0xA) {
-							break;
-						}
-					}
-				}
-
-				return afterFirst;
-			}
-	};
-
-	class StdCFileHandleImpl: public InputHandler_SextetStream::Impl
-	{
-		protected:
-			std::FILE * file;
-
-		public:
-			StdCFileHandleImpl(InputHandler_SextetStreamFromFile * handler, std::FILE * file) :
-				InputHandler_SextetStream::Impl(handler)
-			{
-				this->file = file;
-			}
-
-			virtual LineReader * getUnvalidatedLineReader()
-			{
-				return new StdCFileLineReader(this->file);
-			}
-
-			virtual ~StdCFileHandleImpl()
-			{
-				// line reader dtor will close file for us
-			}
-	};
-
-	class StdCFileNameImpl: public InputHandler_SextetStream::Impl
-	{
-		protected:
-			RString filename;
-
-		public:
-			StdCFileNameImpl(InputHandler_SextetStreamFromFile * handler, const RString& filename) :
-				InputHandler_SextetStream::Impl(handler)
-			{
-				this->filename = filename;
-			}
-
-			virtual LineReader * getUnvalidatedLineReader()
-			{
-				return new StdCFileLineReader(filename);
-			}
-
-			virtual ~StdCFileNameImpl()
-			{
-				// Nothing to destroy
-			}
-	};
-}
-
-
-InputHandler_SextetStreamFromFile::InputHandler_SextetStreamFromFile(FILE * file)
-{
-	_impl = new StdCFileHandleImpl(this, file);
-}
-
-InputHandler_SextetStreamFromFile::InputHandler_SextetStreamFromFile(const RString& filename)
-{
-	_impl = new StdCFileNameImpl(this, filename);
-}
-
 InputHandler_SextetStreamFromFile::InputHandler_SextetStreamFromFile()
 {
-	_impl = new StdCFileNameImpl(this, g_sSextetStreamInputFilename);
+	_impl = new InputHandler_SextetStream::Impl(this, StdCFilePacketReader::Create(g_sSextetStreamInputFilename));
 }
 
+InputHandler_SextetStreamFromFile::~InputHandler_SextetStreamFromFile()
+{
+}
+
+
+// SextetStreamFromSelectFile
+
+#if !defined(_WINDOWS)
+
+REGISTER_INPUT_HANDLER_CLASS(SextetStreamFromSelectFile);
+
+InputHandler_SextetStreamFromSelectFile::InputHandler_SextetStreamFromSelectFile()
+{
+	_impl = new InputHandler_SextetStream::Impl(this, SelectFilePacketReader::Create(g_sSextetStreamInputFilename));
+}
+
+InputHandler_SextetStreamFromSelectFile::~InputHandler_SextetStreamFromSelectFile()
+{
+}
+
+#endif
+
+#ifndef WITHOUT_NETWORKING
+
+// SextetStreamFromSocket
+
+#include "ezsockets.h"
+#include "Sextets/IO/EzSocketsPacketReader.h"
+
+REGISTER_INPUT_HANDLER_CLASS(SextetStreamFromSocket);
+
+#define DEFAULT_SOCKET_HOST "localhost"
+#define DEFAULT_SOCKET_PORT 6761
+
+static Preference<RString> g_sSextetStreamInputSocketHost("SextetStreamInputSocketHost", DEFAULT_SOCKET_HOST);
+static Preference<int> g_iSextetStreamInputSocketPort("SextetStreamInputSocketPort", DEFAULT_SOCKET_PORT);
+
+InputHandler_SextetStreamFromSocket::InputHandler_SextetStreamFromSocket()
+{
+	RString host = g_sSextetStreamInputSocketHost;
+	unsigned short port = (unsigned short) g_iSextetStreamInputSocketPort;
+
+	_impl = new InputHandler_SextetStream::Impl(this, EzSocketsPacketReader::Create(host, port));
+}
+
+InputHandler_SextetStreamFromSocket::~InputHandler_SextetStreamFromSocket()
+{
+}
+
+#endif // ndef WITHOUT_NETWORKING
+
 /*
- * Copyright © 2014 Peter S. May
+ * Copyright © 2014-2016 Peter S. May
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the

--- a/src/arch/InputHandler/InputHandler_SextetStream.h
+++ b/src/arch/InputHandler/InputHandler_SextetStream.h
@@ -4,19 +4,23 @@
 #include "InputHandler.h"
 #include <cstdio>
 
+#include "Sextets/IO/PacketReaderEventGenerator.h"
+
 class InputHandler_SextetStream: public InputHandler
 {
 public:
 	InputHandler_SextetStream();
 	virtual ~InputHandler_SextetStream();
-	//virtual void Update();
+	virtual void Update();
 	virtual void GetDevicesAndDescriptions(vector<InputDeviceInfo>& vDevicesOut);
 
 public:
 	class Impl;
+	friend class Impl;
 protected:
 	Impl * _impl;
 };
+
 
 // Note: InputHandler_SextetStreamFromFile uses blocking I/O. For the
 // handler thread to close in a timely fashion, the producer of data for the
@@ -29,25 +33,47 @@ protected:
 class InputHandler_SextetStreamFromFile: public InputHandler_SextetStream
 {
 public:
+	virtual ~InputHandler_SextetStreamFromFile();
+
 	// Note: In the current implementation, the filename (either the
 	// `filename` parameter or the `SextetStreamInputFilename` setting) is
 	// passed to fopen(), not a RageFile ctor, so specify the file to be
 	// opened on the actual filesystem instead of the mapped filesystem. (I
 	// couldn't get RageFile to work here, possibly because I haven't
-	// determined how to disable buffering on an input file.) 
+	// determined how to disable buffering on an input file.)
 	InputHandler_SextetStreamFromFile();
-	InputHandler_SextetStreamFromFile(const RString& filename);
-
-	// The file object passed here must already be open and buffering should
-	// be disabled. The file object will be closed in the destructor.
-	InputHandler_SextetStreamFromFile(std::FILE * file);
 
 };
+
+#if !defined(WITHOUT_NETWORKING)
+class InputHandler_SextetStreamFromSocket: public InputHandler_SextetStream
+{
+public:
+	virtual ~InputHandler_SextetStreamFromSocket();
+	InputHandler_SextetStreamFromSocket();
+};
+#endif // !defined(WITHOUT_NETWORKING)
+
+
+#if !defined(WIN32)
+// Only for systems that support select() on ordinary files
+class InputHandler_SextetStreamFromSelectFile: public InputHandler_SextetStream
+{
+public:
+	virtual ~InputHandler_SextetStreamFromSelectFile();
+
+	// Note: The configured filename (the `SextetStreamInputFilename`
+	// setting) is passed to open(), not a RageFile ctor, so specify the
+	// file to be opened on the actual filesystem instead of the mapped
+	// filesystem.
+	InputHandler_SextetStreamFromSelectFile();
+};
+#endif // !defined(WIN32)
 
 #endif
 
 /*
- * Copyright © 2014 Peter S. May
+ * Copyright © 2014-2016 Peter S. May
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the

--- a/src/arch/InputHandler/InputHandler_SextetStream.md
+++ b/src/arch/InputHandler/InputHandler_SextetStream.md
@@ -4,57 +4,97 @@
 Explanation
 -----------
 
-This is a set of drivers (currently, just one driver) that accept button
-inputs encoded in a stream of character. By accepting this data from a
-stream, input can be produced by a separate program. Such a program can
-be implemented using any language/platform that supports reading from
-the desired input device (and writing to an output stream). If C++ isn't
-your thing, or if learning the guts of StepMania seems a little much
-just to implement an input driver, you're in the right place.
+Each of this set of drivers accepts button inputs encoded as
+SextetStream packets (see `src/Sextets/SextetStream.md` for general
+info) from some other process over an input stream.
+
+Available drivers
+-----------------
+
+There are currently three available SextetStream input drivers:
+
+*   `SextetStreamFromSelectFile` uses POSIX-based non-blocking I/O to
+    access a file, which is expected to be a named pipe/FIFO.
+    *   This driver is not available on Windows.
+    *   This driver uses non-blocking reads.
+    *   The filename to use is set using the `SextetStreamInputFilename`
+        setting in preferences.
+*   `SextetStreamFromFile` uses C stdio (e.g. `fopen()`) to access a
+    file, which is expected to be a named pipe/FIFO.
+    *   Prefer `SextetStreamFromSelectFile` if it is supported by your
+        system.
+    *   If you use Windows and you trust the other users on your
+        machine, prefer `SextetStreamFromSocket`.
+    *   Seriously, a non-blocking named pipe driver for Windows is on
+        the to-do list...
+    *   This driver uses blocking reads which prevent a reading thread
+        from determining whether or not it should continue to run. It
+        should be used primarily as a fallback. To prevent hangs/errors
+        in StepMania, software providing the packets through this driver
+        must output some data (either repeat the most recent packet or
+        merely send a blank line) at least once per second or so in
+        order to allow the condition to be checked. Alternatively, the
+        software providing packets must close the stream at its end
+        before the user attempts to exit StepMania.
+    *   The filename to use is set using the `SextetStreamInputFilename`
+        setting in preferences (same as `SextetStreamFromSelectFile`).
+*   `SextetStreamFromSocket` uses a TCP client to open a connection on a
+    port where the input program is listening.
+    *   This driver uses non-blocking reads.
+    *   The host and port to use are set using the
+        `SextetStreamInputSocketHost` and `SextetStreamInputSocketPort`,
+        respectively.
 
 Quick start
 -----------
 
-You'll need a working StepMania build with the driver
-`InputHandler_SextetStreamFromFile` enabled.
+You'll need a working StepMania build with the driver you want to use
+(`InputHandler_SextetStream_*`) enabled.
 
 For this test, you'll run a test input program to verify that the driver
 is set up properly. This is a simple example of an *input program*, a
 program that will receive input from some arbitrary input source, encode
-the button states, and produce output to be read by StepMania. Because
-this script is for testing and diagnostics, input is accepted as
-keypresses on a GUI window. Actual input programs produce output in the
-same way, but will read input from different sources, such as data from
-a hardware interface (serial/parallel/USB).
+the button states, and produce output to be read by StepMania. Normally,
+an input program reads input from some external source, such as on a
+hardware (serial/parallel/USB) interface. Because this program is for
+testing and diagnostics, the input will instead come from keypresses on
+a GUI window.
 
-### Set up `SextetStreamStdoutTest.jar`
+### Keypress limitations (that are not part of SextetStream)
 
-You'll need the test input program,
-[`SextetStreamStdoutTest.jar`](https://github.com/psmay/SextetStreamStdoutTest/releases),
-as well as a working Java VM to run it. To ensure that the current
-environment is correct, simply run the program:
+Due to the design of some keyboards and/or their drivers, the number of
+keys that can be held at one time, which keys can be pressed
+simultaneously, and which keys have priority over others may vary. The
+SextetStream encoding and drivers impose no such limitation and can
+process all buttons independently of each other if the input program is
+capable of providing such information.
 
-    java -jar SextetStreamStdoutTest.jar
+### Set up `SextetInputTest.jar`
+
+Get a copy of the test input program,
+[`SextetInputTest.jar`](https://github.com/psmay/SextetInputTest/releases),
+which can be used to test the pipe-based and socket-based drivers. A
+working Java VM (version 7 or later) is also needed.
+
+To ensure that the current environment is correct, simply run the
+program:
+
+    java -jar SextetInputTest.jar
 
 A GUI window should open. Click on this window and then try pressing
-some keys. When one of these keys is pressed, its code (number) appears;
-when released, the code disappears.
+some keys. When any of these keys is pressed or released, the displayed
+"State" packet changes on the window.
 
-The output of this program on your console is the encoded sextets
+The output of this program on your console is sextet packets
 representing the state of the pressed keys. A new output line is
-produced immediately when a button is either pressed or released. An
-output line is also produced periodically (about once per second) if
-there have been no recent changes so that the driver is never left
-blocking for too long an interval.
+produced immediately when a button is either pressed or released. A noop
+packet (blank output line) is also produced periodically (about once per
+second) if there have been no recent changes. (The noop packets serve to
+ensure the stream is still open and allow the driver, if it uses
+blocking reads, to check its loop variables.)
 
-Each output line is only as long as necessary to express the current
-state. While nothing is pressed, the output should be this line, about
-once per second:
-
-    @
-
-Press and hold the up arrow. The output should be this line, again about
-once per second:
+Press and hold the up arrow. The output should be the following line, or
+something similar, followed by noop packets if held long enough:
 
     @@@@@@D
 
@@ -73,18 +113,26 @@ you should use your OS or window system settings to disable key repeat,
 at least for the duration of the test, to avoid an undesired rapid-fire
 effect.
 
-### Linux
+When you release the key, the output should be exactly the following
+line, followed by noop packets if left alone long enough:
 
-We assume that `SextetStreamStdoutTest.jar` is working (as outlined
-above) and that `$SM` is the root StepMania directory.
+    @
+
+### Linux (and, in principle, Mac OS X and anything unixish)
+
+We assume that `SextetInputTest.jar` is working (as outlined above) and
+that `$SM` is the root StepMania directory.
+
+#### Using a FIFO
 
 In `Preferences.ini`, set:
 
-    InputDrivers=X11,SextetStreamFromFile
+    InputDrivers=X11,SextetStreamFromSelectFile
     SextetStreamInputFilename=Data/StepMania-Input-SextetStream.in
 
-(This also keeps X11-based keyboard input enabled. The X11 part can be
-removed later after setting up input mappings, if desired.)
+(This also keeps the default keyboard input enabled. The `X11` part can
+be removed later after setting up input mappings, if desired. For Mac OS
+X, replace `X11` with `HID`.)
 
 Create the FIFO:
 
@@ -92,7 +140,7 @@ Create the FIFO:
 
 Run the test input program using the FIFO as output:
 
-    java -jar SextetStreamStdoutTest.jar > "$SM/Data/StepMania-Input-SextetStream.in"
+    java -jar SextetInputTest.jar > "$SM/Data/StepMania-Input-SextetStream.in"
 
 While the input program is running, start StepMania. (While using the
 test program, use windowed mode to keep both StepMania and the input
@@ -101,55 +149,33 @@ go to Options, Test Input. Switch to the test input program and try
 pressing some keys. If StepMania displays corresponding messages, the
 driver is working properly.
 
-#### Serial port under Linux
+#### Using a TCP socket
 
-FIXME: *This has not been tested at all.* The following is a guess at a
-synopsis of how it should work if you're lucky enough for everything to
-have fallen into place just so. (Please amend this message if you manage
-to get this running consistently.)
+In `Preferences.ini`, set:
 
-If you have a microcontroller running firmware that produces output
-compatible with the SextetStream protocol, you can use `socat` as the
-input program to pipe the data directly from the device via a serial
-port:
+    InputDrivers=X11,SextetStreamFromSocket
+    SextetStreamInputSocketHost=localhost
+    SextetStreamInputSocketPort=6761
 
-    socat /dev/ttyUSB0,raw,echo=0,b115200 "$SM/Data/StepMania-Input-SextetStream.in"
+(This also keeps X11-based keyboard input enabled. The X11 part can be
+removed later after setting up input mappings, if desired.)
 
-Substitute your actual serial port device for `/dev/ttyUSB0` and the
-actual port speed for `115200`. (A low speed will not freeze StepMania,
-but may introduce an unacceptable input latency.)
+Run the test input program as a TCP server:
 
-TODO: Supply example Arduino/PIC/... firmware.
+    java -jar SextetInputTest.jar host=localhost port=6761
 
-TODO: Supply example of full-duplex in cooperation with the SextetStream
-lights driver.
-
-### Mac OS X
-
-FIXME: *This has not been tested at all.* The following is a guess at a
-synopsis of how it should work if you're lucky enough for everything to
-have fallen into place just so. (Please amend this message if you manage
-to get this running consistently on Mac OS X.)
-
-Follow the instructions for Linux, but change the `InputDrivers` setting
-to:
-
-    InputDrivers=HID,SextetStreamFromFile
-
-(This also keeps the default HID-based input enabled. The HID part can
-be removed later after setting up input mappings, if desired.)
-
-TODO: Serial examples.
+Continue as above by starting StepMania.
 
 ### Windows
 
-FIXME: *This has not been tested at all.* The following is a guess at a
-synopsis of how it should work if you're lucky enough for everything to
-have fallen into place just so. (Please amend this message if you manage
-to get this running consistently on Windows.)
+**This has not been tested.** It's just a guess of how it should work
+once everything is in place.
 
-We assume that `SextetStreamStdoutTest.jar` is working (as outlined
-above). You will also need
+We assume that `SextetInputTest.jar` is working (as outlined above).
+
+#### Using a named pipe
+
+You will need
 [`createAndWritePipe`](https://github.com/psmay/windows-named-pipe-utils/releases)
 to be able to work with a named pipe from the console.
 
@@ -165,7 +191,7 @@ if desired.)
 Run the input program and use `createAndWritePipe` to redirect the
 output into the named pipe:
 
-    java -jar SextetStreamStdoutTest.jar | createAndWritePipe StepMania-Input-SextetStream
+    java -jar SextetInputTest.jar | createAndWritePipe StepMania-Input-SextetStream
 
 While the input program is running, start StepMania. (While using the
 test program, use windowed mode to keep both StepMania and the input
@@ -174,45 +200,26 @@ go to Options, Test Input. Switch to the test input program and try
 pressing some keys. If StepMania displays corresponding messages, the
 driver is working properly.
 
-TODO: Serial examples.
+#### Using a TCP socket
 
-Keyboard-based demo limitations
--------------------------------
+In `Preferences.ini`, set:
 
-Due to the design of some keyboards and/or their drivers, the number of
-keys that can be held at one time, which keys can be pressed
-simultaneously, and which keys have priority over others may vary. The
-SextetStream driver itself has no such limitation and can process all
-buttons independently of each other if the input program is capable of
-providing such information.
+    InputDrivers=DirectInput,SextetStreamFromSocket
+    SextetStreamInputSocketHost=localhost
+    SextetStreamInputSocketPort=6761
 
-Encoding
+(This also keeps the default DirectInput-based input enabled. The
+DirectInput part can be removed later after setting up input mappings,
+if desired.)
+
+Run the test input program as a TCP server:
+
+    java -jar SextetInputTest.jar host=localhost port=6761
+
+Continue as above by starting StepMania.
+
+Data map
 --------
-
-### Packing sextets
-
-Values are encoded six bits at a time (hence "sextet"). The characters
-are made printable, non-whitespace ASCII so that attempting to read the
-data or pass it through a text-oriented channel will not cause problems.
-The encoding is similar in concept to base64 or uuencode, but in this
-scheme the low 6 bits remain unchanged.
-
-Data is packed into the low 6 bits of a byte, then the two high bits are
-set in such a way that the result is printable, non-whitespace ASCII:
-
-    0x00-0x0F -> 0x40-0x4F
-    0x10-0x1F -> 0x50-0x5F
-    0x20-0x2F -> 0x60-0x6F
-    0x30-0x3F -> 0x30-0x3F
-
-(0x20-0x2F and 0x70-0x7F are avoided since they contain control or
-whitespace characters.)
-
-To encode a 6-bit value `s` in this way, this transform may be used:
-
-    ((s + 0x10) & 0x3F) + 0x30
-
-### Bit meanings
 
 This driver produces events for a virtual game controller with no axes
 and an arbitrary number of buttons. As with an actual gamepad, the
@@ -229,7 +236,6 @@ is currently 32. Higher codes are coded as keypresses for unknown keys
     *   0x08 button B4
     *   0x10 button B5
     *   0x20 button B6
-
 *   …
 
 *   Byte `n` for `n < 5`
@@ -239,7 +245,6 @@ is currently 32. Higher codes are coded as keypresses for unknown keys
     *   0x08 button B`6n+4`
     *   0x10 button B`6n+5`
     *   0x20 button B`6n+6`
-
 *   …
 
 *   Byte 5
@@ -249,7 +254,6 @@ is currently 32. Higher codes are coded as keypresses for unknown keys
     *   0x08 key unk 1
     *   0x10 key unk 2
     *   0x20 key unk 3
-
 *   …
 
 *   Byte `n` for `n > 5`
@@ -260,18 +264,6 @@ is currently 32. Higher codes are coded as keypresses for unknown keys
     *   0x10 key unk `6(n-6)+8`
     *   0x20 key unk `6(n-6)+9`
 
-A message is ended by terminating it with LF (0x0A) or CR LF (0x0D
-0x0A). Data bytes outside 0x30-0x6F are discarded. The message can be as
-large or as short as necessary, to encode all buttons. Any buttons not
-encoded in a message are understood to have the value 0.
-
-These messages both indicate that buttons 4 and 6 are pressed, and all
-others are not:
-
-    # Note: 0x68 & 0x3F == 0x28; 0x40 & 0x3F == 0x00
-    0x68 0x40 0x40 0x0A
-    0x68 0x0A
-
 The number of buttons supported by the implementation is currently the
 number of supported joy buttons plus the number of supported unknown
 keys (as of this writing: 32 + 321 = 353; you certainly shouldn't need
@@ -281,52 +273,32 @@ the highest-indexed bit currently in an on state, it's probably a good
 idea to keep that number low whenever possible, especially when using a
 low-speed input (such as a serial or network connection).
 
-Filesystem
-----------
-
-The current implementation of this driver uses C standard I/O (i.e.,
-`fopen()`, `fread()`, etc.) instead of the `RageFile` abstraction
-Therefore, any `RageFile`-based filesystem abstractions *are not*
-applied. Please keep this in mind when specifying the input path.
-
-FIXME: This behavior is definitely subject to change should the
-following problem ever get worked out: I was unable to get `RageFile` to
-work in this context; I believe the cause is that I couldn't get a
-`RageFile` object to do unbuffered input. It may have been something
-else.
-
-Pipes
------
-
-The input of this driver is streamed from a file. At face value, this is
-not too useful. The actual intent is for the system operator to create a
-*named fifo* or *named pipe* that is being written to by some already
-running program, such as a program that reads button state data in over
-a serial connection. It just happens that opening a named fifo for
-reading can be accomplished in the same fashion as opening a file for
-reading, as long as buffering can be disabled. Since there's an easy,
-platform-ignorant way to do that, that's what we've done.
+Platform notes
+--------------
 
 ### Blocking behavior
 
-This driver uses blocking I/O, but does so in a separate thread so that
-StepMania will read lines about as fast as they are written and there is
-no technical minimum data rate. However, the blocking read temporarily
+The `SextetStreamFromFile` driver uses blocking I/O. It does so in a
+separate thread so that StepMania will read lines about as fast as they
+are written and there is no technical minimum data rate; however, the
+blocking read cannot be interrupted except by the other side of the
+connection either sending new data or closing. If neither happens
+promptly as StepMania closes, it will hang.
 
-particular, as StepMania exits, it may hang waiting for the input thread
-to finish until one of the following happens:
-
-*   The input program closes the stream
-*   The input program outputs a line, allowing StepMania to end the
-    input thread
-
-So, for the purposes of this driver, it is good manners for an input
-program to periodically (e.g. once per second) repeat its current state
+For the purposes of such blocking-read-based, it is good manners for an
+input program to periodically (e.g. once per second) send a noop packet
 so that the input thread is never left blocking for too long at a time.
 (Alternatively, if the input program has some way to determine that
 StepMania is exiting, it may just close the stream instead.)
 
-### Linux (and some other unixish systems)
+The `SextetStreamFromSelectFile` driver is a non-blocking drop-in
+replacement for `SextetStreamFromFile` for non-Windows systems, even
+using the same filename setting. On Windows, `SextetStreamFromSocket`
+provides non-blocking functionality. (Non-blocking named pipe read on
+Windows is not impossible, but not yet a priority. Maybe you'd like to
+take it on?)
+
+### Linux (and other unixish systems) FIFOs
 
 `mkfifo` is used to create a named FIFO. After this is done, two
 programs (one reading and one writing) open the FIFO as if it were some
@@ -338,7 +310,7 @@ and read, respectively.
 Input programs producing output on stdout work trivially; the program's
 output is simply redirected to the FIFO.
 
-### Windows
+### Windows named pipes
 
 The client side of a Windows named pipe is fairly ordinary; the path to
 an already-open pipe can be opened and used as if it were an ordinary
@@ -358,10 +330,29 @@ whatever is received on stdin to the pipe.
 A Windows-specific input program might also just create and write a
 named pipe by itself.
 
+### Sockets
+
+Common sockets functionality is found in the EzSockets library. The
+socket-based driver is tested in Linux and should work in Windows. For
+this driver, the input program is the server and StepMania is the
+client. The input program will need to be waiting for a client before
+starting StepMania.
+
+To-do
+-----
+
+*   Put the connection lifetime code in a large loop so that a
+    disconnect is followed at some point by a retry.
+*   Get this driver into non-Linux builds.
+*   Implement a workalike for `SextetStreamFromSelectFile` in Windows.
+*   Make more example input programs
+    *   e.g. Bidirectional bridge to Arduino-based controller *and*
+        lights
+
 License
 =======
 
-Copyright © 2014 Peter S. May
+Copyright © 2014-2016 Peter S. May
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the

--- a/src/arch/Lights/LightsDriver_SextetStream.cpp
+++ b/src/arch/Lights/LightsDriver_SextetStream.cpp
@@ -5,203 +5,71 @@
 #include "RageUtil.h"
 
 #include <cstring>
+#include <string>
+
+#include "Sextets/IO/PacketWriter.h"
+#include "Sextets/IO/NoopPacketWriter.h"
+#include "Sextets/IO/RageFilePacketWriter.h"
+#include "Sextets/Data.h"
+#include "Sextets/Packet.h"
 
 using namespace std;
-
-// Number of printable characters used to encode lights
-static const size_t CABINET_SEXTET_COUNT = 1;
-static const size_t CONTROLLER_SEXTET_COUNT = 6;
-
-// Number of bytes to contain the full pack and a trailing LF
-static const size_t FULL_SEXTET_COUNT = CABINET_SEXTET_COUNT + (NUM_GameController * CONTROLLER_SEXTET_COUNT) + 1;
+using namespace Sextets;
+using namespace Sextets::IO;
 
 
-// Serialization routines
 
-// Encodes the low 6 bits of a byte as a printable, non-space ASCII
-// character (i.e., within the range 0x21-0x7E) such that the low 6 bits of
-// the character are the same as the input.
-inline uint8_t printableSextet(uint8_t data)
+
+
+// Implementation base class
+
+class LightsDriver_SextetStream::Impl
 {
-	// Maps the 6-bit value into the range 0x30-0x6F, wrapped in such a way
-	// that the low 6 bits of the result are the same as the data (so
-	// decoding is trivial).
-	//
-	//	00nnnn	->	0100nnnn (0x4n)
-	//	01nnnn	->	0101nnnn (0x5n)
-	//	10nnnn	->	0110nnnn (0x6n)
-	//	11nnnn	->	0011nnnn (0x3n)
 
-	// Put another way, the top 4 bits H of the output are determined from
-	// the top two bits T of the input like so:
-	// 	H = ((T + 1) mod 4) + 3
+private:
+	Packet previousPacket;
+	PacketWriter * writer;
 
-	return ((data + (uint8_t)0x10) & (uint8_t)0x3F) + (uint8_t)0x30;
-}
-
-// Packs 6 booleans into a 6-bit value
-inline uint8_t packPlainSextet(bool b0, bool b1, bool b2, bool b3, bool b4, bool b5)
-{
-	return (uint8_t)(
-		(b0 ? 0x01 : 0) |
-		(b1 ? 0x02 : 0) |
-		(b2 ? 0x04 : 0) |
-		(b3 ? 0x08 : 0) |
-		(b4 ? 0x10 : 0) |
-		(b5 ? 0x20 : 0));
-}
-
-// Packs 6 booleans into a printable sextet
-inline uint8_t packPrintableSextet(bool b0, bool b1, bool b2, bool b3, bool b4, bool b5)
-{
-	return printableSextet(packPlainSextet(b0, b1, b2, b3, b4, b5));
-}
-
-// Packs the cabinet lights into a printable sextet and adds it to a buffer
-inline size_t packCabinetLights(const LightsState *ls, uint8_t* buffer)
-{
-	buffer[0] = packPrintableSextet(
-		ls->m_bCabinetLights[LIGHT_MARQUEE_UP_LEFT],
-		ls->m_bCabinetLights[LIGHT_MARQUEE_UP_RIGHT],
-		ls->m_bCabinetLights[LIGHT_MARQUEE_LR_LEFT],
-		ls->m_bCabinetLights[LIGHT_MARQUEE_LR_RIGHT],
-		ls->m_bCabinetLights[LIGHT_BASS_LEFT],
-		ls->m_bCabinetLights[LIGHT_BASS_RIGHT]);
-	return CABINET_SEXTET_COUNT;
-}
-
-// Packs the button lights for a controller into 6 printable sextets and
-// adds them to a buffer
-inline size_t packControllerLights(const LightsState *ls, GameController gc, uint8_t* buffer)
-{
-	// Menu buttons
-	buffer[0] = packPrintableSextet(
-		ls->m_bGameButtonLights[gc][GAME_BUTTON_MENULEFT],
-		ls->m_bGameButtonLights[gc][GAME_BUTTON_MENURIGHT],
-		ls->m_bGameButtonLights[gc][GAME_BUTTON_MENUUP],
-		ls->m_bGameButtonLights[gc][GAME_BUTTON_MENUDOWN],
-		ls->m_bGameButtonLights[gc][GAME_BUTTON_START],
-		ls->m_bGameButtonLights[gc][GAME_BUTTON_SELECT]);
-
-	// Other non-sensors
-	buffer[1] = packPrintableSextet(
-		ls->m_bGameButtonLights[gc][GAME_BUTTON_BACK],
-		ls->m_bGameButtonLights[gc][GAME_BUTTON_COIN],
-		ls->m_bGameButtonLights[gc][GAME_BUTTON_OPERATOR],
-		ls->m_bGameButtonLights[gc][GAME_BUTTON_EFFECT_UP],
-		ls->m_bGameButtonLights[gc][GAME_BUTTON_EFFECT_DOWN],
-		false);
-
-	// Sensors
-	buffer[2] = packPrintableSextet(
-		ls->m_bGameButtonLights[gc][GAME_BUTTON_CUSTOM_01],
-		ls->m_bGameButtonLights[gc][GAME_BUTTON_CUSTOM_02],
-		ls->m_bGameButtonLights[gc][GAME_BUTTON_CUSTOM_03],
-		ls->m_bGameButtonLights[gc][GAME_BUTTON_CUSTOM_04],
-		ls->m_bGameButtonLights[gc][GAME_BUTTON_CUSTOM_05],
-		ls->m_bGameButtonLights[gc][GAME_BUTTON_CUSTOM_06]);
-	buffer[3] = packPrintableSextet(
-		ls->m_bGameButtonLights[gc][GAME_BUTTON_CUSTOM_07],
-		ls->m_bGameButtonLights[gc][GAME_BUTTON_CUSTOM_08],
-		ls->m_bGameButtonLights[gc][GAME_BUTTON_CUSTOM_09],
-		ls->m_bGameButtonLights[gc][GAME_BUTTON_CUSTOM_10],
-		ls->m_bGameButtonLights[gc][GAME_BUTTON_CUSTOM_11],
-		ls->m_bGameButtonLights[gc][GAME_BUTTON_CUSTOM_12]);
-	buffer[4] = packPrintableSextet(
-		ls->m_bGameButtonLights[gc][GAME_BUTTON_CUSTOM_13],
-		ls->m_bGameButtonLights[gc][GAME_BUTTON_CUSTOM_14],
-		ls->m_bGameButtonLights[gc][GAME_BUTTON_CUSTOM_15],
-		ls->m_bGameButtonLights[gc][GAME_BUTTON_CUSTOM_16],
-		ls->m_bGameButtonLights[gc][GAME_BUTTON_CUSTOM_17],
-		ls->m_bGameButtonLights[gc][GAME_BUTTON_CUSTOM_18]);
-	buffer[5] = packPrintableSextet(
-		ls->m_bGameButtonLights[gc][GAME_BUTTON_CUSTOM_19],
-		false,
-		false,
-		false,
-		false,
-		false);
-
-	return CONTROLLER_SEXTET_COUNT;
-}
-
-inline size_t packLine(uint8_t * buffer, const LightsState* ls)
-{
-	size_t index = 0;
-
-	index += packCabinetLights(ls, &(buffer[index]));
-
-	FOREACH_ENUM(GameController, gc)
+public:
+	Impl(PacketWriter * writer)
 	{
-		index += packControllerLights(ls, gc, &(buffer[index]));
+		if(writer == NULL) {
+			writer = new NoopPacketWriter();
+		}
+		this->writer = writer;
 	}
 
-	// Terminate with LF
-	buffer[index++] = 0xA;
-
-	return index;
-}
-
-
-
-// Private members/methods are kept out of the header using an opaque pointer `_impl`.
-// Google "pimpl idiom" for an explanation of what's going on and why it is (or might be) useful.
-
-
-// Implementation class
-
-namespace
-{
-	class Impl
+	virtual ~Impl()
 	{
-	protected:
-		uint8_t lastOutput[FULL_SEXTET_COUNT];
-		RageFile * out;
-
-	public:
-		Impl(RageFile * file) {
-			out = file;
-
-			// Ensure a non-match the first time
-			lastOutput[0] = 0;
+		if(writer != NULL) {
+			delete writer;
+			writer = NULL;
 		}
+	}
 
-		virtual ~Impl() {
-			if(out != NULL)
-			{
-				out->Flush();
-				out->Close();
-				SAFE_DELETE(out);
-			}
-		}
-
-		void Set(const LightsState * ls)
-		{
-			uint8_t buffer[FULL_SEXTET_COUNT];
-
-			packLine(buffer, ls);
+	void Set(const LightsState * ls)
+	{
+		// Skip writing if the writer is not available.
+		if(writer->IsReady()) {
+			Packet packet;
+			packet.SetToLightsState(ls);
 
 			// Only write if the message has changed since the last write.
-			if(memcmp(buffer, lastOutput, FULL_SEXTET_COUNT) != 0)
-			{
-				if(out != NULL)
-				{
-					out->Write(buffer, FULL_SEXTET_COUNT);
-					out->Flush();
-				}
+			if(!packet.Equals(previousPacket)) {
+				writer->WritePacket(packet);
+				LOG->Trace("Packet: %s", packet.GetLine().c_str());
 
 				// Remember last message
-				memcpy(lastOutput, buffer, FULL_SEXTET_COUNT);
+				previousPacket.Copy(packet);
 			}
 		}
-	};
-}
+	}
+};
+
 
 
 // LightsDriver_SextetStream interface
 // (Wrapper for Impl)
-
-#define IMPL ((Impl*)_impl)
 
 LightsDriver_SextetStream::LightsDriver_SextetStream()
 {
@@ -210,18 +78,14 @@ LightsDriver_SextetStream::LightsDriver_SextetStream()
 
 LightsDriver_SextetStream::~LightsDriver_SextetStream()
 {
-	if(IMPL != NULL)
-	{
-		delete IMPL;
+	if(_impl != NULL) {
+		delete _impl;
 	}
 }
 
 void LightsDriver_SextetStream::Set(const LightsState *ls)
 {
-	if(IMPL != NULL)
-	{
-		IMPL->Set(ls);
-	}
+	_impl->Set(ls);
 }
 
 
@@ -236,37 +100,26 @@ REGISTER_LIGHTS_DRIVER_CLASS(SextetStreamToFile);
 #endif
 static Preference<RString> g_sSextetStreamOutputFilename("SextetStreamOutputFilename", DEFAULT_OUTPUT_FILENAME);
 
-inline RageFile * openOutputStream(const RString& filename)
-{
-	RageFile * file = new RageFile;
-
-	if(!file->Open(filename, RageFile::WRITE|RageFile::STREAMED))
-	{
-		LOG->Warn("Error opening file '%s' for output: %s", filename.c_str(), file->GetError().c_str());
-		SAFE_DELETE(file);
-		file = NULL;
-	}
-
-	return file;
-}
-
-LightsDriver_SextetStreamToFile::LightsDriver_SextetStreamToFile(RageFile * file)
-{
-	_impl = new Impl(file);
-}
-
-LightsDriver_SextetStreamToFile::LightsDriver_SextetStreamToFile(const RString& filename)
-{
-	_impl = new Impl(openOutputStream(filename));
-}
-
 LightsDriver_SextetStreamToFile::LightsDriver_SextetStreamToFile()
 {
-	_impl = new Impl(openOutputStream(g_sSextetStreamOutputFilename));
+	LOG->Info("Creating LightsDriver_SextetStreamToFile");
+	LOG->Flush();
+
+	PacketWriter * writer =
+		RageFilePacketWriter::Create(g_sSextetStreamOutputFilename);
+
+	if(writer == NULL) {
+		LOG->Warn("Create of packet writer for LightsDriver_SextetStreamToFile failed.");
+	} else {
+		LOG->Info("Create of packet writer for LightsDriver_SextetStreamToFile OK.");
+	}
+
+	// Impl() accounts for the case where writer is NULL.
+	_impl = new Impl(writer);
 }
 
 /*
- * Copyright © 2014 Peter S. May
+ * Copyright © 2014-2016 Peter S. May
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the

--- a/src/arch/Lights/LightsDriver_SextetStream.md
+++ b/src/arch/Lights/LightsDriver_SextetStream.md
@@ -4,14 +4,30 @@
 Explanation
 -----------
 
-This is a set of drivers (currently, just one driver) that encode light
-states as text and stream the result to the desired output. By making
-the light data available as a readable stream, light control can be
-performed by another program. Such a program can be implemented using
-any language/platform that supports driving the desired output device
-(and reading from an input stream). If C++ isn't your thing, or if
-learning the guts of StepMania seems a little much just to implement a
-lights driver, you're in the right place.
+Each of this set of drivers produces light outputs encoded as
+SextetStream packets (see `src/Sextets/SextetStream.md` for general
+info) to some other process over an output stream.
+
+Available drivers
+-----------------
+
+There is currently only one available SextetStream light driver:
+
+*   `SextetStreamToFile` uses a `RageFile` opened for output to access a
+    file, which is expected to be a named pipe/FIFO.
+    *   This driver opens a `RageFile` with the `RageFile::WRITE` and
+        `RageFile::STREAMED` flags.
+    *   Writes by this driver may block if the lighting program fails to
+        read at a sufficient rate.
+        *   If the lighting program leaves a pending packet unread as
+            StepMania closes down, it may hang until the lighting
+            program completes the read, closes the stream, or exits.
+        *   Unless the processing of a packet is seriously trivial
+            timewise, it may be a good idea to implement the lighting
+            program in terms of a thread that waits for a packet, reads
+            a packet, quickly hands off the packet for processing by
+            another thread, then repeats without waiting for the packet
+            to process.
 
 Quick start
 -----------
@@ -19,22 +35,50 @@ Quick start
 You'll need a working StepMania build with the driver
 `LightsDriver_SextetStreamToFile` enabled.
 
-For this test, you'll run a script, `SextetStreamStdinTest`, to verify
-that the driver is set up properly. The script is a simple example of a
-*lighting program*, a program that will receive input from StepMania and
-produce output using the data. Because the script is for testing and
-diagnostics, the is text in a console window. Actual lighting programs
-receive input in the same way, but will do different things with the
-output, such as sending commands out over a hardware interface
-(serial/parallel/USB) to control physical lights.
+For this test, you'll run a test lighting program to verify that the
+driver is set up properly. This is a simple example of a *lighting
+program*, a program that will receive input from StepMania and produce
+output via some arbitrary output device using the data. Normally, a
+lighting program produces output on some external display, such as on a
+hardware (serial/parallel/USB) interface. Because this program is for
+testing and diagnostics, the output will instead be displayed as a
+simulated lighting display on a GUI window.
 
-### Linux
+### Set up `SextetOutputTest.jar`
 
-You'll need the perl script
-[`SextetStreamStdinTest.pl`](https://gist.github.com/psmay/7f45a867c1ae8f88ec36#file-sextetstreamstdintest-pl).
-Set the executable bit (`chmod ug+x SextetStreamStdinTest.pl`).
+Get a copy of the test lighting program,
+[`SextetOutputTest.jar`](https://github.com/psmay/SextetOutputTest/releases),
+which can be used to test the pipe-based driver. A working Java VM
+(version 7 or later) is also needed. (Note that, as of this writing,
+this test program only supports the `dance` and `techno` game modes.)
 
-We assume that `$SM` is the root StepMania directory.
+To ensure that the current environment is correct, simply run the
+program:
+
+    java -jar SextetOutputTest.jar
+
+A GUI window should open with the simulated display, with all lights
+off. Return to the console window and enter a row of `?` characters (13
+or more for this example), then press Enter.
+
+    ?????????????
+
+If this succeeds, all of the lights should now be on. To turn them back
+off, type a row of `@`, then press Enter.
+
+    @@@@@@@@@@@@@
+
+The input to this program on your console is sextet packets representing
+the states of the output lights. (A `?` character lights all of the bits
+in a given sextet; a `@` turns them back off.) The lighting program
+should be prepared to accept an empty line as a noop packet.
+
+### Linux (and, in principle, Mac OS X and anything unixish)
+
+We assume that `SextetOutputTest.jar` is working (as outlined above) and
+that `$SM` is the root StepMania directory.
+
+#### Using a FIFO
 
 In `Preferences.ini`, set:
 
@@ -47,58 +91,31 @@ Create the FIFO:
 
 Run the test stdin-based lighting program, using the FIFO as input:
 
-    ./SextetStreamStdinTest.pl < "$SM/Data/StepMania-Lights-SextetStream.out"
+    java -jar SextetOutputTest.jar < "$SM/Data/StepMania-Lights-SextetStream.out"
 
-While the lighting program is running, start StepMania. (When using the
-test lighting program, windowed mode may be needed to keep the program
-visible.) The lighting program should display the light information.
+While the lighting program is running, start StepMania. (While using the
+test program, use windowed mode to keep both StepMania and the lighting
+program visible.) When successfully configured, the test program
+displays animated light patterns as StepMania runs, and while under
+Options, Test Input, presses and releases on the dance pad buttons are
+echoed as lights.
 
-When StepMania closes, the FIFO connection ends, causing the lighting
-program to exit as well.
-
-#### Serial port under Linux
-
-If you have a microcontroller running firmware that understands the
-SextetStream protocol, you can use `socat` as the lighting program to
-pipe the data directly to the device via a serial port:
-
-    socat "$SM/Data/StepMania-Lights-SextetStream.out" /dev/ttyUSB0,raw,echo=0,b115200
-
-Substitute your actual serial port device for `/dev/ttyUSB0` and the
-actual port speed for `115200`. (But note that running at too low a
-speed may result in the output blocking, causing StepMania to freeze or
-stutter).
-
-TODO: Supply example Arduino/PIC/... firmware.
-
-TODO: Supply example of full-duplex in cooperation with the SextetStream
-input driver.
-
-### Mac OS X
-
-FIXME: *This has not been tested at all.* The following is a guess at a
-synopsis of how it should work if you're lucky enough for everything to
-have fallen into place just so. (Please amend this message if you manage
-to get this running consistently on Mac OS X.)
-
-The instructions for Linux should work equally well for Mac OS X.
-
-TODO: Serial examples.
+When StepMania closes, the FIFO connection's closing may or may not
+cause the lighting program to exit. If not, the lighting program can be
+exited manually.
 
 ### Windows
 
-FIXME: *This has not been tested at all.* The following is a guess at a
-synopsis of how it should work if you're lucky enough for everything to
-have fallen into place just so. (Please amend this message if you manage
-to get this running consistently on Windows.)
+FIXME: *This has not been tested at all.* It's just a guess of how it
+should work once everything is implemented.
 
-You'll need:
+We assume that `SextetOutputTest.jar` is working (as outlined above).
 
-*   The Windows Script Host script
-    [`SextetStreamStdinTest.wsf`](https://gist.github.com/psmay/7f45a867c1ae8f88ec36#file-sextetstreamstdintest-wsf),
-    the lighting program
-*   [`createAndReadPipe`](https://github.com/psmay/windows-named-pipe-utils/releases),
-    to work with a named pipe from the console.
+#### Using a named pipe
+
+You will need
+[`createAndReadPipe`](https://github.com/psmay/windows-named-pipe-utils/releases),
+to be able to work with a named pipe from the console.
 
 In `Preferences.ini`, set:
 
@@ -108,50 +125,26 @@ In `Preferences.ini`, set:
 Use `createAndReadPipe` to create the named pipe, feeding the output
 into the test stdin-based lighting program:
 
-    createAndReadPipe StepMania-Lights-SextetStream | cscript //nologo SextetStreamStdinTest.wsf
+    createAndReadPipe StepMania-Lights-SextetStream | java -jar SextetOutputTest.jar
 
-While the lighting program is running, start StepMania. (When using the
-test lighting program, windowed mode may be needed to keep the program
-visible.) The lighting program should display the light information.
+While the lighting program is running, start StepMania. (While using the
+test program, use windowed mode to keep both StepMania and the lighting
+program visible.) When successfully configured, the test program
+displays animated light patterns as StepMania runs, and while under
+Options, Test Input, presses and releases on the dance pad buttons are
+echoed as lights.
 
-When StepMania closes, the pipe connection ends, causing the lighting
-program to exit as well.
+When StepMania closes, the named pipe connection's closing may or may
+not cause the lighting program to exit. If not, the lighting program can
+be exited manually.
 
-TODO: Serial examples.
-
-Encoding
+Data map
 --------
 
-### Packing sextets
+The driver outputs a packet at least once each time any light changes.
+Each packet represents the entire current light state.
 
-Values are encoded six bits at a time (hence "sextet").
-
-Data is packed into the low 6 bits of a byte, then the two high bits are
-set in such a way that the result is printable, non-whitespace ASCII:
-
-    0x00-0x0F -> 0x40-0x4F
-    0x10-0x1F -> 0x50-0x5F
-    0x20-0x2F -> 0x60-0x6F
-    0x30-0x3F -> 0x30-0x3F
-
-(0x20-0x2F and 0x70-0x7F are avoided since they contain control or
-whitespace characters.)
-
-The characters are made printable so that attempting to read the output
-or pass it through a text-oriented channel will not cause problems.
-
-In any case, decoding these values is trivial and involves no
-lookups—just do `& 0x3F`. (And even that may be optional, depending on
-the application.)
-
-### Bit meanings
-
-The driver repeatedly outputs a serialization of the current light state
-followed by an LF (0xA, `\n`), at least once each time any light should
-change (and currently no more often than that).
-
-Currently, this message is 13 data bytes followed by LF. The following
-information is contained:
+The following information is encoded in each packet:
 
 *   Byte 0
     *   0x01 Marquee upper-left
@@ -160,7 +153,6 @@ information is contained:
     *   0x08 Marquee lower-right
     *   0x10 Bass left
     *   0x20 Bass right
-
 *   Byte 1
     *   0x01 Player 1 menu left
     *   0x02 Player 1 menu right
@@ -168,7 +160,6 @@ information is contained:
     *   0x08 Player 1 menu down
     *   0x10 Player 1 start
     *   0x20 Player 1 select
-
 *   Byte 2
     *   0x01 Player 1 back
     *   0x02 Player 1 coin
@@ -176,7 +167,6 @@ information is contained:
     *   0x08 Player 1 effect up
     *   0x10 Player 1 effect down
     *   0x20 (reserved)
-
 *   Byte 3
     *   0x01 Player 1 #1
     *   0x02 Player 1 #2
@@ -184,7 +174,6 @@ information is contained:
     *   0x08 Player 1 #4
     *   0x10 Player 1 #5
     *   0x20 Player 1 #6
-
 *   Byte 4
     *   0x01 Player 1 #7
     *   0x02 Player 1 #8
@@ -192,7 +181,6 @@ information is contained:
     *   0x08 Player 1 #10
     *   0x10 Player 1 #11
     *   0x20 Player 1 #12
-
 *   Byte 5
     *   0x01 Player 1 #13
     *   0x02 Player 1 #14
@@ -200,7 +188,6 @@ information is contained:
     *   0x08 Player 1 #16
     *   0x10 Player 1 #17
     *   0x20 Player 1 #18
-
 *   Byte 6
     *   0x01 Player 1 #19
     *   0x02 (reserved)
@@ -208,7 +195,6 @@ information is contained:
     *   0x08 (reserved)
     *   0x10 (reserved)
     *   0x20 (reserved)
-
 *   Byte 7
     *   0x01 Player 2 menu left
     *   0x02 Player 2 menu right
@@ -216,7 +202,6 @@ information is contained:
     *   0x08 Player 2 menu down
     *   0x10 Player 2 start
     *   0x20 Player 2 select
-
 *   Byte 8
     *   0x01 Player 2 back
     *   0x02 Player 2 coin
@@ -224,7 +209,6 @@ information is contained:
     *   0x08 Player 2 effect up
     *   0x10 Player 2 effect down
     *   0x20 (reserved)
-
 *   Byte 9
     *   0x01 Player 2 #1
     *   0x02 Player 2 #2
@@ -232,7 +216,6 @@ information is contained:
     *   0x08 Player 2 #4
     *   0x10 Player 2 #5
     *   0x20 Player 2 #6
-
 *   Byte 10
     *   0x01 Player 2 #7
     *   0x02 Player 2 #8
@@ -240,7 +223,6 @@ information is contained:
     *   0x08 Player 2 #10
     *   0x10 Player 2 #11
     *   0x20 Player 2 #12
-
 *   Byte 11
     *   0x01 Player 2 #13
     *   0x02 Player 2 #14
@@ -248,7 +230,6 @@ information is contained:
     *   0x08 Player 2 #16
     *   0x10 Player 2 #17
     *   0x20 Player 2 #18
-
 *   Byte 12
     *   0x01 Player 2 #19
     *   0x02 (reserved)
@@ -268,22 +249,18 @@ Currently, these mappings are:
     *   4 Pad down
     *   5 Pad up-left
     *   6 Pad up-right
-
-*   techno: Same as dance, plus
+*   techno: Same as dance, and also
     *   7 Pad center
     *   8 Pad down-left
     *   9 Pad down-right
-
 *   pump
     *   1 Pad up-left
     *   2 Pad up-right
     *   3 Pad center
     *   4 Pad down-left
     *   5 Pad down-right
-
 *   kb7
     *   1-7 Keys 1-7
-
 *   ez2
     *   1 Foot upper-left
     *   2 Foot upper-right
@@ -292,14 +269,12 @@ Currently, these mappings are:
     *   5 Hand upper-right
     *   6 Hand lower-left
     *   7 Hand lower-right
-
 *   para
     *   1 Button left
     *   2 Button up-left
     *   3 Button up
     *   4 Button up-right
     *   5 Button right
-
 *   ds3ddx
     *   1 Hand left
     *   2 Foot down-left
@@ -309,18 +284,15 @@ Currently, these mappings are:
     *   6 Foot up-right
     *   7 Foot down-right
     *   8 Hand right
-
 *   beat
     *   1-7 Keys 1-7
     *   8 Scratch up
     *   9 Scratch down
-
 *   maniax
     *   1 Sensor over-left
     *   2 Sensor over-right
     *   3 Sensor under-left
     *   4 Sensor under-right
-
 *   popn
     *   1 Button left white
     *   2 Button left yellow
@@ -332,8 +304,10 @@ Currently, these mappings are:
     *   8 Button right yellow
     *   9 Button right white
 
-Filesystem
-----------
+Platform notes
+--------------
+
+### RageFile
 
 The current implementation of this driver uses a `RageFile` for output.
 Therefore, any `RageFile`-based filesystem abstractions *are* applied.
@@ -343,27 +317,7 @@ FIXME: This behavior is probably permanent, but if it is not possible to
 open a Windows pipe using `RageFile`, `RageFile` should probably change
 so that it is.
 
-Pipes
------
-
-The output of this driver streams to a file. At face value, this is not
-too useful. The actual intent is for the system operator to create a
-*named fifo* or *named pipe* that is being listened to by some already
-running program, such as a program that sends light data out over a
-serial connection. It just happens that opening a named fifo for writing
-can be accomplished in the same fashion as opening a file for writing.
-Since there's an easy, platform-ignorant way to do that, that's what
-we've done.
-
-Note that this uses blocking I/O, so your light processing program must
-make sure to empty the fifo as quickly as it gets filled. If this
-driver's write blocks, parts of the application stall. If the program is
-non-trivial, using a separate thread dedicated to reading may be useful.
-
-How you actually start up the other end of the connection depends on
-your platform.
-
-### Linux (and some other unixish systems)
+### Linux (and some other unixish systems) FIFOs
 
 `mkfifo` is used to create a named FIFO. After this is done, two
 programs (one reading and one writing) open the FIFO as if it were some
@@ -375,7 +329,7 @@ read and write, respectively.
 Lighting programs accepting input on stdin work trivially; the FIFO is
 simply redirected into the program's stdin.
 
-### Windows
+### Windows named pipes
 
 The client side of a Windows named pipe is fairly ordinary; the path to
 an already-open pipe can be opened and used as if it were an ordinary
@@ -395,10 +349,31 @@ redirected.
 A Windows-specific lighting program might also just create and read a
 named pipe by itself.
 
+To-do
+-----
+
+*   Put the connection lifetime code in a large loop so that a
+    disconnect is followed at some point by a retry.
+*   Get this driver into non-Linux builds.
+*   `SextetStreamToFile` driver should be implemented to discard any
+    packets it is not able to write.
+*   Provide more example lighting programs
+    *   e.g. Bidirectional bridge to Arduino-based controller *and*
+        lights
+*   Create additional drivers
+    *   A TCP driver (`SextetStreamToSocket`) is needed.
+        *   An initial implementation based on EzSockets was withdrawn
+            because packets were being buffered, negating any utility,
+            and I wasn't able to convince the socket to flush instead of
+            buffering.
+    *   A POSIX select()-based non-blocking I/O driver
+        (`SextetStreamToSelectFile`) is needed.
+        *   A workalike to this is also needed for Windows.
+
 License
 =======
 
-Copyright © 2014 Peter S. May
+Copyright © 2014-2016 Peter S. May
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the


### PR DESCRIPTION
A proposed new version of SextetStream drivers. The main changes:

* A new `SextetStreamFromSocket` driver has been implemented (using EzSockets) to recieve game inputs over a TCP connection.
    * Buffering behavior with either EzSockets or the test lighting program has so far been uncooperative with my efforts to make a TCP lights driver, but I intend to have that eventually as well.
* In the interest of easing new implementations, some of the more reusable code has been broken out into the `src/Sextets` hierarchy and is designed to look and act more like actual object-oriented code than previously.
    * This work has been put to use with the new `SextetStreamFromSocket` driver.
    * I anticipate possible pushback on the location of this code; if this code belongs somewhere other than `src/Sextets`, please offer suggestions.
* Documentation has been improved.

Screenshot: The documented test programs (not included but available elsewhere on GitHub; see docs), which simulate external input and lights:

![stepmania-with-sextetstream-tests](https://cloud.githubusercontent.com/assets/4047532/16417534/4a603b18-3d14-11e6-85df-5f77e9f22aaa.png)