### PR TITLE
5.1 mod language rewrite

### DIFF
--- a/src/ModValue.cpp
+++ b/src/ModValue.cpp
@@ -7,63 +7,412 @@
 #include "RageMath.h"
 #include "LuaBinding.h"
 
-using std::vector;
-
-/*
-static const vector<string> mod_names= {
-	"alternate", "beat", "blind", "blink", "boomerang", "boost", "brake",
-	"bumpy", "centered", "confusion", "cover", "cross", "dark", "dizzy",
-	"drunk", "expand", "flip", "hidden", "hidden_offset", "invert",
-	"max_scroll_bpm", "mini", "no_attack", "pass_mark", "player_autoplayer",
-	"rand_attack", "random_speed", "random_vanish", "reverse", "roll",
-	"scroll_speed", "skew", "split", "stealth", "sudden", "sudden_offset",
-	"tilt", "time_spacing", "tiny", "tipsy", "tornado", "twirl", "wave",
-	"xmode"
+enum mut
+{
+	mut_never,
+	mut_frame,
+	mut_note
 };
-*/
 
-static const char* ModInputTypeNames[] = {
-	"Scalar",
-	"EvalBeat",
-	"EvalSecond",
-	"MusicBeat",
-	"MusicSecond",
-	"DistBeat",
-	"DistSecond",
-	"YOffset",
-	"StartDistBeat",
-	"StartDistSecond",
-	"EndDistBeat",
-	"EndDistSecond",
-	"NoteTimeRandom",
-	"MusicTimeRandom",
-	"StageRandom",
-};
-XToString(ModInputType);
-LuaXType(ModInputType);
+struct mod_operand
+{
+	virtual ~mod_operand() {}
+	virtual mut get_update_type()= 0;
+	virtual double evaluate(mod_val_inputs& input)= 0;
+	virtual bool needs_beat()= 0;
+	virtual bool needs_second()= 0;
+	virtual bool needs_y_offset()= 0;
 
-static const char* ModFunctionTypeNames[] = {
-	"Constant",
-	"Product",
-	"Power",
-	"Log",
-	"Sine",
-	"Tan",
-	"Square",
-	"Triangle",
-	"Spline",
+	mut m_update_type;
 };
-XToString(ModFunctionType);
-LuaXType(ModFunctionType);
 
-static const char* ModSumTypeNames[] = {
-	"Add",
-	"Subtract",
-	"Multiply",
-	"Divide",
+struct mod_input_number : mod_operand
+{
+	double m_value;
+	virtual double evaluate(mod_val_inputs&)
+	{ return m_value;	}
+	virtual mut get_update_type()
+	{ return mut_never; }
+	virtual bool needs_beat()
+	{ return false; }
+	virtual bool needs_second()
+	{ return false; }
+	virtual bool needs_y_offset()
+	{ return false; }
 };
-XToString(ModSumType);
-LuaXType(ModSumType);
+
+#define SIMPLE_MOD_INPUT_TYPE(field_name, update, beat, second, yoff)	\
+struct mod_input_##field_name : mod_operand \
+{ \
+	virtual double evaluate(mod_val_inputs& input) \
+	{ return input.field_name; } \
+	virtual mut get_update_type() \
+	{ return update; } \
+	virtual bool needs_beat() \
+	{ return beat; } \
+	virtual bool needs_second() \
+	{ return second; } \
+	virtual bool needs_y_offset() \
+	{ return yoff; } \
+};
+
+SIMPLE_MOD_INPUT_TYPE(column, mut_never, false, false, false);
+SIMPLE_MOD_INPUT_TYPE(y_offset, mut_note, false, false, true);
+SIMPLE_MOD_INPUT_TYPE(note_id_in_chart, mut_note, false, false, false);
+SIMPLE_MOD_INPUT_TYPE(note_id_in_column, mut_note, false, false, false);
+SIMPLE_MOD_INPUT_TYPE(row_id, mut_note, false, false, false);
+SIMPLE_MOD_INPUT_TYPE(eval_beat, mut_note, true, false, false);
+SIMPLE_MOD_INPUT_TYPE(eval_second, mut_note, false, true, false);
+SIMPLE_MOD_INPUT_TYPE(music_beat, mut_frame, true, false, false);
+SIMPLE_MOD_INPUT_TYPE(music_second, mut_frame, false, true, false);
+SIMPLE_MOD_INPUT_TYPE(dist_beat, mut_note, true, false, false);
+SIMPLE_MOD_INPUT_TYPE(dist_second, mut_note, false, true, false);
+// start_dist and end dist can be done with:
+// {"MO_subtract", "MI_music_beat" "MI_start_beat"}
+SIMPLE_MOD_INPUT_TYPE(start_beat, mut_never, true, false, false);
+SIMPLE_MOD_INPUT_TYPE(start_second, mut_never, false, true, false);
+SIMPLE_MOD_INPUT_TYPE(end_beat, mut_never, true, false, false);
+SIMPLE_MOD_INPUT_TYPE(end_second, mut_never, false, true, false);
+
+#undef SIMPLE_MOD_INPUT_TYPE
+
+enum mit
+{
+	mit_number,
+	mit_column,
+	mit_y_offset,
+	mit_note_id_in_chart,
+	mit_note_id_in_column,
+	mit_row_id,
+	mit_eval_beat,
+	mit_eval_second,
+	mit_music_beat,
+	mit_music_second,
+	mit_dist_beat,
+	mit_dist_second,
+	mit_start_beat,
+	mit_start_second,
+	mit_end_beat,
+	mit_end_second
+};
+
+struct mod_operator : mod_operand
+{
+	virtual ~mod_operator()
+	{
+		for(auto&& op : m_operands)
+		{
+			delete op;
+			op= nullptr;
+		}
+	}
+	virtual double evaluate(mod_val_inputs& input)= 0;
+	virtual void load_from_lua(mod_function* parent, lua_State* L, int index);
+	mut get_update_type() { return m_update_type; }
+	virtual void per_frame_update(mod_val_inputs& input);
+	virtual void per_note_update(mod_val_inputs& input);
+	virtual bool needs_beat();
+	virtual bool needs_second();
+	virtual bool needs_y_offset();
+
+	mut m_update_type;
+	vector<mod_operand*> m_operands;
+	vector<double> m_operand_results;
+	vector<size_t> m_per_note_operands;
+	vector<size_t> m_per_frame_operands;
+};
+
+static mod_operand* load_single_operand(mod_function* parent, lua_State* L, int operator_index,
+	size_t operand_index);
+static void load_operands_into_container(mod_function* parent, lua_State* L, int index,
+	vector<mod_operand*>& container);
+static void organize_simple_operands(mod_function* parent, mod_operator* self);
+static mod_operand* create_simple_input(std::string const& input_type, double value);
+
+#define PER_NOTE_UPDATE_IF if(!m_per_note_operands.empty()) { per_note_update(input); }
+#define EVAL_RESULT_EVAL \
+virtual double evaluate(mod_val_inputs& input) \
+{ \
+	PER_NOTE_UPDATE_IF; \
+	return m_eval_result; \
+}
+
+#define plus_wrap(left, right) (left + right)
+#define subtract_wrap(left, right) (left - right)
+#define multiply_wrap(left, right) (left * right)
+#define divide_wrap(left, right) (left / right)
+
+#define SIMPLE_OPERATOR(op_name, eval) \
+struct mod_operator_##op_name : mod_operator \
+{ \
+	virtual double evaluate(mod_val_inputs& input) \
+	{ \
+		PER_NOTE_UPDATE_IF; \
+		double ret= m_operand_results[0]; \
+		for(size_t cur= 1; cur < m_operand_results.size(); ++cur) \
+		{ \
+			ret= eval(ret, m_operand_results[cur]); \
+		} \
+		return ret; \
+	} \
+	void add_simple_operand(std::string const& input_type, double value) \
+	{ m_operands.push_back(create_simple_input(input_type, value)); } \
+};
+
+static double log_wrapper(double left, double right)
+{
+	return log(left) / log(right);
+}
+
+SIMPLE_OPERATOR(add, plus_wrap);
+SIMPLE_OPERATOR(subtract, subtract_wrap);
+SIMPLE_OPERATOR(multiply, multiply_wrap);
+SIMPLE_OPERATOR(divide, divide_wrap);
+SIMPLE_OPERATOR(exp, pow);
+SIMPLE_OPERATOR(log, log_wrapper);
+
+#undef plus_wrap
+#undef subtract_wrap
+#undef multiply_wrap
+#undef divide_wrap
+#undef SIMPLE_OPERATOR
+
+#define WAVE_OPERATOR(op_name, wave_eval) \
+struct mod_operator_##op_name : mod_operator \
+{ \
+	EVAL_RESULT_EVAL; \
+	virtual void load_from_lua(mod_function* parent, lua_State* L, int index) \
+	{ \
+		mod_operator::load_from_lua(parent, L, index); \
+		if(m_operands.size() != 1) \
+		{ \
+			throw std::string("Wave functions only take one operand."); \
+		} \
+		if(m_update_type == mut_never) \
+		{ \
+			double angle= m_operand_results[0]; \
+			m_eval_result= (wave_eval); \
+		} \
+	} \
+	virtual void per_frame_update(mod_val_inputs& input) \
+	{ \
+		mod_operator::per_frame_update(input); \
+		double angle= m_operand_results[0]; \
+		m_eval_result= (wave_eval); \
+	} \
+	virtual void per_note_update(mod_val_inputs& input) \
+	{ \
+		mod_operator::per_note_update(input); \
+		double angle= m_operand_results[0]; \
+		m_eval_result= (wave_eval); \
+	} \
+	double m_eval_result; \
+};
+
+static double square_wave(double angle)
+{
+	angle= fmod(angle, Rage::D_PI * 2.0);
+	if(angle < 0.0)
+	{
+		angle+= Rage::D_PI * 2.0;
+	}
+	return angle >= Rage::D_PI ? -1.0 : 1.0;
+}
+
+static double triangle_wave(double angle)
+{
+	angle= fmod(angle, Rage::D_PI * 2.0);
+	if(angle < 0.0)
+	{
+		angle+= Rage::D_PI * 2.0;
+	}
+	double result= angle * Rage::D_PI_REC;
+	if(result < .5)
+	{
+		return result * 2.0;
+	}
+	else if(result < 1.5)
+	{
+		return 1.0 - ((result - .5) * 2.0);
+	}
+	else
+	{
+		return -4.0 + (result * 2.0);
+	}
+}
+
+WAVE_OPERATOR(sine, (Rage::FastSin(angle)));
+WAVE_OPERATOR(cos, (Rage::FastCos(angle)));
+WAVE_OPERATOR(tan, (tan(angle)));
+WAVE_OPERATOR(square, (square_wave(angle)));
+WAVE_OPERATOR(triangle, (triangle_wave(angle)));
+
+#undef WAVE_OPERATOR
+
+struct mod_operator_random : mod_operator
+{
+	virtual void load_from_lua(mod_function* parent, lua_State* L, int index)
+	{
+		mod_operator::load_from_lua(parent, L, index);
+		if(m_operands.size() != 1)
+		{
+			throw std::string("Random operator only takes one operand.");
+		}
+		if(m_update_type == mut_never)
+		{
+			m_eval_result= GAMESTATE->simple_stage_frandom(m_operand_results[0]);
+		}
+	}
+	EVAL_RESULT_EVAL;
+	void per_frame_update(mod_val_inputs& input);
+	void per_note_update(mod_val_inputs& input);
+	double m_eval_result;
+};
+
+struct mod_operator_phase : mod_operator
+{
+	EVAL_RESULT_EVAL;
+	virtual void load_from_lua(mod_function* parent, lua_State* L, int index);
+	struct phase
+	{
+		phase()
+			:start(0.0), finish(0.0), mult(1.0), offset(0.0)
+		{}
+		double start;
+		double finish;
+		double mult;
+		double offset;
+	};
+	phase const* find_phase(double input);
+	void phase_eval();
+	void per_frame_update(mod_val_inputs& input);
+	void per_note_update(mod_val_inputs& input);
+	double m_eval_result;
+	vector<phase> m_phases;
+	phase m_default_phase;
+};
+
+struct mod_operator_repeat : mod_operator
+{
+	mod_operator_repeat()
+		:m_rep_begin(0.0), m_rep_end(0.0)
+	{}
+	EVAL_RESULT_EVAL;
+	void repeat_eval();
+	virtual void load_from_lua(mod_function* parent, lua_State* L, int index);
+	void per_frame_update(mod_val_inputs& input);
+	void per_note_update(mod_val_inputs& input);
+	double m_eval_result;
+	double m_rep_begin;
+	double m_rep_end;
+};
+
+struct mod_operator_spline : mod_operator
+{
+	mod_operator_spline()
+		:m_loop(false), m_polygonal(false), m_has_per_frame_points(false),
+		 m_has_per_note_points(false)
+	{}
+	EVAL_RESULT_EVAL;
+	void spline_eval();
+	virtual void load_from_lua(mod_function* parent, lua_State* L, int index);
+	void per_frame_update(mod_val_inputs& input);
+	void per_note_update(mod_val_inputs& input);
+
+	double m_eval_result;
+	CubicSpline m_spline;
+	bool m_loop;
+	bool m_polygonal;
+	bool m_has_per_frame_points;
+	bool m_has_per_note_points;
+};
+
+#undef EVAL_RESULT_EVAL
+
+enum mot
+{
+	mot_add,
+	mot_subtract,
+	mot_multiply,
+	mot_divide,
+	mot_exp,
+	mot_log,
+	mot_sine,
+	mot_cos,
+	mot_tan,
+	mot_square,
+	mot_triangle,
+	mot_random,
+	mot_phase,
+	mot_repeat,
+	mot_spline
+};
+
+static mod_operand* create_mod_operator(mod_function* parent, lua_State* L, int index);
+static mod_operand* create_mod_input(lua_State* L, int index);
+static mod_operand* load_operand_on_stack(mod_function* parent, lua_State* L);
+
+struct mod_function
+{
+	mod_function(ModifiableValue* parent, double col)
+		:m_priority(0), m_sum_type(mot_add),
+		 m_start_beat(invalid_modfunction_time),
+		 m_start_second(invalid_modfunction_time),
+		 m_end_beat(invalid_modfunction_time),
+		 m_end_second(invalid_modfunction_time),
+		 m_base_operand(nullptr), m_column(col),
+		 m_parent(parent)
+	{}
+	~mod_function();
+	void change_parent(ModifiableValue* new_parent)
+	{
+		m_parent= new_parent;
+	}
+
+
+	double evaluate(mod_val_inputs& input);
+	double evaluate_with_time(mod_val_inputs& input);
+	void load_from_lua(lua_State* L, int index, uint32_t col);
+	void simple_load(std::string const& name, std::string const& input_type,
+		double value);
+	void add_per_frame_operator(mod_operator* op);
+
+	void calc_unprovided_times(TimingData const* timing);
+	bool needs_beat();
+	bool needs_second();
+	bool needs_y_offset();
+	std::string const& get_name() { return m_name; }
+	void set_input_fields(mod_val_inputs& input)
+	{
+		input.column= m_column;
+		input.set_time(m_start_beat, m_start_second, m_end_beat, m_end_second);
+	}
+
+	// needs_per_frame_update exists so that ModifiableValue can check after
+	// creating a mod_function to see if it needs to be added to the manager for
+	// solving every frame.
+	bool needs_per_frame_update();
+	void per_frame_update(mod_val_inputs& input);
+
+	int m_priority;
+	mot m_sum_type;
+	double m_start_beat;
+	double m_start_second;
+	double m_end_beat;
+	double m_end_second;
+
+private:
+	// do not use mod_function::operator=, too much pointer handling.
+	mod_function& operator=(mod_function&)
+	{return *this;}
+	mod_operand* m_base_operand;
+	vector<mod_operator*> m_per_frame_operators;
+	double m_column;
+
+	std::string m_name;
+	ModifiableValue* m_parent;
+};
+
 
 void ModManager::update(double curr_beat, double curr_second)
 {
@@ -158,7 +507,7 @@ void ModManager::update(double curr_beat, double curr_second)
 	}
 }
 
-void ModManager::add_mod(ModFunction* func, ModifiableValue* parent)
+void ModManager::add_mod(mod_function* func, ModifiableValue* parent)
 {
 	if(func->m_start_second > m_prev_curr_second)
 	{
@@ -174,7 +523,7 @@ void ModManager::add_mod(ModFunction* func, ModifiableValue* parent)
 	}
 }
 
-void ModManager::remove_mod(ModFunction* func)
+void ModManager::remove_mod(mod_function* func)
 {
 	for(auto&& managed_list : {&m_past_funcs, &m_present_funcs, &m_future_funcs})
 	{
@@ -204,7 +553,7 @@ void ModManager::remove_all_mods(ModifiableValue* parent)
 	}
 }
 
-void ModManager::add_to_per_frame_update(ModFunction* func)
+void ModManager::add_to_per_frame_update(mod_function* func)
 {
 	if(func->needs_per_frame_update())
 	{
@@ -212,7 +561,7 @@ void ModManager::add_to_per_frame_update(ModFunction* func)
 	}
 }
 
-void ModManager::remove_from_per_frame_update(ModFunction* func)
+void ModManager::remove_from_per_frame_update(mod_function* func)
 {
 	auto entry= m_per_frame_update_funcs.find(func);
 	if(entry != m_per_frame_update_funcs.end())
@@ -234,7 +583,7 @@ void ModManager::dump_list_status()
 	}
 }
 
