### PR TITLE
Use a trick to speed up RageVColor::ftoc

### DIFF
--- a/src/rage/RageVColor.cpp
+++ b/src/rage/RageVColor.cpp
@@ -12,16 +12,24 @@
  *
  * should output the same value (+-1) 256 times.  If this function is
  * incorrect, the first and/or last values may be biased. */
-uint8_t ftoc(float a);
+inline uint8_t ftoc(float a);
 
-uint8_t ftoc(float a)
+inline uint8_t ftoc(float a)
 {
-	/* std::lrint is much faster than C casts.  We don't care which way negative values
-	 * are rounded, since we'll clamp them to zero below.  Be sure to truncate (not
-	 * round) positive values.  The highest value that should be converted to 1 is
-	 * roughly (1/256 - 0.00001); if we don't truncate, values up to (1/256 + 0.5)
-	 * will be converted to 1, which is wrong. */
-	int ret = std::lrint(a * 256.f - 0.5f);
+	//This value is 2^52 * 1.5.
+	const double INT_MANTISSA = 6755399441055744.0;
+
+	/* Be sure to truncate (not round) positive values. The highest value that
+	 * should be converted to 1 is roughly(1 / 256 - 0.00001); if we don't
+	 * truncate, values up to (1/256 + 0.5) will be converted to 1, which is
+	 * wrong. */
+	double base = double(a * 256.f - 0.5f);
+
+	/* INT_MANTISSA is chosen such that, when added to a sufficiently small
+	 * double, the mantissa bits of that double can be reinterpreted as that
+	 * number rounded to an integer. This is done to improve performance. */
+	base += INT_MANTISSA;
+	int ret = reinterpret_cast<int&>(base);
 	
 	/* Benchmarking shows that clamping here, as integers, is much faster than clamping
 	 * before the conversion, as floats. */


### PR DESCRIPTION
This technique is outlined in http://stereopsis.com/sree/fpu2006.html, and is dirty but does seem to have a measurable effect on performance (especially in hold rendering). The game still works with this change and does not seem to have any major problems as a result.