### PR TITLE
Revert "Merge pull request #1173 from kyzentun/no_alloca_in_sound"

### DIFF
--- a/src/RageSoundReader_Resample_Good.cpp
+++ b/src/RageSoundReader_Resample_Good.cpp
@@ -668,6 +668,7 @@ int RageSoundReader_Resample_Good::Read( float *pBuf, int iFrames )
 	{
 		int iFramesNeeded = m_apResamplers[0]->NumInputsForOutputSamples(iFrames);
 		float *pTmpBuf = (float *) alloca( iFramesNeeded * sizeof(float) * iChannels );
+		ASSERT( pTmpBuf != NULL );
 		int iFramesIn = m_pSource->Read( pTmpBuf, iFramesNeeded );
 		if( iFramesIn < 0 )
 			return iFramesIn;

--- a/src/RageSoundReader_SpeedChange.cpp
+++ b/src/RageSoundReader_SpeedChange.cpp
@@ -89,11 +89,10 @@ int RageSoundReader_SpeedChange::FillData( int iMaxFrames )
 		if( iBytesToRead <= 0 )
 			return m_iDataBufferAvailFrames;
 
-		float* pTempBuffer= new float[iBytesToRead/sizeof(float)];
+		float *pTempBuffer = (float *) alloca( iBytesToRead );
 		int iGotFrames = m_pSource->Read( pTempBuffer, iFramesToRead );
 		if( iGotFrames < 0 )
 		{
-			delete[] pTempBuffer;
 			if( iGotFrames == END_OF_FILE && m_iDataBufferAvailFrames )
 				return m_iDataBufferAvailFrames;
 			return iGotFrames;
@@ -115,7 +114,6 @@ int RageSoundReader_SpeedChange::FillData( int iMaxFrames )
 				++pOut;
 			}
 		}
-		delete[] pTempBuffer;
 
 		m_iDataBufferAvailFrames += iGotFrames;
 	}

--- a/src/RageSoundReader_WAV.cpp
+++ b/src/RageSoundReader_WAV.cpp
@@ -289,6 +289,7 @@ public:
 		int iMaxSize = min( (int) m_WavData.m_iBlockAlign - 7 * m_WavData.m_iChannels, (m_WavData.m_iDataChunkSize+m_WavData.m_iDataChunkPos) - m_File.Tell() );
 
 		char *pBuf = (char *) alloca( iMaxSize );
+		ASSERT( pBuf != NULL );
 
 		int iBlockSize = m_File.Read( pBuf, iMaxSize );
 		if( iBlockSize == 0 )

--- a/src/RageSurface_Load_PNG.cpp
+++ b/src/RageSurface_Load_PNG.cpp
@@ -50,10 +50,7 @@ void PNG_Error( png_struct *png, const char *error )
 	strncpy( info->err, error, 1024 );
 	info->err[1023] = 0;
 	LOG->Trace( "loading \"%s\": err: %s", info->fn, info->err );
-	// This exception is just thrown to go to the catch block for cleanup.  The
-	// message has already been printed, so the exception value can be ignored.
-	// -Kyz
-	throw int(1);
+	longjmp( png_jmpbuf(png), 1 );
 }
 
 void PNG_Warning( png_struct *png, const char *warning )
@@ -90,10 +87,12 @@ static RageSurface *RageSurface_Load_PNG( RageFile *f, const char *fn, char erro
 
 	RageSurface *volatile img = NULL;
 	CHECKPOINT_M("Potential issue with png jump about to be analyzed.");
-
-	png_byte** row_pointers= NULL;
-	try
+	if( setjmp(png_jmpbuf(png) ))
 	{
+		png_destroy_read_struct( &png, &info_ptr, NULL );
+		delete img;
+		return NULL;
+	}
 
 	png_set_read_fn( png, f, RageFile_png_read );
 
@@ -228,7 +227,8 @@ static RageSurface *RageSurface_Load_PNG( RageFile *f, const char *fn, char erro
 	}
 	ASSERT( img != NULL );
 
-	row_pointers = new png_byte*[height];
+	/* alloca to prevent memleaks if libpng longjmps us */
+	png_byte **row_pointers = (png_byte **) alloca( sizeof(png_byte*) * height );
 	CHECKPOINT_M( ssprintf("%p",row_pointers) );
 
 	for( unsigned y = 0; y < height; ++y )
@@ -241,17 +241,6 @@ static RageSurface *RageSurface_Load_PNG( RageFile *f, const char *fn, char erro
 
 	png_read_end( png, info_ptr );
 	png_destroy_read_struct( &png, &info_ptr, NULL );
-	}
-	catch(int e)
-	{
-		png_destroy_read_struct(&png, &info_ptr, NULL);
-		delete img;
-		if(row_pointers != NULL)
-		{
-			delete[] row_pointers;
-		}
-		return NULL;
-	}
 
 	return img;
 }


### PR DESCRIPTION
> This reverts commit 019ef5728a6a7d25a870362f6bc49c0348f06cc3, reversing changes made to 4305c8a78604a9970aae56ca0ab54179a63870e4.

StepMania would crash on OS X when a non-png image with a .png was encountered.  While it initially seemed that the recent commit re-enabling exceptions on OS X was the cause, reverting that commit did not fix the crash on OS X.

Rather, it seems that 019ef5728a6a7d25a870362f6bc49c0348f06cc3 introduced the crash on OS X; commit e5906168739d647477ded952855d0459880cf883 (OS X exceptions) can be left alone.