-void ModManager::insert_into_past(ModFunction* func, ModifiableValue* parent)
+void ModManager::insert_into_past(mod_function* func, ModifiableValue* parent)
 {
 	// m_past_funcs is sorted in descending end second order.  Entries with the
 	// same end second are sorted in undefined order.
@@ -252,7 +601,7 @@ void ModManager::insert_into_past(ModFunction* func, ModifiableValue* parent)
 	m_past_funcs.push_back(func_and_parent(func, parent));
 }
 
-void ModManager::insert_into_present(ModFunction* func, ModifiableValue* parent)
+void ModManager::insert_into_present(mod_function* func, ModifiableValue* parent)
 {
 	add_to_per_frame_update(func);
 	parent->add_mod_to_active_list(func);
@@ -271,7 +620,7 @@ void ModManager::insert_into_present(ModFunction* func, ModifiableValue* parent)
 	m_present_funcs.push_back(func_and_parent(func, parent));
 }
 
-void ModManager::insert_into_future(ModFunction* func, ModifiableValue* parent)
+void ModManager::insert_into_future(mod_function* func, ModifiableValue* parent)
 {
 	// m_future_funcs is sorted in ascending start second order.  Entries with
 	// the same start second are sorted in undefined order.
@@ -293,23 +642,333 @@ void ModManager::remove_from_present(std::list<func_and_parent>::iterator fapi)
 	m_present_funcs.erase(fapi);
 }
 
-void ModInput::init_simple(ModFunction* parent, ModInputType input_type,
-	double input_scalar)
+
+static mot str_to_mot(std::string const& str)
 {
-	clear();
-	m_parent= parent;
-	set_type(input_type);
-	m_scalar= input_scalar;
+#define CONVENT(field_name) {#field_name, mot_##field_name}
+	static std::unordered_map<std::string, mot> conversion= {
+		{"+", mot_add},
+		{"-", mot_subtract},
+		{"*", mot_multiply},
+		{"/", mot_divide},
+		{"^", mot_exp},
+		{"v", mot_log},
+		CONVENT(add),
+		CONVENT(subtract),
+		CONVENT(multiply),
+		CONVENT(divide),
+		CONVENT(exp),
+		CONVENT(log),
+		CONVENT(sine),
+		CONVENT(cos),
+		CONVENT(tan),
+		CONVENT(square),
+		CONVENT(triangle),
+		CONVENT(random),
+		CONVENT(phase),
+		CONVENT(repeat),
+		CONVENT(spline)
+	};
+#undef CONVENT
+	auto entry= conversion.find(str);
+	if(entry == conversion.end())
+	{
+		throw std::string(fmt::sprintf("Invalid mod operator type: %s", str.c_str()));
+	}
+	return entry->second;
 }
 
