### PR TITLE
Performance fixes + change song start delay based on music rate

### DIFF
--- a/src/Player.cpp
+++ b/src/Player.cpp
@@ -1093,7 +1093,7 @@ void Player::Update( float fDeltaTime )
 	}
 
 	// Check for completely judged rows.
-	UpdateJudgedRows();
+	UpdateJudgedRows(fDeltaTime);
 
 	// Check for TapNote misses
 	if (!GAMESTATE->m_bInStepEditor)
@@ -2478,10 +2478,12 @@ void Player::UpdateTapNotesMissedOlderThan( float fMissIfOlderThanSeconds )
 	}
 }
 
-void Player::UpdateJudgedRows()
+void Player::UpdateJudgedRows(float fDeltaTime)
 {
-	// Look ahead far enough to catch any rows judged early.
+	// Look into the past and future only as far as we need to
+	// catch misses and early hits
 	const int iEndRow = BeatToNoteRow( m_Timing->GetBeatFromElapsedTime( m_pPlayerState->m_Position.m_fMusicSeconds + GetMaxStepDistanceSeconds() ) );
+	const int iStartRow = BeatToNoteRow(m_Timing->GetBeatFromElapsedTime(m_pPlayerState->m_Position.m_fMusicSeconds - GetMaxStepDistanceSeconds() - fDeltaTime - 0.1666667f));
 	bool bAllJudged = true;
 	const bool bSeparately = GAMESTATE->GetCurrentGame()->m_bCountNotesSeparately;
 
@@ -2491,6 +2493,10 @@ void Player::UpdateJudgedRows()
 		for( ; !iter.IsAtEnd()  &&  iter.Row() <= iEndRow; ++iter )
 		{
 			int iRow = iter.Row();
+
+			// Do not go across rows which are too old
+			if (iStartRow > iRow)
+				continue;
 
 			// Do not judge arrows in WarpSegments or FakeSegments
 			if (!m_Timing->IsJudgableAtRow(iRow))

--- a/src/Player.h
+++ b/src/Player.h
@@ -120,7 +120,7 @@ public:
 
 protected:
 	void UpdateTapNotesMissedOlderThan( float fMissIfOlderThanThisBeat );
-	void UpdateJudgedRows();
+	void UpdateJudgedRows(float fDeltaTime);
 	void FlashGhostRow( int iRow );
 	void HandleTapRowScore( unsigned row );
 	void HandleHoldScore( const TapNote &tn );

--- a/src/RageDisplay_D3D.cpp
+++ b/src/RageDisplay_D3D.cpp
@@ -380,7 +380,7 @@ std::string SetD3DParams( bool &bNewDeviceOut )
 			D3DADAPTER_DEFAULT,
 			D3DDEVTYPE_HAL,
 			GraphicsWindow::GetHwnd(),
-			D3DCREATE_HARDWARE_VERTEXPROCESSING | D3DCREATE_MULTITHREADED,
+			D3DCREATE_HARDWARE_VERTEXPROCESSING,
 			&g_d3dpp,
 			&g_pd3dDevice );
 		if( FAILED(hr) )

--- a/src/ScreenGameplay.cpp
+++ b/src/ScreenGameplay.cpp
@@ -1484,7 +1484,7 @@ void ScreenGameplay::StartPlayingSong( float fMinTimeToNotes, float fMinTimeToMu
 		const float fFirstSecond = GAMESTATE->m_pCurSong->GetFirstSecond();
 		float fStartDelay = fMinTimeToNotes - fFirstSecond;
 		fStartDelay = max( fStartDelay, fMinTimeToMusic );
-		p.m_StartSecond = -fStartDelay;
+		p.m_StartSecond = -fStartDelay * p.m_fSpeed;
 	}
 
 	ASSERT( !m_pSoundMusic->IsPlaying() );


### PR DESCRIPTION
Open to suggestions regarding the magic number I needed for my judgement optimization. Figured there was probably variables I could use to make it perfect, but couldn't find them. Using the magic number on-top of frame delta ensures none are missed, and no magic number didn't result in a performance gain despite not catching any missed arrows.