-void ModInput::clear()
+static mod_operand* create_mod_operator(mod_function* parent, lua_State* L, int index)
 {
-	m_type= MIT_Scalar;
-	m_scalar= 0.0;
-	m_offset= 0.0;
-	m_rep_begin= 0.0;
-	m_rep_end= 0.0;
-	m_phases.clear();
+	lua_rawgeti(L, index, 1);
+	if(lua_type(L, -1) != LUA_TSTRING)
+	{
+		lua_pop(L, 1);
+		throw std::string("Mod operator type must be a string.");
+	}
+	std::string str_type= lua_tostring(L, -1);
+	lua_pop(L, 1);
+	mot op_type= str_to_mot(str_type);
+	mod_operator* new_oper= nullptr;
+#define SET_NEW(op_name) \
+	case mot_##op_name: new_oper= new mod_operator_##op_name; break;
+	switch(op_type)
+	{
+		SET_NEW(add);
+		SET_NEW(subtract);
+		SET_NEW(multiply);
+		SET_NEW(divide);
+		SET_NEW(exp);
+		SET_NEW(log);
+		SET_NEW(sine);
+		SET_NEW(cos);
+		SET_NEW(tan);
+		SET_NEW(square);
+		SET_NEW(triangle);
+		SET_NEW(random);
+		SET_NEW(phase);
+		SET_NEW(repeat);
+		SET_NEW(spline);
+		default: break;
+	}
+#undef SET_NEW
+	if(new_oper == nullptr)
+	{
+		throw std::string("Unknown mod operator type.");
+	}
+	try
+	{
+		new_oper->load_from_lua(parent, L, index);
+	}
+	catch(std::string err)
+	{
+		delete new_oper;
+		throw err;
+	}
+	return new_oper;
+}
+
+static mit str_to_mit(std::string const& str)
+{
+#define CONVENT(field_name) {#field_name, mit_##field_name}
+	static std::unordered_map<std::string, mit> conversion= {
+		CONVENT(column),
+		CONVENT(y_offset),
+		CONVENT(note_id_in_chart),
+		CONVENT(note_id_in_column),
+		CONVENT(row_id),
+		CONVENT(eval_beat),
+		CONVENT(eval_second),
+		CONVENT(music_beat),
+		CONVENT(music_second),
+		CONVENT(dist_beat),
+		CONVENT(dist_second),
+		CONVENT(start_beat),
+		CONVENT(start_second),
+		CONVENT(end_beat),
+		CONVENT(end_second)
+	};
+#undef CONVENT
+	auto entry= conversion.find(str);
+	if(entry == conversion.end())
+	{
+		throw std::string(fmt::sprintf("Invalid mod input type: %s", str.c_str()));
+	}
+	return entry->second;
+}
+
+static mod_operand* create_mod_input(std::string const& str_type)
+{
+	mit type= str_to_mit(str_type);
+#define RET_ENTRY(field_name) \
+	case mit_##field_name: return new mod_input_##field_name;
+#define ENTRY_BS_PAIR(base) RET_ENTRY(base##_beat); RET_ENTRY(base##_second);
+	switch(type)
+	{
+		RET_ENTRY(column);
+		RET_ENTRY(y_offset);
+		RET_ENTRY(note_id_in_chart);
+		RET_ENTRY(note_id_in_column);
+		RET_ENTRY(row_id);
+		ENTRY_BS_PAIR(eval);
+		ENTRY_BS_PAIR(music);
+		ENTRY_BS_PAIR(dist);
+		ENTRY_BS_PAIR(start);
+		ENTRY_BS_PAIR(end);
+		default: break;
+	}
+#undef ENTRY_BS_PAIR
+#undef RET_ENTRY
+	throw std::string(fmt::sprintf("Unknown mod input type: %s", str_type.c_str()));
+}
+
+static mod_operand* create_mod_input(lua_State* L, int index)
+{
+	if(lua_type(L, index) == LUA_TNUMBER)
+	{
+		mod_input_number* ret= new mod_input_number;
+		ret->m_value= lua_tonumber(L, index);
+		return ret;
+	}
+	std::string str= lua_tostring(L, index);
+	return create_mod_input(str);
+}
+
+static mod_operand* create_simple_input(std::string const& input_type, double value)
+{
+	if(input_type == "number")
+	{
+		mod_input_number* op= new mod_input_number;
+		op->m_value= value;
+		return op;
+	}
+	else
+	{
+		try
+		{
+			mod_operand* op= create_mod_input(input_type);
+			return op;
+		}
+		catch(std::string err)
+		{
+			LuaHelpers::ReportScriptError("lol kyz messed up");
+			LuaHelpers::ReportScriptError(err);
+			mod_input_number* op= new mod_input_number;
+			op->m_value= value;
+			return op;
+		}
+	}
+}
+
+static mod_operand* load_operand_on_stack(mod_function* parent, lua_State* L)
+{
+	int op_index= lua_gettop(L);
+	mod_operand* new_oper= nullptr;
+	try
+	{
+		switch(lua_type(L, op_index))
+		{
+			case LUA_TTABLE:
+				if(lua_objlen(L, op_index) < 2)
+				{
+					throw std::string("Mod operator table must have at least two elements.");
+				}
+				new_oper= create_mod_operator(parent, L, op_index);
+				break;
+			case LUA_TNUMBER:
+			case LUA_TSTRING:
+				new_oper= create_mod_input(L, op_index);
+				break;
+			default:
+				throw std::string("Invalid operand type.");
+				break;
+		}
+	}
+	catch(std::string err)
+	{
+		lua_pop(L, 1);
+		throw err;
+	}
+	lua_pop(L, 1);
+	return new_oper;
+}
+
+static mod_operand* load_single_operand(mod_function* parent, lua_State* L, int operator_index,
+	size_t operand_index)
+{
+	lua_rawgeti(L, operator_index, operand_index);
+	return load_operand_on_stack(parent, L);
+}
+
+static void load_operands_into_container(mod_function* parent, lua_State* L, int index,
+	vector<mod_operand*>& container)
+{
+	// index points to operator table.
+	// first entry in the table is the type of the operator.
+	size_t last_operand= lua_objlen(L, index);
+	container.reserve(last_operand - 1);
+	for(size_t cur= 2; cur <= last_operand; ++cur)
+	{
+		try
+		{
+			mod_operand* new_oper= load_single_operand(parent, L, index, cur);
+			container.push_back(new_oper);
+		}
+		catch(std::string err)
+		{
+			for(auto&& op : container) { delete op; }
+			container.clear();
+			throw err;
+		}
+	}
+}
+
+static void organize_simple_operands(mod_function* parent, mod_operator* self)
+{
+	self->m_operand_results.resize(self->m_operands.size());
+	mut most_frequent_update_type= mut_never;
+	mod_val_inputs input_for_never(0.0, 0.0);
+	parent->set_input_fields(input_for_never);
+	for(size_t op= 0; op < self->m_operands.size(); ++op)
+	{
+		mut op_update= self->m_operands[op]->get_update_type();
+		if(op_update > most_frequent_update_type)
+		{
+			most_frequent_update_type= op_update;
+		}
+		switch(op_update)
+		{
+			case mut_never:
+				self->m_operand_results[op]= self->m_operands[op]->evaluate(input_for_never);
+				break;
+			case mut_frame:
+				self->m_per_frame_operands.push_back(op);
+				break;
+			case mut_note:
+				self->m_per_note_operands.push_back(op);
+				break;
+			default:
+				break;
+		}
+	}
+	self->m_update_type= most_frequent_update_type;
+	if(!self->m_per_frame_operands.empty())
+	{
+		parent->add_per_frame_operator(self);
+	}
+}
+
+void mod_operator::load_from_lua(mod_function* parent, lua_State* L, int index)
+{
+	load_operands_into_container(parent, L, index, m_operands);
+	organize_simple_operands(parent, this);
+}
+
+void mod_operator::per_frame_update(mod_val_inputs& input)
+{
+	for(auto&& op : m_per_frame_operands)
+	{
+		m_operand_results[op]= m_operands[op]->evaluate(input);
+	}
+}
+
+void mod_operator::per_note_update(mod_val_inputs& input)
+{
+	for(auto&& op : m_per_note_operands)
+	{
+		m_operand_results[op]= m_operands[op]->evaluate(input);
+	}
+}
+
+#define MOD_OP_NEEDS_THING(thing) \
+bool mod_operator::needs_##thing() \
+{ \
+	for(auto&& op : m_operands) \
+	{ \
+		if(op->needs_##thing()) \
+		{ \
+			return true; \
+		} \
+	} \
+	return false; \
+}
+
+MOD_OP_NEEDS_THING(beat);
+MOD_OP_NEEDS_THING(second);
+MOD_OP_NEEDS_THING(y_offset);
+
+#undef MOD_OP_NEEDS_THING
+
+void mod_operator_random::per_frame_update(mod_val_inputs& input)
+{
+	mod_operator::per_frame_update(input);
+	m_eval_result= GAMESTATE->simple_stage_frandom(m_operand_results[0]);
+}
+
+void mod_operator_random::per_note_update(mod_val_inputs& input)
+{
+	mod_operator::per_note_update(input);
+	m_eval_result= GAMESTATE->simple_stage_frandom(m_operand_results[0]);
 }
 
 static void get_numbers(lua_State* L, int index, vector<double*> const& ret)
@@ -322,155 +981,52 @@ static void get_numbers(lua_State* L, int index, vector<double*> const& ret)
 	}
 }
 
-static void push_numbers(lua_State* L, vector<double*> const& noms)
-{
-	lua_createtable(L, noms.size(), 0);
-	for(size_t i= 0; i < noms.size(); ++i)
-	{
-		lua_pushnumber(L, *noms[i]);
-		lua_rawseti(L, -2, i+1);
-	}
-}
-
-void ModInput::push_phase(lua_State* L, size_t phase)
-{
-	push_numbers(L, {&m_phases[phase].start, &m_phases[phase].finish,
-					&m_phases[phase].mult, &m_phases[phase].offset});
-}
-
-void ModInput::push_def_phase(lua_State* L)
-{
-	push_numbers(L, {&m_default_phase.start, &m_default_phase.finish,
-					&m_default_phase.mult, &m_default_phase.offset});
-}
-
-void ModInput::load_rep(lua_State* L, int index)
+static void load_one_phase(lua_State* L, int index,
+	mod_operator_phase::phase& dest)
 {
 	if(lua_istable(L, index))
 	{
-		rep_apple= &ModInput::apply_rep;
-		get_numbers(L, index, {&m_rep_begin, &m_rep_end});
-	}
-	else
-	{
-		rep_apple= nullptr;
+		get_numbers(L, index, {&dest.start, &dest.finish, &dest.mult, &dest.offset});
 	}
 }
 
-void ModInput::load_one_phase(lua_State* L, int index, size_t phase)
-{
-	if(lua_istable(L, index))
-	{
-		get_numbers(L, index, {&m_phases[phase].start, &m_phases[phase].finish,
-					&m_phases[phase].mult, &m_phases[phase].offset});
-	}
-}
-
-void ModInput::load_def_phase(lua_State* L, int index)
-{
-	if(lua_istable(L, index))
-	{
-		get_numbers(L, index, {&m_default_phase.start, &m_default_phase.finish,
-					&m_default_phase.mult, &m_default_phase.offset});
-	}
-}
-
-void ModInput::load_phases(lua_State* L, int index)
-{
-	if(lua_istable(L, index))
-	{
-		enable_phases();
-		lua_getfield(L, index, "default");
-		load_def_phase(L, lua_gettop(L));
-		lua_pop(L, 1);
-		size_t num_phases= lua_objlen(L, index);
-		m_phases.resize(num_phases);
-		for(size_t i= 0; i < num_phases; ++i)
-		{
-			lua_rawgeti(L, index, i+1);
-			load_one_phase(L, lua_gettop(L), i);
-			lua_pop(L, 1);
-		}
-		sort_phases();
-	}
-}
-
-bool compare_phases(ModInput::phase left, ModInput::phase right)
+static bool compare_phases(mod_operator_phase::phase const& left, mod_operator_phase::phase const& right)
 {
 	return left.start < right.start;
 }
 
-void ModInput::sort_phases()
+void mod_operator_phase::load_from_lua(mod_function* parent, lua_State* L, int index)
 {
+	// {"phase", operand, {default= {start, finish, mult, offset}, ...}}
+	m_operands.push_back(load_single_operand(parent, L, index, 2));
+	organize_simple_operands(parent, this);
+	lua_rawgeti(L, index, 3);
+	int phase_index= lua_gettop(L);
+	if(!lua_istable(L, phase_index))
+	{
+		lua_pop(L, 1);
+		throw std::string("Cannot create phase operator without phase table.");
+	}
+	lua_getfield(L, phase_index, "default");
+	load_one_phase(L, lua_gettop(L), m_default_phase);
+	lua_pop(L, 1);
+	size_t num_phases= lua_objlen(L, phase_index);
+	m_phases.resize(num_phases);
+	for(size_t i= 0; i < num_phases; ++i)
+	{
+		lua_rawgeti(L, phase_index, i+1);
+		load_one_phase(L, lua_gettop(L), m_phases[i]);
+		lua_pop(L, 1);
+	}
 	stable_sort(m_phases.begin(), m_phases.end(), compare_phases);
-}
 
-void ModInput::load_spline(lua_State* L, int index)
-{
-	if(lua_istable(L, index))
+	if(m_update_type == mut_never)
 	{
-		enable_spline();
-		m_loop_spline= get_optional_bool(L, index, "loop");
-		m_polygonal_spline= get_optional_bool(L, index, "polygonal");
-		size_t num_points= lua_objlen(L, index);
-		m_spline.resize(num_points);
-		for(size_t p= 0; p < num_points; ++p)
-		{
-			lua_rawgeti(L, index, p+1);
-			m_spline.set_point(p, static_cast<float>(lua_tonumber(L, -1)));
-			lua_pop(L, 1);
-		}
-		m_spline.solve(m_loop_spline, m_polygonal_spline);
+		phase_eval();
 	}
 }
 
-void ModInput::load_from_lua(lua_State* L, int index, ModFunction* parent, uint32_t col)
-{
-	m_parent= parent;
-	m_column= col;
-	if(lua_isnumber(L, index))
-	{
-		set_type(MIT_Scalar);
-		m_scalar= lua_tonumber(L, index);
-		return;
-	}
-	if(lua_istable(L, index))
-	{
-		lua_rawgeti(L, index, 1);
-		set_type(Enum::Check<ModInputType>(L, -1));
-		lua_pop(L, 1);
-		// The use of lua_tonumber is deliberate.  If the scalar or offset value
-		// does not exist, lua_tonumber will return 0.
-		lua_rawgeti(L, index, 2);
-		m_scalar= lua_tonumber(L, -1);
-		lua_pop(L, 1);
-		lua_rawgeti(L, index, 3);
-		m_offset= lua_tonumber(L, -1);
-		lua_pop(L, 1);
-		lua_getfield(L, index, "rep");
-		load_rep(L, lua_gettop(L));
-		lua_pop(L, 1);
-		lua_getfield(L, index, "phases");
-		load_phases(L, lua_gettop(L));
-		lua_pop(L, 1);
-		lua_getfield(L, index, "spline");
-		load_spline(L, lua_gettop(L));
-		lua_pop(L, 1);
-	}
-}
-
-void ModInput::set_type(ModInputType t)
-{
-	ModInputMetaType old_meta_type= get_meta_type();
-	m_type= t;
-	ModInputMetaType new_meta_type= get_meta_type();
-	if(m_parent != nullptr && old_meta_type != new_meta_type)
-	{
-		m_parent->recategorize(this, old_meta_type, new_meta_type);
-	}
-}
-
-ModInput::phase const* ModInput::find_phase(double input)
+mod_operator_phase::phase const* mod_operator_phase::find_phase(double input)
 {
 	if(m_phases.empty() || input < m_phases.front().start || input >= m_phases.back().finish)
 	{
@@ -525,560 +1081,161 @@ ModInput::phase const* ModInput::find_phase(double input)
 	return &m_phases[lower];
 }
 
-double ModInput::apply_rep(double input)
+void mod_operator_phase::phase_eval()
 {
+	double res= m_operand_results[0];
+	phase const* cur= find_phase(res);
+	m_eval_result= ((res - cur->start) * cur->mult) + cur->offset;
+}
+
+void mod_operator_phase::per_frame_update(mod_val_inputs& input)
+{
+	mod_operator::per_frame_update(input);
+	phase_eval();
+}
+
+void mod_operator_phase::per_note_update(mod_val_inputs& input)
+{
+	mod_operator::per_note_update(input);
+	phase_eval();
+}
+
+void mod_operator_repeat::load_from_lua(mod_function* parent, lua_State* L, int index)
+{
+	m_operands.push_back(load_single_operand(parent, L, index, 2));
+	organize_simple_operands(parent, this);
+	m_rep_begin= 0.0;
+	m_rep_end= 0.0;
+	lua_rawgeti(L, index, 3);
+	if(lua_isnumber(L, -1))
+	{
+		m_rep_begin= lua_tonumber(L, -1);
+	}
+	lua_pop(L, 1);
+	lua_rawgeti(L, index, 4);
+	if(lua_isnumber(L, -1))
+	{
+		m_rep_end= lua_tonumber(L, -1);
+	}
+	lua_pop(L, 1);
+
+	if(m_update_type == mut_never)
+	{
+		repeat_eval();
+	}
+}
+
+void mod_operator_repeat::per_frame_update(mod_val_inputs& input)
+{
+	mod_operator::per_frame_update(input);
+	repeat_eval();
+}
+
+void mod_operator_repeat::per_note_update(mod_val_inputs& input)
+{
+	mod_operator::per_note_update(input);
+	repeat_eval();
+}
+
+void mod_operator_repeat::repeat_eval()
+{
+	double op_result= m_operand_results[0];
 	double const dist= m_rep_end - m_rep_begin;
-	double const mod_res= fmod(input, dist);
+	double const mod_res= fmod(op_result, dist);
 	if(mod_res < 0.0)
 	{
-		return mod_res + dist + m_rep_begin;
-	}
-	return mod_res + m_rep_begin;
-}
-
-double ModInput::pick(mod_val_inputs const& input)
-{
-	double ret= 0.0;
-	switch(m_type)
-	{
-		case MIT_Scalar:
-			ret= input.scalar;
-			break;
-		case MIT_EvalBeat:
-			ret= input.eval_beat;
-			break;
-		case MIT_EvalSecond:
-			ret= input.eval_second;
-			break;
-		case MIT_MusicBeat:
-			ret= input.music_beat;
-			break;
-		case MIT_MusicSecond:
-			ret= input.music_second;
-			break;
-		case MIT_DistBeat:
-			ret= input.dist_beat;
-			break;
-		case MIT_DistSecond:
-			ret= input.dist_second;
-			break;
-		case MIT_YOffset:
-			ret= input.y_offset;
-			break;
-		case MIT_StartDistBeat:
-			ret= input.start_dist_beat;
-			break;
-		case MIT_StartDistSecond:
-			ret= input.start_dist_second;
-			break;
-		case MIT_EndDistBeat:
-			ret= input.end_dist_beat;
-			break;
-		case MIT_EndDistSecond:
-			ret= input.end_dist_second;
-			break;
-		case MIT_NoteTimeRandom:
-			ret= GAMESTATE->simple_stage_frandom(
-				(BeatToNoteRow(input.eval_beat)) + (m_column << 24));
-			break;
-		case MIT_MusicTimeRandom:
-			ret= GAMESTATE->simple_stage_frandom(
-				(BeatToNoteRow(input.music_beat)) + (m_column << 24));
-			break;
-		case MIT_StageRandom:
-			ret= GAMESTATE->simple_stage_frandom((m_column << 24));
-			break;
-		default:
-			break;
-	}
-	if(rep_apple != nullptr)
-	{
-		ret= (this->*rep_apple)(ret);
-	}
-	if(phase_apple != nullptr)
-	{
-		ret= (this->*phase_apple)(ret);
-	}
-	ret*= m_scalar;
-	if(spline_apple != nullptr)
-	{
-		ret= (this->*spline_apple)(ret);
-	}
-	return ret + m_offset;
-}
-
-void ModInput::send_repick()
-{
-	if(get_meta_type() == MIMT_Scalar && m_parent != nullptr)
-	{
-		m_parent->repick(this);
-	}
-}
-
-void ModInput::send_spline_repick()
-{
-	m_spline.solve(m_loop_spline, m_polygonal_spline);
-	send_repick();
-}
-
-void ModInput::set_scalar(double s)
-{
-	m_scalar= s;
-	send_repick();
-}
-
-void ModInput::set_offset(double s)
-{
-	m_offset= s;
-	send_repick();
-}
-
-void ModInput::push_rep(lua_State* L)
-{
-	push_numbers(L, {&m_rep_begin, &m_rep_end});
-}
-
-void ModInput::push_all_phases(lua_State* L)
-{
-	lua_createtable(L, m_phases.size(), 0);
-	for(size_t i= 0; i < m_phases.size(); ++i)
-	{
-		push_phase(L, i);
-		lua_rawseti(L, -2, i+1);
-	}
-}
-
-void ModInput::enable_phases()
-{
-	phase_apple= &ModInput::apply_phase;
-	send_repick();
-}
-
-void ModInput::disable_phases()
-{
-	phase_apple= nullptr;
-	send_repick();
-}
-
-void ModInput::check_disable_phases()
-{
-	if(m_phases.empty() && m_default_phase.mult == 1.0 && m_default_phase.offset == 0.0)
-	{
-		disable_phases();
-	}
-}
-
-void ModInput::remove_phase(size_t phase)
-{
-	if(phase < m_phases.size())
-	{
-		m_phases.erase(m_phases.begin() + phase);
-	}
-	check_disable_phases();
-	send_repick();
-}
-
-void ModInput::clear_phases()
-{
-	m_phases.clear();
-	check_disable_phases();
-	send_repick();
-}
-
-void ModInput::enable_spline()
-{
-	spline_apple= &ModInput::apply_spline;
-	send_repick();
-}
-
-void ModInput::disable_spline()
-{
-	spline_apple= nullptr;
-	send_repick();
-}
-
-void ModInput::set_spline_loop(bool b)
-{
-	m_loop_spline= b;
-	send_spline_repick();
-}
-
-void ModInput::set_spline_polygonal(bool b)
-{
-	m_polygonal_spline= b;
-	m_spline.solve(m_loop_spline, m_polygonal_spline);
-	send_spline_repick();
-}
-
-double ModInput::get_spline_point(size_t p)
-{
-	float as_t= static_cast<float>(p);
-	return m_spline.evaluate(as_t, m_loop_spline);
-}
-
-void ModInput::set_spline_point(size_t p, double value)
-{
-	if(p < m_spline.size())
-	{
-		m_spline.set_point(p, static_cast<float>(value));
-		m_spline.solve(m_loop_spline, m_polygonal_spline);
-		send_spline_repick();
-	}
-}
-
-void ModInput::add_spline_point(double value)
-{
-	m_spline.resize(m_spline.size()+1);
-	m_spline.set_point(m_spline.size()-1, static_cast<float>(value));
-	m_spline.solve(m_loop_spline, m_polygonal_spline);
-	send_spline_repick();
-}
-
-void ModInput::remove_spline_point(size_t p)
-{
-	p= std::min(p, m_spline.size());
-	m_spline.remove_point(p);
-	m_spline.solve(m_loop_spline, m_polygonal_spline);
-	send_spline_repick();
-}
-
-void ModInput::push_spline(lua_State* L)
-{
-	lua_createtable(L, m_spline.size(), 2);
-	lua_pushboolean(L, m_loop_spline);
-	lua_setfield(L, -2, "loop");
-	lua_pushboolean(L, m_polygonal_spline);
-	lua_setfield(L, -2, "polygonal");
-	for(size_t p= 0; p < m_spline.size(); ++p)
-	{
-		lua_pushnumber(L, get_spline_point(p));
-		lua_rawseti(L, -2, p+1);
-	}
-}
-
-void ModFunction::update_input_set(mod_val_inputs const& input,
-	vector<size_t>& input_set)
-{
-	const_cast<mod_val_inputs&>(input).set_time(m_start_beat, m_start_second,
-		input.music_beat, input.music_second, m_end_beat, m_end_second);
-	for(auto pindex : input_set)
-	{
-		m_picked_inputs[pindex]= m_inputs[pindex].pick(input);
-	}
-}
-
-void ModFunction::update_input_set_in_spline(mod_val_inputs const& input,
-	vector<size_t>& input_set)
-{
-	const_cast<mod_val_inputs&>(input).set_time(m_start_beat, m_start_second,
-		input.music_beat, input.music_second, m_end_beat, m_end_second);
-	for(auto pindex : input_set)
-	{
-		m_picked_inputs[pindex]= m_inputs[pindex].pick(input);
-		// The first input is the t value.
-		if(pindex > 0)
-		{
-			m_spline.set_point(pindex-1, static_cast<float>(m_picked_inputs[pindex]));
-		}
-	}
-}
-
-size_t ModFunction::find_child(ModInput* child)
-{
-	for(size_t p= 0; p < m_inputs.size(); ++p)
-	{
-		if(child == &(m_inputs[p]))
-		{
-			return p;
-		}
-	}
-	return m_inputs.size();
-}
-
-void ModFunction::remove_child_from_percoset(size_t child_index,
-	vector<size_t>& percoset)
-{
-	for(auto pill= percoset.begin(); pill != percoset.end(); ++pill)
-	{
-		if(*pill == child_index)
-		{
-			percoset.erase(pill);
-			return;
-		}
-	}
-}
-
-void ModFunction::recategorize(ModInput* child, ModInputMetaType old_meta,
-	ModInputMetaType new_meta)
-{
-	if(m_being_loaded)
-	{
-		return;
-	}
-	size_t index= find_child(child);
-	if(index >= m_inputs.size())
-	{
-		return;
-	}
-	if(old_meta == MIMT_PerFrame)
-	{
-		remove_child_from_percoset(index, m_per_frame_inputs);
-	}
-	else if(old_meta == MIMT_PerNote)
-	{
-		remove_child_from_percoset(index, m_per_note_inputs);
-	}
-	if(new_meta == MIMT_PerFrame)
-	{
-		m_per_frame_inputs.push_back(index);
-	}
-	else if(new_meta == MIMT_PerNote)
-	{
-		m_per_note_inputs.push_back(index);
+		m_eval_result= mod_res + dist + m_rep_begin;
 	}
 	else
 	{
-		mod_val_inputs scalar_input(0.0, 0.0);
-		m_picked_inputs[index]= child->pick(scalar_input);
+		m_eval_result= mod_res + m_rep_begin;
 	}
 }
 
-void ModFunction::repick(ModInput* child)
+void mod_operator_spline::load_from_lua(mod_function* parent, lua_State* L, int index)
 {
-	if(m_picked_inputs.empty())
+	mod_operator::load_from_lua(parent, L, index);
+	if(m_operands.size() < 2)
 	{
-		return;
+		throw std::string("Spline operator must have at least two operands: t value and points.");
 	}
-	size_t index= find_child(child);
-	if(index < m_inputs.size())
+	m_spline.resize(m_operands.size() - 1);
+	for(size_t p= 1; p < m_operands.size(); ++p)
 	{
-		mod_val_inputs scalar_input(0.0, 0.0);
-		m_picked_inputs[index]= m_inputs[index].pick(scalar_input);
-	}
-}
-
-void ModFunction::per_frame_update(mod_val_inputs const& input)
-{
-	if(!m_per_frame_inputs.empty())
-	{
-		(this->*m_pfu)(input);
-	}
-}
-
-void ModFunction::per_frame_update_normal(mod_val_inputs const& input)
-{
-	update_input_set(input, m_per_frame_inputs);
-}
-
-void ModFunction::per_note_update_normal(mod_val_inputs const& input)
-{
-	update_input_set(input, m_per_note_inputs);
-}
-
-void ModFunction::per_frame_update_spline(mod_val_inputs const& input)
-{
-	update_input_set_in_spline(input, m_per_frame_inputs);
-	if(m_per_note_inputs.empty() && m_has_point_per_frame_input)
-	{
-		m_spline.solve(m_loop_spline, m_polygonal_spline);
-	}
-}
-
-void ModFunction::per_note_update_spline(mod_val_inputs const& input)
-{
-	update_input_set_in_spline(input, m_per_note_inputs);
-	m_spline.solve(m_loop_spline, m_polygonal_spline);
-}
-
-double ModFunction::constant_eval()
-{
-	return m_picked_inputs[0];
-}
-
-double ModFunction::product_eval()
-{
-	return m_picked_inputs[0] * m_picked_inputs[1];
-}
-
-double ModFunction::power_eval()
-{
-	return pow(m_picked_inputs[0], m_picked_inputs[1]);
-}
-
-double ModFunction::log_eval()
-{
-	return log(m_picked_inputs[0]) / log(m_picked_inputs[1]);
-}
-
-#define ZERO_AMP_WAVE_RETURN \
-if(m_picked_inputs[2] == 0.0) \
-{ \
-	return m_picked_inputs[3]; \
-}
-#define WAVE_ANGLE_CALC \
-double angle= fmod(m_picked_inputs[0] + m_picked_inputs[1], Rage::D_PI * 2.0); \
-if(angle < 0.0) \
-{ \
-	angle+= Rage::D_PI * 2.0; \
-}
-#define WAVE_RET return (wave_res * m_picked_inputs[2]) + m_picked_inputs[3];
-
-double ModFunction::sine_eval()
-{
-	ZERO_AMP_WAVE_RETURN;
-	WAVE_ANGLE_CALC;
-	double const wave_res= static_cast<double>(Rage::FastSin(angle));
-	WAVE_RET;
-}
-
-double ModFunction::tan_eval()
-{
-	ZERO_AMP_WAVE_RETURN;
-	WAVE_ANGLE_CALC;
-	double const wave_res= tan(angle);
-	WAVE_RET;
-}
-
-double ModFunction::square_eval()
-{
-	ZERO_AMP_WAVE_RETURN;
-	WAVE_ANGLE_CALC;
-	double const wave_res= (angle >= Rage::D_PI ? -1.0 : 1.0);
-	WAVE_RET;
-}
-
-double ModFunction::triangle_eval()
-{
-	ZERO_AMP_WAVE_RETURN;
-	WAVE_ANGLE_CALC;
-	double wave_res= angle * Rage::D_PI_REC;
-	if(wave_res < .5)
-	{
-		wave_res= wave_res * 2.0;
-	}
-	else if(wave_res < 1.5)
-	{
-		wave_res= 1.0 - ((wave_res - .5) * 2.0);
-	}
-	else
-	{
-		wave_res= -4.0 + (wave_res * 2.0);
-	}
-	WAVE_RET;
-}
-
-#undef WAVE_RET
-#undef WAVE_ANGLE_CALC
-#undef ZERO_AMP_WAVE_RETURN
-
-double ModFunction::spline_eval()
-{
-	return m_spline.evaluate(static_cast<float>(m_picked_inputs[0]), m_loop_spline);
-}
-
-void ModFunction::set_type(ModFunctionType type)
-{
-	m_type= type;
-	size_t num_inputs= 0;
-	switch(m_type)
-	{
-		case MFT_Constant:
-			m_sub_eval= &ModFunction::constant_eval;
-			num_inputs= 1;
-			break;
-		case MFT_Product:
-			m_sub_eval= &ModFunction::product_eval;
-			num_inputs= 2;
-			break;
-		case MFT_Power:
-			m_sub_eval= &ModFunction::power_eval;
-			num_inputs= 2;
-			break;
-		case MFT_Log:
-			m_sub_eval= &ModFunction::log_eval;
-			num_inputs= 2;
-			break;
-		case MFT_Sine:
-			m_sub_eval= &ModFunction::sine_eval;
-			num_inputs= 4;
-			break;
-		case MFT_Tan:
-			m_sub_eval= &ModFunction::tan_eval;
-			num_inputs= 4;
-			break;
-		case MFT_Square:
-			m_sub_eval= &ModFunction::square_eval;
-			num_inputs= 4;
-			break;
-		case MFT_Triangle:
-			m_sub_eval= &ModFunction::triangle_eval;
-			num_inputs= 4;
-			break;
-		case MFT_Spline:
-			m_sub_eval= &ModFunction::spline_eval;
-			m_pfu= &ModFunction::per_frame_update_spline;
-			m_pnu= &ModFunction::per_note_update_spline;
-			break;
-		default:
-			return;
-	}
-	if(m_type != MFT_Spline)
-	{
-		m_inputs.resize(num_inputs);
-	}
-}
-
-void ModFunction::init_picked_inputs()
-{
-	m_picked_inputs.resize(m_inputs.size());
-	mod_val_inputs scalar_input(0.0, 0.0);
-	for(size_t p= 0; p < m_inputs.size(); ++p)
-	{
-		ModInputMetaType mt= m_inputs[p].get_meta_type();
-		switch(mt)
+		m_spline.set_point(p-1, static_cast<float>(m_operand_results[p]));
+		switch(m_operands[p]->get_update_type())
 		{
-			case MIMT_Scalar:
-				m_picked_inputs[p]= m_inputs[p].pick(scalar_input);
+			case mut_frame:
+				m_has_per_frame_points= true;
 				break;
-			case MIMT_PerFrame:
-				m_per_frame_inputs.push_back(p);
-				break;
-			case MIMT_PerNote:
-				m_per_note_inputs.push_back(p);
+			case mut_note:
+				m_has_per_note_points= true;
 				break;
 			default:
 				break;
 		}
 	}
+	m_loop= get_optional_bool(L, index, "loop");
+	m_polygonal= get_optional_bool(L, index, "polygonal");
+	if(!m_has_per_frame_points && !m_has_per_note_points)
+	{
+		m_spline.solve(m_loop, m_polygonal);
+	}
 }
 
-bool ModFunction::load_from_lua(lua_State* L, int index, uint32_t col)
+void mod_operator_spline::per_frame_update(mod_val_inputs& input)
 {
-	m_being_loaded= true;
-	lua_rawgeti(L, index, 1);
-	ModFunctionType type= Enum::Check<ModFunctionType>(L, -1, true, true);
-	lua_pop(L, 1);
-	if(type == ModFunctionType_Invalid)
+	for(auto&& op : m_per_frame_operands)
 	{
-		m_being_loaded= false;
-		return false;
+		m_operand_results[op]= m_operands[op]->evaluate(input);
+		if(op > 0)
+		{
+			m_spline.set_point(op-1, m_operand_results[op]);
+		}
 	}
-	set_type(type);
-	// The lua table looks like this:
-	// {
-	//   name= "string", -- optional
-	//   start_beat= 5, -- optional
-	//   start_sec= 5, -- optional
-	//   end_beat= 5, -- optional
-	//   end_sec= 5, -- optional
-	//   sum_type= "ModValSumType_Add", -- optional
-	//   type, input, ...
-	// }
-	// name, the start and end values, and sum_type are optional.
-	// The ... is for the inputs after the first.
-	// So the first input is at lua table index 2.
+	if(m_has_per_frame_points && !m_has_per_note_points)
+	{
+		m_spline.solve(m_loop, m_polygonal);
+	}
+	if(m_operands[0]->get_update_type() == mut_frame)
+	{
+		spline_eval();
+	}
+}
+
+void mod_operator_spline::per_note_update(mod_val_inputs& input)
+{
+	for(auto&& op : m_per_note_operands)
+	{
+		m_operand_results[op]= m_operands[op]->evaluate(input);
+		if(op > 0)
+		{
+			m_spline.set_point(op-1, m_operand_results[op]);
+		}
+	}
+	if(m_has_per_note_points)
+	{
+		m_spline.solve(m_loop, m_polygonal);
+	}
+	spline_eval();
+}
+
+void mod_operator_spline::spline_eval()
+{
+	m_eval_result= m_spline.evaluate(static_cast<float>(m_operand_results[0]), m_loop);
+}
+
+mod_function::~mod_function()
+{
+	delete m_base_operand;
+}
+
+void mod_function::load_from_lua(lua_State* L, int index, uint32_t col)
+{
+	// {start_beat= 4, end_beat= 8, name= "frogger", priority= 0,
+	//   sum_type= "add", {"add", 5, "music_beat"}}
 	lua_getfield(L, index, "name");
-	if(lua_isstring(L, -1))
+	if(lua_type(L, -1) == LUA_TSTRING)
 	{
 		m_name= lua_tostring(L, -1);
 	}
@@ -1087,134 +1244,58 @@ bool ModFunction::load_from_lua(lua_State* L, int index, uint32_t col)
 		m_name= unique_name("mod");
 	}
 	lua_pop(L, 1);
+	lua_getfield(L, index, "sum_type");
+	if(lua_type(L, -1) == LUA_TSTRING)
+	{
+		std::string str_type= lua_tostring(L, -1);
+		lua_pop(L, 1);
+		m_sum_type= str_to_mot(str_type);
+		switch(m_sum_type)
+		{
+			case mot_add:
+			case mot_subtract:
+			case mot_multiply:
+			case mot_divide:
+				break;
+			default:
+				throw std::string("sum_type not supported for mod function.");
+		}
+	}
+	else
+	{
+		lua_pop(L, 1);
+	}
+	m_priority= get_optional_int(L, index, "priority", 0);
 	m_start_beat= get_optional_double(L, index, "start_beat", invalid_modfunction_time);
 	m_start_second= get_optional_double(L, index, "start_second", invalid_modfunction_time);
 	m_end_beat= get_optional_double(L, index, "end_beat", invalid_modfunction_time);
 	m_end_second= get_optional_double(L, index, "end_second", invalid_modfunction_time);
-	lua_getfield(L, index, "column");
-	if(lua_isnumber(L, -1))
-	{
-		int col_from_lua= lua_tonumber(L, -1);
-		if(col_from_lua < 0)
-		{
-			m_column= col;
-		}
-		else
-		{
-			m_column= static_cast<uint32_t>(col_from_lua);
-		}
-	}
-	else
-	{
-		m_column= col;
-	}
-	lua_pop(L, 1);
-	lua_getfield(L, index, "sum_type");
-	if(lua_isstring(L, -1))
-	{
-		ModSumType sum_type= Enum::Check<ModSumType>(L, -1, true, true);
-		if(sum_type == ModSumType_Invalid)
-		{
-			sum_type= MST_Add;
-		}
-		m_sum_type= sum_type;
-	}
-	lua_pop(L, 1);
-	if(m_type != MFT_Spline)
-	{
-		size_t elements= lua_objlen(L, index);
-		size_t limit= std::min(elements, m_inputs.size()+1);
-		for(size_t el= 2; el <= limit; ++el)
-		{
-			lua_rawgeti(L, index, el);
-			m_inputs[el-2].load_from_lua(L, lua_gettop(L), this, m_column);
-			lua_pop(L, 1);
-		}
-	}
-	else
-	{
-		// The first element of the table is the type.  So the number of points
-		// is one less than the size of the table.
-		size_t num_points= lua_objlen(L, index) - 1;
-		// The t value input is going to be put in the first slot.  So there is
-		// one more input than the number of points.
-		m_inputs.resize(num_points+1);
-		m_spline.resize(num_points);
-		lua_getfield(L, index, "t");
-		m_inputs[0].load_from_lua(L, lua_gettop(L), this, m_column);
-		lua_pop(L, 1);
-		m_loop_spline= get_optional_bool(L, index, "loop");
-		m_polygonal_spline= get_optional_bool(L, index, "polygonal");
-		for(size_t el= 2; el <= num_points+1; ++el)
-		{
-			lua_rawgeti(L, index, el);
-			m_inputs[el-1].load_from_lua(L, lua_gettop(L), this, m_column);
-			lua_pop(L, 1);
-		}
-	}
-	init_picked_inputs();
-	if(m_type == MFT_Spline)
-	{
-		// All scalar inputs are sent to the spline on loading.  So the ones that
-		// are not scalars are listed in per_note_inputs and per_frame_inputs so
-		// those stages only send the ones they need to.
-		// If all the input points are scalars, then they only need to be copied
-		// into the spline once, and the spline only has to be solved once ever.
-		// The t value input is in the first slot.  So there is one more input
-		// than the number of points.
-		for(size_t p= 1; p < m_picked_inputs.size(); ++p)
-		{
-			m_spline.set_point(p-1, static_cast<float>(m_picked_inputs[p]));
-		}
-		m_has_point_per_frame_input= false;
-		for(size_t p= 0; p < m_per_frame_inputs.size(); ++p)
-		{
-			if(m_per_frame_inputs[p] > 0)
-			{
-				m_has_point_per_frame_input= true;
-				break;
-			}
-		}
-		if(!m_has_point_per_frame_input && m_per_note_inputs.empty())
-		{
-			m_spline.solve(m_loop_spline, m_polygonal_spline);
-		}
-	}
-	m_being_loaded= false;
-	return true;
+	m_column= get_optional_double(L, index, "column", col);
+	lua_rawgeti(L, index, 1);
+	m_base_operand= load_operand_on_stack(this, L);
 }
 
-void ModFunction::push_inputs(lua_State* L, int table_index)
+void mod_function::simple_load(std::string const& name, std::string const& input_type, double value)
 {
-	size_t curr_input= 0;
-	int out_index= 1;
-	// For splines, the first input is the t value input.  But the returned
-	// inputs table should look like the table the ModFunction was created
-	// from.  So a spline starts at input 1, and puts the t input in a field.
-	if(m_type == MFT_Spline)
-	{
-		curr_input= 1;
-		m_inputs[0].PushSelf(L);
-		lua_setfield(L, table_index, "t");
-	}
-	for(; curr_input < m_inputs.size(); ++curr_input)
-	{
-		m_inputs[curr_input].PushSelf(L);
-		lua_rawseti(L, table_index, out_index);
-		++out_index;
-	}
-}
-
-void ModFunction::init_single_input(std::string const& name,
-	ModInputType input_type, double input_scalar)
-{
-	m_being_loaded= true;
-	set_type(MFT_Constant);
 	m_name= name;
-	m_sum_type= MST_Add;
-	m_inputs[0].init_simple(this, input_type, input_scalar);
-	init_picked_inputs();
-	m_being_loaded= false;
+	if(input_type == "number")
+	{
+		mod_input_number* op= new mod_input_number;
+		op->m_value= value;
+		m_base_operand= op;
+	}
+	else
+	{
+		mod_operator_multiply* op= new mod_operator_multiply;
+		op->add_simple_operand(input_type, 0.0);
+		op->add_simple_operand("number", value);
+		m_base_operand= op;
+	}
+}
+
+void mod_function::add_per_frame_operator(mod_operator* op)
+{
+	m_per_frame_operators.push_back(op);
 }
 
 static void calc_timing_pair(TimingData const* timing, double& beat, double& second)
@@ -1231,39 +1312,77 @@ static void calc_timing_pair(TimingData const* timing, double& beat, double& sec
 	}
 }
 
-void ModFunction::calc_unprovided_times(TimingData const* timing)
+void mod_function::calc_unprovided_times(TimingData const* timing)
 {
 	calc_timing_pair(timing, m_start_beat, m_start_second);
 	calc_timing_pair(timing, m_end_beat, m_end_second);
 }
 
-#define MF_NEEDS_THING(thing) \
-bool ModFunction::needs_##thing() \
+#define MOD_FUNC_NEEDS_THING(thing) \
+bool mod_function::needs_##thing() \
 { \
-	for(auto&& input : m_inputs) \
-	{ \
-		if(input.needs_##thing()) \
-		{ \
-			return true; \
-		} \
-	} \
-	return false; \
+	return m_base_operand->needs_##thing(); \
+}
+MOD_FUNC_NEEDS_THING(beat);
+MOD_FUNC_NEEDS_THING(second);
+MOD_FUNC_NEEDS_THING(y_offset);
+
+bool mod_function::needs_per_frame_update()
+{
+	return !m_per_frame_operators.empty();
 }
 
-MF_NEEDS_THING(beat);
-MF_NEEDS_THING(second);
-MF_NEEDS_THING(y_offset);
-#undef MF_NEEDS_THING
-
-static ModFunction* create_field_mod(ModifiableValue* parent, lua_State* L, int index, uint32_t col)
+void mod_function::per_frame_update(mod_val_inputs& input)
 {
-	ModFunction* ret= new ModFunction(parent, col);
-	if(!ret->load_from_lua(L, index, col))
+	for(auto&& op : m_per_frame_operators)
+	{
+		op->per_frame_update(input);
+	}
+}
+
+double mod_function::evaluate(mod_val_inputs& input)
+{
+	input.column= m_column;
+	return m_base_operand->evaluate(input);
+}
+
+double mod_function::evaluate_with_time(mod_val_inputs& input)
+{
+	set_input_fields(input);
+	return m_base_operand->evaluate(input);
+}
+
+static mod_function* create_mod_function(ModifiableValue* parent,
+	lua_State* L, int index, double col)
+{
+	mod_function* ret= new mod_function(parent, col);
+	try
+	{
+		ret->load_from_lua(L, index, col);
+	}
+	catch(std::string err)
 	{
 		delete ret;
-		return nullptr;
+		throw err;
 	}
 	return ret;
+}
+
+static mod_function* create_simple_mod_function(ModifiableValue* parent,
+	std::string const& name, std::string const& input_type, double value)
+{
+	mod_function* ret= new mod_function(parent, 0.0);
+	ret->simple_load(name, input_type, value);
+	return ret;
+}
+
+ModifiableValue::ModifiableValue(ModManager* man, double value)
+	:m_manager(man)
+{
+	if(value != 0.0)
+	{
+		add_simple_mod("base_value", "number", value);
+	}
 }
 
 ModifiableValue::~ModifiableValue()
@@ -1272,29 +1391,29 @@ ModifiableValue::~ModifiableValue()
 	clear_managed_mods();
 }
 
-double ModifiableValue::evaluate(mod_val_inputs const& input)
+double ModifiableValue::evaluate(mod_val_inputs& input)
 {
-	double sum= m_value;
+	double sum= 0;
 	if(!m_mods.empty())
 	{
 		for(auto&& mod : m_mods)
 		{
+			input.column= m_column;
 			switch(mod->m_sum_type)
 			{
-				case MST_Add:
+				case mot_add:
 					sum+= mod->evaluate(input);
 					break;
-				case MST_Subtract:
+				case mot_subtract:
 					sum-= mod->evaluate(input);
 					break;
-				case MST_Multiply:
+				case mot_multiply:
 					sum*= mod->evaluate(input);
 					break;
-				case MST_Divide:
+				case mot_divide:
 					sum/= mod->evaluate(input);
 					break;
 				default:
-					FAIL_M(fmt::sprintf("Invalid ModSumType: %i", static_cast<int>(mod->m_sum_type)));
 					break;
 			}
 		}
@@ -1303,22 +1422,22 @@ double ModifiableValue::evaluate(mod_val_inputs const& input)
 	{
 		for(auto&& mod : m_active_managed_mods)
 		{
-			switch(mod->m_sum_type)
+			input.column= m_column;
+			switch(mod.second->m_sum_type)
 			{
-				case MST_Add:
-					sum+= mod->evaluate_with_time(input);
+				case mot_add:
+					sum+= mod.second->evaluate_with_time(input);
 					break;
-				case MST_Subtract:
-					sum-= mod->evaluate_with_time(input);
+				case mot_subtract:
+					sum-= mod.second->evaluate_with_time(input);
 					break;
-				case MST_Multiply:
-					sum*= mod->evaluate_with_time(input);
+				case mot_multiply:
+					sum*= mod.second->evaluate_with_time(input);
 					break;
-				case MST_Divide:
-					sum/= mod->evaluate_with_time(input);
+				case mot_divide:
+					sum/= mod.second->evaluate_with_time(input);
 					break;
 				default:
-					FAIL_M(fmt::sprintf("Invalid ModSumType: %i", static_cast<int>(mod->m_sum_type)));
 					break;
 			}
 		}
@@ -1326,36 +1445,8 @@ double ModifiableValue::evaluate(mod_val_inputs const& input)
 	return sum;
 }
 
-ModFunction* ModifiableValue::add_mod_internal(lua_State* L, int index)
-{
-	ModFunction* new_mod= create_field_mod(this, L, index, m_column);
-	if(new_mod == nullptr)
-	{
-		LuaHelpers::ReportScriptError("Problem creating modifier: unknown type.");
-	}
-	return new_mod;
-}
-
-ModFunction* ModifiableValue::insert_mod_internal(ModFunction* new_mod)
-{
-	ModFunction* ret= nullptr;
-	auto insert_point= find_mod(new_mod->get_name());
-	if(insert_point == m_mods.end())
-	{
-		m_mods.push_back(new_mod);
-		ret= new_mod;
-	}
-	else
-	{
-		(*(*insert_point)) = (*new_mod);
-		delete new_mod;
-		ret= (*insert_point);
-	}
-	m_manager->add_to_per_frame_update(ret);
-	return ret;
-}
-
-std::list<ModFunction*>::iterator ModifiableValue::find_mod(std::string const& name)
+std::list<mod_function*>::iterator ModifiableValue::find_mod(
+	std::string const& name)
 {
 	for(auto iter= m_mods.begin(); iter != m_mods.end(); ++iter)
 	{
@@ -1367,24 +1458,31 @@ std::list<ModFunction*>::iterator ModifiableValue::find_mod(std::string const& n
 	return m_mods.end();
 }
 
-ModFunction* ModifiableValue::add_mod(lua_State* L, int index)
+void ModifiableValue::insert_mod_internal(mod_function* new_mod)
 {
-	ModFunction* new_mod= add_mod_internal(L, index);
-	if(new_mod == nullptr)
+	auto insert_point= find_mod(new_mod->get_name());
+	if(insert_point == m_mods.end())
 	{
-		return nullptr;
+		m_mods.push_back(new_mod);
 	}
-	return insert_mod_internal(new_mod);
+	else
+	{
+		m_manager->remove_from_per_frame_update(*insert_point);
+		delete *insert_point;
+		*insert_point= new_mod;
+	}
+	m_manager->add_to_per_frame_update(new_mod);
+#define MF_SET_NEEDS(thing) \
+	if(new_mod->needs_##thing()) { m_needs_##thing= true; }
+	MF_SET_NEEDS(beat);
+	MF_SET_NEEDS(second);
+	MF_SET_NEEDS(y_offset);
+#undef MF_SET_NEEDS
 }
 
-ModFunction* ModifiableValue::get_mod(std::string const& name)
+void ModifiableValue::add_mod(lua_State* L, int index)
 {
-	auto mod= find_mod(name);
-	if(mod != m_mods.end())
-	{
-		return *mod;
-	}
-	return nullptr;
+	insert_mod_internal(create_mod_function(this, L, index, m_column));
 }
 
 void ModifiableValue::remove_mod(std::string const& name)
@@ -1406,40 +1504,23 @@ void ModifiableValue::clear_mods()
 	m_mods.clear();
 }
 
-ModFunction* ModifiableValue::add_managed_mod(lua_State* L, int index)
+void ModifiableValue::add_managed_mod(lua_State* L, int index)
 {
-	ModFunction* new_mod= add_mod_internal(L, index);
-	if(new_mod == nullptr)
-	{
-		return nullptr;
-	}
+	mod_function* new_mod= create_mod_function(this, L, index, m_column);
 	new_mod->calc_unprovided_times(m_timing);
-	ModFunction* ret= nullptr;
 	auto mod= m_managed_mods.find(new_mod->get_name());
 	if(mod == m_managed_mods.end())
 	{
 		m_managed_mods.insert(make_pair(new_mod->get_name(), new_mod));
-		ret= new_mod;
 	}
 	else
 	{
-		(*(mod->second)) = (*new_mod);
-		delete new_mod;
-		ret= mod->second;
+		m_manager->remove_mod(mod->second);
+		delete mod->second;
+		mod->second= new_mod;
 	}
-	m_manager->add_mod(ret, this);
+	m_manager->add_mod(new_mod, this);
 	//m_manager->dump_list_status();
-	return ret;
-}
-
-ModFunction* ModifiableValue::get_managed_mod(std::string const& name)
-{
-	auto mod= m_managed_mods.find(name);
-	if(mod != m_managed_mods.end())
-	{
-		return mod->second;
-	}
-	return nullptr;
 }
 
 void ModifiableValue::remove_managed_mod(std::string const& name)
@@ -1461,29 +1542,32 @@ void ModifiableValue::clear_managed_mods()
 	{
 		delete mod.second;
 	}
+	m_active_managed_mods.clear();
 	m_managed_mods.clear();
 }
 
-void ModifiableValue::add_mod_to_active_list(ModFunction* mod)
+void ModifiableValue::add_mod_to_active_list(mod_function* mod)
 {
-	m_active_managed_mods.insert(mod);
+	m_active_managed_mods.insert(std::make_pair(mod->m_priority, mod));
 }
 
-void ModifiableValue::remove_mod_from_active_list(ModFunction* mod)
+void ModifiableValue::remove_mod_from_active_list(mod_function* mod)
 {
-	auto iter= m_active_managed_mods.find(mod);
-	if(iter != m_active_managed_mods.end())
+	auto iter= m_active_managed_mods.find(mod->m_priority);
+	for(; iter != m_active_managed_mods.end(); ++iter)
 	{
-		m_active_managed_mods.erase(iter);
+		if(iter->second == mod)
+		{
+			m_active_managed_mods.erase(iter);
+			return;
+		}
 	}
 }
 
 void ModifiableValue::add_simple_mod(std::string const& name,
-	ModInputType input_type, double input_scalar)
+	std::string const& input_type, double value)
 {
-	ModFunction* new_mod= new ModFunction(this, m_column);
-	new_mod->init_single_input(name, input_type, input_scalar);
-	insert_mod_internal(new_mod);
+	insert_mod_internal(create_simple_mod_function(this, name, input_type, value));
 }
 
 void ModifiableValue::take_over_mods(ModifiableValue& other)
@@ -1492,10 +1576,12 @@ void ModifiableValue::take_over_mods(ModifiableValue& other)
 	for(auto&& mod : m_mods)
 	{
 		mod->change_parent(this);
+		m_manager->add_to_per_frame_update(mod);
 	}
 	m_managed_mods.swap(other.m_managed_mods);
 	for(auto&& mod : m_managed_mods)
 	{
+		mod.second->change_parent(this);
 		m_manager->add_mod(mod.second, this);
 	}
 	m_active_managed_mods.swap(other.m_active_managed_mods);
@@ -1505,27 +1591,11 @@ void ModifiableValue::take_over_mods(ModifiableValue& other)
 #define MV_NEEDS_THING(thing) \
 bool ModifiableValue::needs_##thing() \
 { \
-	for(auto&& fun : m_mods) \
-	{ \
-		if(fun->needs_##thing()) \
-		{ \
-			return true; \
-		} \
-	} \
-	for(auto&& fun : m_active_managed_mods) \
-	{ \
-		if(fun->needs_##thing()) \
-		{ \
-			return true; \
-		} \
-	} \
-	return false; \
+	return m_needs_##thing; \
 }
-
 MV_NEEDS_THING(beat);
 MV_NEEDS_THING(second);
 MV_NEEDS_THING(y_offset);
-#undef MV_NEEDS_THING
 
 #define MV3_NEEDS_THING(thing) \
 bool ModifiableVector3::needs_##thing() \
@@ -1550,265 +1620,19 @@ MT_NEEDS_THING(y_offset);
 #undef MT_NEEDS_THING
 
 
-// lua start
-struct LunaModInput : Luna<ModInput>
-{
-	static int get_type(T* p, lua_State* L)
-	{
-		Enum::Push(L, p->get_type());
-		return 1;
-	}
-	static int set_type(T* p, lua_State* L)
-	{
-		p->set_type(Enum::Check<ModInputType>(L, 1));
-		COMMON_RETURN_SELF;
-	}
-	GETTER_SETTER_FLOAT_METHOD(scalar);
-	GETTER_SETTER_FLOAT_METHOD(offset);
-	static int get_rep(T* p, lua_State* L)
-	{
-		p->push_rep(L);
-		return 1;
-	}
-	static int set_rep(T* p, lua_State* L)
-	{
-		p->load_rep(L, 1);
-		COMMON_RETURN_SELF;
-	}
-	static int get_all_phases(T* p, lua_State* L)
-	{
-		p->push_all_phases(L);
-		return 1;
-	}
-	static int get_phase(T* p, lua_State* L)
-	{
-		size_t phase= static_cast<size_t>(IArg(1)) - 1;
-		if(phase >= p->get_num_phases())
-		{
-			lua_pushnil(L);
-		}
-		else
-		{
-			p->push_phase(L, phase);
-		}
-		return 1;
-	}
-	static int get_default_phase(T* p, lua_State* L)
-	{
-		p->push_def_phase(L);
-		return 1;
-	}
-	static int get_num_phases(T* p, lua_State* L)
-	{
-		lua_pushnumber(L, p->get_num_phases());
-		return 1;
-	}
-	static int set_all_phases(T* p, lua_State* L)
-	{
-		p->load_phases(L, 1);
-		COMMON_RETURN_SELF;
-	}
-	static int set_phase(T* p, lua_State* L)
-	{
-		size_t phase= static_cast<size_t>(IArg(1)) - 1;
-		if(phase >= p->get_num_phases() || !lua_istable(L, 2))
-		{
-			luaL_error(L, "Args to ModInput:set_phase must be an index and a table.");
-		}
-		p->load_one_phase(L, 2, phase);
-		p->sort_phases();
-		COMMON_RETURN_SELF;
-	}
-	static int set_default_phase(T* p, lua_State* L)
-	{
-		p->load_def_phase(L, 1);
-		COMMON_RETURN_SELF;
-	}
-	static int remove_phase(T* p, lua_State* L)
-	{
-		size_t phase= static_cast<size_t>(IArg(1)) - 1;
-		p->remove_phase(phase);
-		COMMON_RETURN_SELF;
-	}
-	static int clear_phases(T* p, lua_State* L)
-	{
-		(void)L;
-		p->clear_phases();
-		COMMON_RETURN_SELF;
-	}
-	static int set_enable_phases(T* p, lua_State* L)
-	{
-		bool enable= BArg(1);
-		if(enable)
-		{
-			p->enable_phases();
-		}
-		else
-		{
-			p->disable_phases();
-		}
-		COMMON_RETURN_SELF;
-	}
-	static int get_enable_phases(T* p, lua_State* L)
-	{
-		lua_pushboolean(L, p->get_enable_phases());
-		return 1;
-	}
-	static int get_enable_spline(T* p, lua_State* L)
-	{
-		lua_pushboolean(L, p->get_enable_spline());
-		return 1;
-	}
-	static int set_enable_spline(T* p, lua_State* L)
-	{
-		bool enable= BArg(1);
-		if(enable)
-		{
-			p->enable_spline();
-		}
-		else
-		{
-			p->disable_spline();
-		}
-		COMMON_RETURN_SELF;
-	}
-	GETTER_SETTER_BOOL_METHOD(spline_loop);
-	GETTER_SETTER_BOOL_METHOD(spline_polygonal);
-	static size_t spline_point_index(T* p, lua_State* L, int index)
-	{
-		int i= IArg(index);
-		if(i < 1)
-		{
-			luaL_error(L, "Invalid spline point index.");
-		}
-		size_t ret= static_cast<size_t>(i) - 1;
-		if(ret >= p->get_spline_size())
-		{
-			luaL_error(L, "Invalid spline point index.");
-		}
-		return ret;
-	}
-	static int get_spline_size(T* p, lua_State* L)
-	{
-		lua_pushnumber(L, p->get_spline_size());
-		return 1;
-	}
-	static int get_spline_point(T* p, lua_State* L)
-	{
-		size_t point= spline_point_index(p, L, 1);
-		lua_pushnumber(L, p->get_spline_point(point));
-		return 1;
-	}
-	static int set_spline_point(T* p, lua_State* L)
-	{
-		size_t point= spline_point_index(p, L, 1);
-		p->set_spline_point(point, FArg(2));
-		COMMON_RETURN_SELF;
-	}
-	static int add_spline_point(T* p, lua_State* L)
-	{
-		p->add_spline_point(FArg(1));
-		COMMON_RETURN_SELF;
-	}
-	static int remove_spline_point(T* p, lua_State* L)
-	{
-		if(p->get_spline_empty())
-		{
-			COMMON_RETURN_SELF;
-		}
-		size_t point= 0;
-		if(lua_isnil(L, 1))
-		{
-			point= p->get_spline_size()-1;
-		}
-		else
-		{
-			point= spline_point_index(p, L, 1);
-		}
-		p->remove_spline_point(point);
-		COMMON_RETURN_SELF;
-	}
-	static int get_spline(T* p, lua_State* L)
-	{
-		p->push_spline(L);
-		return 1;
-	}
-	static int set_spline(T* p, lua_State* L)
-	{
-		p->load_spline(L, 1);
-		COMMON_RETURN_SELF;
-	}
-	LunaModInput()
-	{
-		ADD_GET_SET_METHODS(type);
-		ADD_GET_SET_METHODS(scalar);
-		ADD_GET_SET_METHODS(offset);
-		ADD_GET_SET_METHODS(rep);
-		ADD_GET_SET_METHODS(all_phases);
-		ADD_GET_SET_METHODS(phase);
-		ADD_GET_SET_METHODS(default_phase);
-		ADD_METHOD(get_num_phases);
-		ADD_METHOD(remove_phase);
-		ADD_METHOD(clear_phases);
-		ADD_GET_SET_METHODS(enable_phases);
-		ADD_METHOD(get_spline_size);
-		ADD_GET_SET_METHODS(spline_point);
-		ADD_METHOD(add_spline_point);
-		ADD_METHOD(remove_spline_point);
-		ADD_GET_SET_METHODS(spline);
-	}
-};
-LUA_REGISTER_CLASS(ModInput);
-
-struct LunaModFunction : Luna<ModFunction>
-{
-	static int get_inputs(T* p, lua_State* L)
-	{
-		lua_createtable(L, p->num_inputs(), 0);
-		p->push_inputs(L, lua_gettop(L));
-		return 1;
-	}
-	GET_SET_ENUM_METHOD(sum_type, ModSumType, m_sum_type);
-	LunaModFunction()
-	{
-		ADD_METHOD(get_inputs);
-		ADD_GET_SET_METHODS(sum_type);
-	}
-};
-LUA_REGISTER_CLASS(ModFunction);
-
 struct LunaModifiableValue : Luna<ModifiableValue>
 {
 	static int add_mod(T* p, lua_State* L)
 	{
-		p->add_mod(L, lua_gettop(L));
+		try
+		{
+			p->add_mod(L, lua_gettop(L));
+		}
+		catch(std::string err)
+		{
+			luaL_error(L, err.c_str());
+		}
 		COMMON_RETURN_SELF;
-	}
-	static int add_get_mod(T* p, lua_State* L)
-	{
-		ModFunction* mod= p->add_mod(L, lua_gettop(L));
-		if(mod == nullptr)
-		{
-			lua_pushnil(L);
-		}
-		else
-		{
-			mod->PushSelf(L);
-		}
-		return 1;
-	}
-	static int get_mod(T* p, lua_State* L)
-	{
-		ModFunction* mod= p->get_mod(SArg(1));
-		if(mod == nullptr)
-		{
-			lua_pushnil(L);
-		}
-		else
-		{
-			mod->PushSelf(L);
-		}
-		return 1;
 	}
 	static int remove_mod(T* p, lua_State* L)
 	{
@@ -1822,7 +1646,14 @@ struct LunaModifiableValue : Luna<ModifiableValue>
 	}
 	static int add_managed_mod(T* p, lua_State* L)
 	{
-		p->add_managed_mod(L, lua_gettop(L));
+		try
+		{
+			p->add_managed_mod(L, lua_gettop(L));
+		}
+		catch(std::string err)
+		{
+			luaL_error(L, err.c_str());
+		}
 		COMMON_RETURN_SELF;
 	}
 	static int add_managed_mod_set(T* p, lua_State* L)
@@ -1832,39 +1663,21 @@ struct LunaModifiableValue : Luna<ModifiableValue>
 			luaL_error(L, "Arg for add_managed_mod_set must be a table of ModFunctins.");
 		}
 		size_t num_mods= lua_objlen(L, 1);
-		for(size_t m= 0; m < num_mods; ++m)
+		for(size_t m= 1; m <= num_mods; ++m)
 		{
-			lua_rawgeti(L, 1, m+1);
-			p->add_managed_mod(L, lua_gettop(L));
+			lua_rawgeti(L, 1, m);
+			try
+			{
+				p->add_managed_mod(L, lua_gettop(L));
+			}
+			catch(std::string err)
+			{
+				lua_pop(L, 1);
+				luaL_error(L, err.c_str());
+			}
 			lua_pop(L, 1);
 		}
 		COMMON_RETURN_SELF;
-	}
-	static int add_get_managed_mod(T* p, lua_State* L)
-	{
-		ModFunction* mod= p->add_managed_mod(L, lua_gettop(L));
-		if(mod == nullptr)
-		{
-			lua_pushnil(L);
-		}
-		else
-		{
-			mod->PushSelf(L);
-		}
-		return 1;
-	}
-	static int get_managed_mod(T* p, lua_State* L)
-	{
-		ModFunction* mod= p->get_managed_mod(SArg(1));
-		if(mod == nullptr)
-		{
-			lua_pushnil(L);
-		}
-		else
-		{
-			mod->PushSelf(L);
-		}
-		return 1;
 	}
 	static int remove_managed_mod(T* p, lua_State* L)
 	{
@@ -1876,36 +1689,21 @@ struct LunaModifiableValue : Luna<ModifiableValue>
 		p->clear_managed_mods();
 		COMMON_RETURN_SELF;
 	}
-	static int get_value(T* p, lua_State* L)
-	{
-		lua_pushnumber(L, p->m_value);
-		return 1;
-	}
-	static int set_value(T* p, lua_State* L)
-	{
-		p->m_value= FArg(1);
-		COMMON_RETURN_SELF;
-	}
 	static int evaluate(T* p, lua_State* L)
 	{
-		mod_val_inputs input(FArg(1), FArg(2), FArg(3), FArg(4), FArg(5));
+		mod_val_inputs input(FArg(1), FArg(2), FArg(3), FArg(4), FArg(5), nullptr);
 		lua_pushnumber(L, p->evaluate(input));
 		return 1;
 	}
 	LunaModifiableValue()
 	{
 		ADD_METHOD(add_mod);
-		ADD_METHOD(add_get_mod);
-		ADD_METHOD(get_mod);
 		ADD_METHOD(remove_mod);
 		ADD_METHOD(clear_mods);
 		ADD_METHOD(add_managed_mod);
 		ADD_METHOD(add_managed_mod_set);
-		ADD_METHOD(add_get_managed_mod);
-		ADD_METHOD(get_managed_mod);
 		ADD_METHOD(remove_managed_mod);
 		ADD_METHOD(clear_managed_mods);
-		ADD_GET_SET_METHODS(value);
 		ADD_METHOD(evaluate);
 	}
 };

--- a/src/NewField.h
+++ b/src/NewField.h
@@ -119,10 +119,10 @@ struct NewFieldColumn : ActorFrame
 		if(off > last_y_offset_visible) { return 1; }
 		return 0;
 	}
-	double calc_y_offset(double beat, double second);
+	double calc_y_offset(double beat, double second, TapNote const* note);
 	double head_y_offset()
 	{
-		return calc_y_offset(m_curr_beat, m_curr_second);
+		return calc_y_offset(m_curr_beat, m_curr_second, nullptr);
 	}
 	double calc_lift_pretrail(double beat, double second, double yoffset);
 	double get_reverse_shift()

--- a/src/NoteData.cpp
+++ b/src/NoteData.cpp
@@ -35,6 +35,9 @@ void NoteData::SetOccuranceTimeForAllTaps(TimingData* timing_data)
 	vector<TapNote*> notes_on_curr_row;
 	TapNoteSubType highest_subtype_on_row= TapNoteSubType_Invalid;
 	double curr_row_second= -1.0;
+	vector<int> column_ids(GetNumTracks(), 0);
+	int curr_note_id= 0;
+	int curr_row_id= -1; // Start at -1 so that the first row update sets to 0.
 	while(!curr_note.IsAtEnd())
 	{
 		if(curr_note.Row() != curr_row)
@@ -47,10 +50,16 @@ void NoteData::SetOccuranceTimeForAllTaps(TimingData* timing_data)
 			highest_subtype_on_row= TapNoteSubType_Invalid;
 			curr_row= curr_note.Row();
 			curr_row_second= timing_data->GetElapsedTimeFromBeat(NoteRowToBeat(curr_row));
+			++curr_row_id;
 		}
 		if(curr_note->type != TapNoteType_Empty)
 		{
 			curr_note->occurs_at_second= curr_row_second;
+			curr_note->id_in_chart= static_cast<float>(curr_note_id);
+			curr_note->id_in_column= static_cast<float>(column_ids[curr_note.Track()]);
+			curr_note->row_id= static_cast<float>(curr_row_id);
+			++curr_note_id;
+			++column_ids[curr_note.Track()];
 			notes_on_curr_row.push_back(&(*curr_note));
 			if(curr_note->subType != TapNoteSubType_Invalid)
 			{

--- a/src/NoteTypes.h
+++ b/src/NoteTypes.h
@@ -149,6 +149,11 @@ struct TapNote
 	// there is a hold head on the same row.  It needs to be a TapNoteSubType
 	// instead of a bool to handle rolls. -Kyz
 	TapNoteSubType highest_subtype_on_row;
+	// id_in_chart, id_in_column, and row_id are for passing to mods.  The mod
+	// system uses floating point for everything, so they're floats. -Kyz
+	float id_in_chart;
+	float id_in_column;
+	float row_id;
 
 	// used only if Type == attack:
 	std::string		sAttackModifiers;

--- a/src/NotesLoaderSSC.cpp
+++ b/src/NotesLoaderSSC.cpp
@@ -914,7 +914,7 @@ bool SSCLoader::LoadNoteDataFromSimfile( const std::string & cachePath, Steps &o
 							Difficulty match_diff= StringToDifficulty(matcher);
 							if(matcher.empty())
 							{
-								match_diff == Difficulty_Edit;
+								match_diff= Difficulty_Edit;
 							}
 							if(out.GetDifficulty() != match_diff &&
 								!(out.GetDifficulty() == Difficulty_Edit &&


### PR DESCRIPTION
This completely changes the syntax of the mod system in 5.1.

Inputs and operators are more cleanly separated.  There aren't weird warts on the input class like phase and repeat.  Those things are operators now.

The seed for the random input can be controlled now instead of being an awkward wart.

This breaks compatibility with any mod code written for the old 5.1 system.  Anything written for the previous system can be rewritten in the new system.