### PR TITLE
SDL2 windows

### DIFF
--- a/CMake/DefineOptions.cmake
+++ b/CMake/DefineOptions.cmake
@@ -6,6 +6,9 @@ option(WITH_NETWORKING "Build with networking support." ON)
 # This option quiets warnings that are a part of external projects.
 option(WITH_EXTERNAL_WARNINGS "Build with warnings for all components, not just StepMania." OFF)
 
+# This option enables using SDL for windows. This will eventually always be ON.
+option(WITH_SDL "Build with SDL windows." OFF)
+
 # This option is not yet working, but will likely default to ON in the future.
 option(WITH_LTO "Build with Link Time Optimization (LTO)/Whole Program Optimization." OFF)
 

--- a/CMake/Modules/FindSDL2.cmake
+++ b/CMake/Modules/FindSDL2.cmake
@@ -1,0 +1,193 @@
+# Locate SDL2 library
+# This module defines
+# SDL2_LIBRARY, the name of the library to link against
+# SDL2_FOUND, if false, do not try to link to SDL2
+# SDL2_INCLUDE_DIR, where to find SDL.h
+#
+# This module responds to the the flag:
+# SDL2_BUILDING_LIBRARY
+# If this is defined, then no SDL2_main will be linked in because
+# only applications need main().
+# Otherwise, it is assumed you are building an application and this
+# module will attempt to locate and set the the proper link flags
+# as part of the returned SDL2_LIBRARY variable.
+#
+# Don't forget to include SDL2main.h and SDL2main.m your project for the
+# OS X framework based version. (Other versions link to -lSDL2main which
+# this module will try to find on your behalf.) Also for OS X, this
+# module will automatically add the -framework Cocoa on your behalf.
+#
+#
+# Additional Note: If you see an empty SDL2_LIBRARY_TEMP in your configuration
+# and no SDL2_LIBRARY, it means CMake did not find your SDL2 library
+# (SDL2.dll, libsdl2.so, SDL2.framework, etc).
+# Set SDL2_LIBRARY_TEMP to point to your SDL2 library, and configure again.
+# Similarly, if you see an empty SDL2MAIN_LIBRARY, you should set this value
+# as appropriate. These values are used to generate the final SDL2_LIBRARY
+# variable, but when these values are unset, SDL2_LIBRARY does not get created.
+#
+#
+# $SDL2DIR is an environment variable that would
+# correspond to the ./configure --prefix=$SDL2DIR
+# used in building SDL2.
+# l.e.galup  9-20-02
+#
+# Modified by Eric Wing.
+# Added code to assist with automated building by using environmental variables
+# and providing a more controlled/consistent search behavior.
+# Added new modifications to recognize OS X frameworks and
+# additional Unix paths (FreeBSD, etc).
+# Also corrected the header search path to follow "proper" SDL2 guidelines.
+# Added a search for SDL2main which is needed by some platforms.
+# Added a search for threads which is needed by some platforms.
+# Added needed compile switches for MinGW.
+#
+# On OSX, this will prefer the Framework version (if found) over others.
+# People will have to manually change the cache values of
+# SDL2_LIBRARY to override this selection or set the CMake environment
+# CMAKE_INCLUDE_PATH to modify the search paths.
+#
+# Note that the header path has changed from SDL2/SDL.h to just SDL.h
+# This needed to change because "proper" SDL2 convention
+# is #include "SDL.h", not <SDL2/SDL.h>. This is done for portability
+# reasons because not all systems place things in SDL2/ (see FreeBSD).
+#
+# Ported by Johnny Patterson. This is a literal port for SDL2 of the FindSDL.cmake
+# module with the minor edit of changing "SDL" to "SDL2" where necessary. This
+# was not created for redistribution, and exists temporarily pending official
+# SDL2 CMake modules.
+
+#=============================================================================
+# Copyright 2003-2009 Kitware, Inc.
+#
+# Distributed under the OSI-approved BSD License (the "License");
+# see accompanying file Copyright.txt for details.
+#
+# This software is distributed WITHOUT ANY WARRANTY; without even the
+# implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the License for more information.
+#=============================================================================
+# (To distribute this file outside of CMake, substitute the full
+#  License text for the above reference.)
+
+FIND_PATH(SDL2_INCLUDE_DIR SDL.h
+  HINTS
+  $ENV{SDL2DIR}
+  PATH_SUFFIXES include/SDL2 include
+  PATHS
+  ~/Library/Frameworks
+  /Library/Frameworks
+  /usr/local/include/SDL2
+  /usr/include/SDL2
+  /sw # Fink
+  /opt/local # DarwinPorts
+  /opt/csw # Blastwave
+  /opt
+)
+#MESSAGE("SDL2_INCLUDE_DIR is ${SDL2_INCLUDE_DIR}")
+
+FIND_LIBRARY(SDL2_LIBRARY_TEMP
+  NAMES SDL2
+  HINTS
+  $ENV{SDL2DIR}
+  PATH_SUFFIXES lib64 lib
+  PATHS
+  /sw
+  /opt/local
+  /opt/csw
+  /opt
+)
+
+#MESSAGE("SDL2_LIBRARY_TEMP is ${SDL2_LIBRARY_TEMP}")
+
+IF(NOT SDL2_BUILDING_LIBRARY)
+  IF(NOT ${SDL2_INCLUDE_DIR} MATCHES ".framework")
+    # Non-OS X framework versions expect you to also dynamically link to
+    # SDL2main. This is mainly for Windows and OS X. Other (Unix) platforms
+    # seem to provide SDL2main for compatibility even though they don't
+    # necessarily need it.
+    FIND_LIBRARY(SDL2MAIN_LIBRARY
+      NAMES SDL2main
+      HINTS
+      $ENV{SDL2DIR}
+      PATH_SUFFIXES lib64 lib
+      PATHS
+      /sw
+      /opt/local
+      /opt/csw
+      /opt
+    )
+  ENDIF(NOT ${SDL2_INCLUDE_DIR} MATCHES ".framework")
+ENDIF(NOT SDL2_BUILDING_LIBRARY)
+
+# SDL2 may require threads on your system.
+# The Apple build may not need an explicit flag because one of the
+# frameworks may already provide it.
+# But for non-OSX systems, I will use the CMake Threads package.
+IF(NOT APPLE)
+  FIND_PACKAGE(Threads)
+ENDIF(NOT APPLE)
+
+# MinGW needs an additional library, mwindows
+# It's total link flags should look like -lmingw32 -lSDL2main -lSDL2 -lmwindows
+# (Actually on second look, I think it only needs one of the m* libraries.)
+IF(MINGW)
+  SET(MINGW32_LIBRARY mingw32 CACHE STRING "mwindows for MinGW")
+ENDIF(MINGW)
+
+SET(SDL2_FOUND "NO")
+IF(SDL2_LIBRARY_TEMP)
+  # For SDL2main
+  IF(NOT SDL2_BUILDING_LIBRARY)
+    IF(SDL2MAIN_LIBRARY)
+      SET(SDL2_LIBRARY_TEMP ${SDL2MAIN_LIBRARY} ${SDL2_LIBRARY_TEMP})
+    ENDIF(SDL2MAIN_LIBRARY)
+  ENDIF(NOT SDL2_BUILDING_LIBRARY)
+
+  # For OS X, SDL2 uses Cocoa as a backend so it must link to Cocoa.
+  # CMake doesn't display the -framework Cocoa string in the UI even
+  # though it actually is there if I modify a pre-used variable.
+  # I think it has something to do with the CACHE STRING.
+  # So I use a temporary variable until the end so I can set the
+  # "real" variable in one-shot.
+  IF(APPLE)
+    SET(SDL2_LIBRARY_TEMP ${SDL2_LIBRARY_TEMP} "-framework Cocoa")
+  ENDIF(APPLE)
+
+  # For threads, as mentioned Apple doesn't need this.
+  # In fact, there seems to be a problem if I used the Threads package
+  # and try using this line, so I'm just skipping it entirely for OS X.
+  IF(NOT APPLE)
+    SET(SDL2_LIBRARY_TEMP ${SDL2_LIBRARY_TEMP} ${CMAKE_THREAD_LIBS_INIT})
+  ENDIF(NOT APPLE)
+
+  # For MinGW library
+  IF(MINGW)
+    SET(SDL2_LIBRARY_TEMP ${MINGW32_LIBRARY} ${SDL2_LIBRARY_TEMP})
+  ENDIF(MINGW)
+
+  # Set the final string here so the GUI reflects the final state.
+  SET(SDL2_LIBRARY ${SDL2_LIBRARY_TEMP} CACHE STRING "Where the SDL2 Library can be found")
+  # Set the temp variable to INTERNAL so it is not seen in the CMake GUI
+  SET(SDL2_LIBRARY_TEMP "${SDL2_LIBRARY_TEMP}" CACHE INTERNAL "")
+
+  SET(SDL2_FOUND "YES")
+
+  # extract the major and minor version numbers from SDL2/SDL_version.h
+  # we have to handle framework a little bit differently :
+  if("${SDL2_INCLUDE_DIR}" MATCHES ".framework")
+    set(SDL2_VERSION_H_INPUT "${SDL2_INCLUDE_DIR}/Headers/SDL_version.h")
+  else()
+    set(SDL2_VERSION_H_INPUT "${SDL2_INCLUDE_DIR}/SDL_version.h")
+  endif()
+  FILE(READ "${SDL2_VERSION_H_INPUT}" SDL2_VERSION_H_CONTENTS)
+  STRING(REGEX REPLACE ".*#define[ \t]+SDL_MAJOR_VERSION[ \t]+([0-9]+).*#define[ \t]+SDL_MINOR_VERSION[ \t]+([0-9]+).*#define[ \t]+SDL_PATCHLEVEL[ \t]+([0-9]+).*"
+                       "\\1.\\2.\\3" SDL2_VERSION "${SDL2_VERSION_H_CONTENTS}")
+#MESSAGE("SDL2 Version is ${SDL2_VERSION}")
+
+ENDIF(SDL2_LIBRARY_TEMP)
+
+INCLUDE(FindPackageHandleStandardArgs)
+
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(SDL2
+                                  REQUIRED_VARS SDL2_LIBRARY SDL2_INCLUDE_DIR VERSION_VAR SDL2_VERSION)

--- a/CMake/Modules/FindSDL2.cmake
+++ b/CMake/Modules/FindSDL2.cmake
@@ -6,13 +6,13 @@
 #
 # This module responds to the the flag:
 # SDL2_BUILDING_LIBRARY
-# If this is defined, then no SDL2_main will be linked in because
+# If this is defined, then no SDL2main will be linked in because
 # only applications need main().
 # Otherwise, it is assumed you are building an application and this
 # module will attempt to locate and set the the proper link flags
 # as part of the returned SDL2_LIBRARY variable.
 #
-# Don't forget to include SDL2main.h and SDL2main.m your project for the
+# Don't forget to include SDLmain.h and SDLmain.m your project for the
 # OS X framework based version. (Other versions link to -lSDL2main which
 # this module will try to find on your behalf.) Also for OS X, this
 # module will automatically add the -framework Cocoa on your behalf.
@@ -37,7 +37,7 @@
 # and providing a more controlled/consistent search behavior.
 # Added new modifications to recognize OS X frameworks and
 # additional Unix paths (FreeBSD, etc).
-# Also corrected the header search path to follow "proper" SDL2 guidelines.
+# Also corrected the header search path to follow "proper" SDL guidelines.
 # Added a search for SDL2main which is needed by some platforms.
 # Added a search for threads which is needed by some platforms.
 # Added needed compile switches for MinGW.
@@ -48,14 +48,9 @@
 # CMAKE_INCLUDE_PATH to modify the search paths.
 #
 # Note that the header path has changed from SDL2/SDL.h to just SDL.h
-# This needed to change because "proper" SDL2 convention
+# This needed to change because "proper" SDL convention
 # is #include "SDL.h", not <SDL2/SDL.h>. This is done for portability
 # reasons because not all systems place things in SDL2/ (see FreeBSD).
-#
-# Ported by Johnny Patterson. This is a literal port for SDL2 of the FindSDL.cmake
-# module with the minor edit of changing "SDL" to "SDL2" where necessary. This
-# was not created for redistribution, and exists temporarily pending official
-# SDL2 CMake modules.
 
 #=============================================================================
 # Copyright 2003-2009 Kitware, Inc.
@@ -70,35 +65,31 @@
 # (To distribute this file outside of CMake, substitute the full
 #  License text for the above reference.)
 
-FIND_PATH(SDL2_INCLUDE_DIR SDL.h
-  HINTS
-  $ENV{SDL2DIR}
-  PATH_SUFFIXES include/SDL2 include
-  PATHS
+SET(SDL2_SEARCH_PATHS
   ~/Library/Frameworks
   /Library/Frameworks
-  /usr/local/include/SDL2
-  /usr/include/SDL2
+  /usr/local
+  /usr
   /sw # Fink
   /opt/local # DarwinPorts
   /opt/csw # Blastwave
   /opt
 )
-#MESSAGE("SDL2_INCLUDE_DIR is ${SDL2_INCLUDE_DIR}")
+
+FIND_PATH(SDL2_INCLUDE_DIR SDL.h
+  HINTS
+  $ENV{SDL2DIR}
+  PATH_SUFFIXES include/SDL2 include
+  PATHS ${SDL2_SEARCH_PATHS}
+)
 
 FIND_LIBRARY(SDL2_LIBRARY_TEMP
   NAMES SDL2
   HINTS
   $ENV{SDL2DIR}
   PATH_SUFFIXES lib64 lib
-  PATHS
-  /sw
-  /opt/local
-  /opt/csw
-  /opt
+  PATHS ${SDL2_SEARCH_PATHS}
 )
-
-#MESSAGE("SDL2_LIBRARY_TEMP is ${SDL2_LIBRARY_TEMP}")
 
 IF(NOT SDL2_BUILDING_LIBRARY)
   IF(NOT ${SDL2_INCLUDE_DIR} MATCHES ".framework")
@@ -111,11 +102,7 @@ IF(NOT SDL2_BUILDING_LIBRARY)
       HINTS
       $ENV{SDL2DIR}
       PATH_SUFFIXES lib64 lib
-      PATHS
-      /sw
-      /opt/local
-      /opt/csw
-      /opt
+      PATHS ${SDL2_SEARCH_PATHS}
     )
   ENDIF(NOT ${SDL2_INCLUDE_DIR} MATCHES ".framework")
 ENDIF(NOT SDL2_BUILDING_LIBRARY)
@@ -135,7 +122,6 @@ IF(MINGW)
   SET(MINGW32_LIBRARY mingw32 CACHE STRING "mwindows for MinGW")
 ENDIF(MINGW)
 
-SET(SDL2_FOUND "NO")
 IF(SDL2_LIBRARY_TEMP)
   # For SDL2main
   IF(NOT SDL2_BUILDING_LIBRARY)
@@ -170,24 +156,8 @@ IF(SDL2_LIBRARY_TEMP)
   SET(SDL2_LIBRARY ${SDL2_LIBRARY_TEMP} CACHE STRING "Where the SDL2 Library can be found")
   # Set the temp variable to INTERNAL so it is not seen in the CMake GUI
   SET(SDL2_LIBRARY_TEMP "${SDL2_LIBRARY_TEMP}" CACHE INTERNAL "")
-
-  SET(SDL2_FOUND "YES")
-
-  # extract the major and minor version numbers from SDL2/SDL_version.h
-  # we have to handle framework a little bit differently :
-  if("${SDL2_INCLUDE_DIR}" MATCHES ".framework")
-    set(SDL2_VERSION_H_INPUT "${SDL2_INCLUDE_DIR}/Headers/SDL_version.h")
-  else()
-    set(SDL2_VERSION_H_INPUT "${SDL2_INCLUDE_DIR}/SDL_version.h")
-  endif()
-  FILE(READ "${SDL2_VERSION_H_INPUT}" SDL2_VERSION_H_CONTENTS)
-  STRING(REGEX REPLACE ".*#define[ \t]+SDL_MAJOR_VERSION[ \t]+([0-9]+).*#define[ \t]+SDL_MINOR_VERSION[ \t]+([0-9]+).*#define[ \t]+SDL_PATCHLEVEL[ \t]+([0-9]+).*"
-                       "\\1.\\2.\\3" SDL2_VERSION "${SDL2_VERSION_H_CONTENTS}")
-#MESSAGE("SDL2 Version is ${SDL2_VERSION}")
-
 ENDIF(SDL2_LIBRARY_TEMP)
 
 INCLUDE(FindPackageHandleStandardArgs)
 
-FIND_PACKAGE_HANDLE_STANDARD_ARGS(SDL2
-                                  REQUIRED_VARS SDL2_LIBRARY SDL2_INCLUDE_DIR VERSION_VAR SDL2_VERSION)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(SDL2 REQUIRED_VARS SDL2_LIBRARY SDL2_INCLUDE_DIR)

--- a/StepmaniaCore.cmake
+++ b/StepmaniaCore.cmake
@@ -221,6 +221,18 @@ if(WITH_OGG)
   endif()
 endif()
 
+if(WITH_SDL)
+
+    find_package(SDL2)
+    
+    if(NOT SDL2_FOUND)
+        message(FATAL_ERROR "SDL2 Library was not found. If you wish to compile without SDL2, set WITH_SDL to OFF when configuring.")
+    else()
+        set(HAS_SDL TRUE)
+    endif()
+
+endif()
+
 find_package(nasm)
 find_package(yasm)
 

--- a/Themes/_fallback/Languages/en.ini
+++ b/Themes/_fallback/Languages/en.ini
@@ -214,6 +214,9 @@ Importing these strings will override all data in '%s'. Continue?=Importing thes
 There are no strings to export for this language.=There are no strings to export for this language.
 This will permanently delete '%s'. Continue?=This will permanently delete '%s'. Continue?
 
+[LowLevelWindow_SDL]
+Failed to create an SDL window=Failed to create an SDL window
+
 [LowLevelWindow_X11]
 Failed to establish a connection with the X server=Failed to establish a connection with the X server
 

--- a/src/CMakeData-arch.cmake
+++ b/src/CMakeData-arch.cmake
@@ -206,9 +206,16 @@ elseif(APPLE)
     "arch/LowLevelWindow/LowLevelWindow_MacOSX.h"
   )
 else(UNIX)
-  if (X11_FOUND)
+  if (SDL2_FOUND)
     list(APPEND SMDATA_ARCH_LOWLEVEL_SRC
-      "arch/LowLevelWindow/LowLevelWindow_X11.cpp"
+      "arch/LowLevelWindow/LowLevelWindow_SDL.cpp"      
+    )
+    list(APPEND SMDATA_ARCH_LOWLEVEL_HPP
+      "arch/LowLevelWindow/LowLevelWindow_SDL.h"
+    )
+  elseif (X11_FOUND)
+      list(APPEND SMDATA_ARCH_LOWLEVEL_SRC
+      "arch/LowLevelWindow/LowLevelWindow_X11.cpp"   
     )
     list(APPEND SMDATA_ARCH_LOWLEVEL_HPP
       "arch/LowLevelWindow/LowLevelWindow_X11.h"

--- a/src/CMakeData-arch.cmake
+++ b/src/CMakeData-arch.cmake
@@ -191,7 +191,14 @@ list(APPEND SMDATA_ARCH_LOWLEVEL_HPP
   "arch/LowLevelWindow/LowLevelWindow.h"
 )
 
-if(WIN32)
+if(SDL2_FOUND)
+  list(APPEND SMDATA_ARCH_LOWLEVEL_SRC
+    "arch/LowLevelWindow/LowLevelWindow_SDL.cpp"
+  )
+  list(APPEND SMDATA_ARCH_LOWLEVEL_HPP
+    "arch/LowLevelWindow/LowLevelWindow_SDL.h"
+  )
+elseif(WIN32)
   list(APPEND SMDATA_ARCH_LOWLEVEL_SRC
     "arch/LowLevelWindow/LowLevelWindow_Win32.cpp"
   )
@@ -205,23 +212,14 @@ elseif(APPLE)
   list(APPEND SMDATA_ARCH_LOWLEVEL_HPP
     "arch/LowLevelWindow/LowLevelWindow_MacOSX.h"
   )
-else(UNIX)
-  if (SDL2_FOUND)
-    list(APPEND SMDATA_ARCH_LOWLEVEL_SRC
-      "arch/LowLevelWindow/LowLevelWindow_SDL.cpp"      
-    )
-    list(APPEND SMDATA_ARCH_LOWLEVEL_HPP
-      "arch/LowLevelWindow/LowLevelWindow_SDL.h"
-    )
-  elseif (X11_FOUND)
-      list(APPEND SMDATA_ARCH_LOWLEVEL_SRC
-      "arch/LowLevelWindow/LowLevelWindow_X11.cpp"   
-    )
-    list(APPEND SMDATA_ARCH_LOWLEVEL_HPP
-      "arch/LowLevelWindow/LowLevelWindow_X11.h"
-    )
-  endif()
-endif(WIN32)
+elseif (X11_FOUND)
+  list(APPEND SMDATA_ARCH_LOWLEVEL_SRC
+    "arch/LowLevelWindow/LowLevelWindow_X11.cpp"   
+  )
+  list(APPEND SMDATA_ARCH_LOWLEVEL_HPP
+    "arch/LowLevelWindow/LowLevelWindow_X11.h"
+  )
+endif()
 
 source_group("Arch Specific\\\\Low Level Window" FILES ${SMDATA_ARCH_LOWLEVEL_SRC} ${SMDATA_ARCH_LOWLEVEL_HPP})
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -183,12 +183,25 @@ if(WIN32)
   )
 
   if(MSVC)
-    # Allow for getting a virtualdub stack trace.
-    add_custom_command(TARGET "${SM_EXE_NAME}"
-      POST_BUILD
-      COMMAND "mapconv" "${SM_PROGRAM_DIR}/$<$<CONFIG:DEBUG>:${SM_NAME_DEBUG}>$<$<CONFIG:MINSIZEREL>:${SM_NAME_MINSIZEREL}>$<$<CONFIG:RELWITHDEBINFO>:${SM_NAME_RELWITHDEBINFO}>$<$<CONFIG:RELEASE>:${SM_NAME_RELEASE}>.map" "${SM_PROGRAM_DIR}/$<$<CONFIG:DEBUG>:${SM_NAME_DEBUG}>$<$<CONFIG:MINSIZEREL>:${SM_NAME_MINSIZEREL}>$<$<CONFIG:RELWITHDEBINFO>:${SM_NAME_RELWITHDEBINFO}>$<$<CONFIG:RELEASE>:${SM_NAME_RELEASE}>.vdi"
-      COMMENT "Generating file to allow for easier stack traces."
+    # TODO: Look into a better way for custom commands to reduce duplication.
+    if (SDL2_FOUND)
+      get_filename_component(SDL2_DLL_DIR ${SDL2_LIBRARY} DIRECTORY)
+      add_custom_command(TARGET "${SM_EXE_NAME}"
+        POST_BUILD
+        # Attempt to allow generating a stack trace.
+        COMMAND "mapconv" "${SM_PROGRAM_DIR}/$<$<CONFIG:DEBUG>:${SM_NAME_DEBUG}>$<$<CONFIG:MINSIZEREL>:${SM_NAME_MINSIZEREL}>$<$<CONFIG:RELWITHDEBINFO>:${SM_NAME_RELWITHDEBINFO}>$<$<CONFIG:RELEASE>:${SM_NAME_RELEASE}>.map" "${SM_PROGRAM_DIR}/$<$<CONFIG:DEBUG>:${SM_NAME_DEBUG}>$<$<CONFIG:MINSIZEREL>:${SM_NAME_MINSIZEREL}>$<$<CONFIG:RELWITHDEBINFO>:${SM_NAME_RELWITHDEBINFO}>$<$<CONFIG:RELEASE>:${SM_NAME_RELEASE}>.vdi"
+        # Copy the SDL2.dll
+        COMMAND ${CMAKE_COMMAND} -E copy "${SDL2_DLL_DIR}/SDL2.dll" "${SM_PROGRAM_DIR}/SDL2.dll"
+        COMMENT "Post-build stuff for Windows."
     )
+    else()
+      # Allow for getting a virtualdub stack trace.
+      add_custom_command(TARGET "${SM_EXE_NAME}"
+        POST_BUILD
+        COMMAND "mapconv" "${SM_PROGRAM_DIR}/$<$<CONFIG:DEBUG>:${SM_NAME_DEBUG}>$<$<CONFIG:MINSIZEREL>:${SM_NAME_MINSIZEREL}>$<$<CONFIG:RELWITHDEBINFO>:${SM_NAME_RELWITHDEBINFO}>$<$<CONFIG:RELEASE>:${SM_NAME_RELEASE}>.map" "${SM_PROGRAM_DIR}/$<$<CONFIG:DEBUG>:${SM_NAME_DEBUG}>$<$<CONFIG:MINSIZEREL>:${SM_NAME_MINSIZEREL}>$<$<CONFIG:RELWITHDEBINFO>:${SM_NAME_RELWITHDEBINFO}>$<$<CONFIG:RELEASE>:${SM_NAME_RELEASE}>.vdi"
+        COMMENT "Generating file to allow for easier stack traces."
+      )
+    endif()
   endif()
 elseif(APPLE)
   set_target_properties("${SM_EXE_NAME}" PROPERTIES
@@ -388,6 +401,11 @@ if (WIN32)
     )
   endif()
 
+  if(SDL2_FOUND)
+    list(APPEND SMDATA_LINK_LIB ${SDL2_LIBRARY})
+    sm_add_compile_definition("${SM_EXE_NAME}" HAVE_SDL)
+  endif()
+
   list(APPEND SMDATA_LINK_LIB
     "dbghelp.lib"
     "setupapi.lib"
@@ -396,6 +414,9 @@ if (WIN32)
 
   get_filename_component(DIRECTX_LIBRARY_DIR "${DIRECTX_LIBRARIES}" DIRECTORY)
 
+  if (SDL2_FOUND)
+    sm_add_link_flag("${SM_EXE_NAME}" "/LIBPATH:\"${SDL2_LIBRARY}\"")
+  endif()
   sm_add_link_flag("${SM_EXE_NAME}" "/LIBPATH:\"${DIRECTX_LIBRARY_DIR}\"")
   sm_add_link_flag("${SM_EXE_NAME}" "/LIBPATH:\"${SM_EXTERN_DIR}/ffmpeg/lib\"")
   sm_add_link_flag("${SM_EXE_NAME}" "/LIBPATH:\"${SM_SRC_DIR}/archutils/Win32/ddk\"")
@@ -450,6 +471,11 @@ elseif(APPLE)
       "${SM_FFMPEG_ROOT}/libswscale/libswscale.a"
       "${SM_FFMPEG_ROOT}/libavutil/libavutil.a"
     )
+  endif()
+
+  if(SDL2_FOUND)
+    list(APPEND SMDATA_LINK_LIB ${SDL2_LIBRARY})
+    sm_add_compile_definition("${SM_EXE_NAME}" HAVE_SDL)
   endif()
 else() # Unix / Linux
   # TODO: Remember to find and locate the zip archive files.
@@ -628,6 +654,12 @@ else()
       "${SM_FFMPEG_ROOT}"
     )
   endif()
+endif()
+
+if (WITH_SDL)
+  list(APPEND SM_INCLUDE_DIRS
+    ${SDL2_INCLUDE_DIR}
+  )
 endif()
 
 if(WIN32)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -530,6 +530,11 @@ else() # Unix / Linux
   if(X11_FOUND)
     list(APPEND SMDATA_LINK_LIB ${X11_LIBRARIES})
   endif()
+  
+  if(SDL2_FOUND)
+    list(APPEND SMDATA_LINK_LIB ${SDL2_LIBRARY})
+    sm_add_compile_definition("${SM_EXE_NAME}" HAVE_SDL)
+  endif()
 
   if(PCRE_FOUND)
     list(APPEND SMDATA_LINK_LIB ${PCRE_LIBRARY})

--- a/src/RageDisplay_OGL.cpp
+++ b/src/RageDisplay_OGL.cpp
@@ -862,9 +862,9 @@ void RageDisplay_Legacy::EndFrame()
 		CameraPopMatrix();
 	}
 
-	FrameLimitBeforeVsync( g_pWind->GetActualVideoModeParams().rate );
+    FrameLimitBeforeVsync( g_pWind->GetActualVideoModeParams().rate );
 	g_pWind->SwapBuffers();
-	FrameLimitAfterVsync();
+    FrameLimitAfterVsync();
 
 	// Some would advise against glFinish(), ever. Those people don't realize
 	// the degree of freedom GL hosts are permitted in queueing commands.

--- a/src/arch/InputHandler/InputHandler_DirectInputHelper.cpp
+++ b/src/arch/InputHandler/InputHandler_DirectInputHelper.cpp
@@ -58,7 +58,7 @@ bool DIDevice::Open()
 	hr = Device->SetCooperativeLevel( GraphicsWindow::GetHwnd(), coop );
 	if ( hr != DI_OK )
 	{
-		LOG->Info( hr_format(hr, "OpenDevice(%s): IDirectInputDevice2::SetCooperativeLevel", m_sName.c_str()) );
+		LOG->Info( hr_format(hr, "OpenDevice(%s): IDirectInputDevice2::SetCooperativeLevel", m_sName.c_str()) ); // TODO: Why could this crash when invalid handler?
 		return false;
 	}
 

--- a/src/arch/LowLevelWindow/LowLevelWindow_SDL.cpp
+++ b/src/arch/LowLevelWindow/LowLevelWindow_SDL.cpp
@@ -2,8 +2,11 @@
 #include "LowLevelWindow_SDL.h"
 #include "RageLog.h"
 #include "RageException.h"
+#if defined(X11_FOUND)
 #include "archutils/Unix/X11Helper.h"
+#endif
 #include "PrefsManager.h" // XXX
+#include "DisplaySpec.h"
 #include "RageDisplay.h" // VideoModeParams
 #include "DisplayResolutions.h"
 #include "LocalizedString.h"
@@ -13,9 +16,9 @@ using namespace RageDisplay_Legacy_Helpers;
 
 #include <stack>
 #include <math.h>	// ceil()
-#include <SDL2/SDL.h>
-#include <SDL2/SDL_opengl.h>
-#include <SDL2/SDL_syswm.h>
+#include <SDL.h>
+#include <SDL_opengl.h>
+#include <SDL_syswm.h>
 
 
 static SDL_Window* g_DisplayWindow;
@@ -91,8 +94,10 @@ std::string LowLevelWindow_SDL::TryVideoMode( const VideoModeParams &p, bool &bN
         SDL_VERSION(&info.version);
 
         if(SDL_GetWindowWMInfo(g_DisplayWindow,&info)) { // Retrieve the Window ID so that the X11 InputHandler can use this
+#if defined(X11_FOUND)
             X11Helper::Win = info.info.x11.window;
             X11Helper::Dpy = info.info.x11.display;
+#endif
         }
         else
         {

--- a/src/arch/LowLevelWindow/LowLevelWindow_SDL.cpp
+++ b/src/arch/LowLevelWindow/LowLevelWindow_SDL.cpp
@@ -1,0 +1,165 @@
+#include "global.h"
+#include "LowLevelWindow_SDL.h"
+#include "RageLog.h"
+#include "RageException.h"
+#include "archutils/Unix/X11Helper.h"
+#include "PrefsManager.h" // XXX
+#include "RageDisplay.h" // VideoModeParams
+#include "DisplayResolutions.h"
+#include "LocalizedString.h"
+
+#include "RageDisplay_OGL_Helpers.h"
+using namespace RageDisplay_Legacy_Helpers;
+
+#include <stack>
+#include <math.h>	// ceil()
+#include <SDL2/SDL.h>
+#include <SDL2/SDL_opengl.h>
+#include <SDL2/SDL_syswm.h>
+
+
+static SDL_Window* g_DisplayWindow;
+static SDL_DisplayMode g_DisplayMode;
+static SDL_GLContext g_Context;
+
+static LocalizedString FAILED_WINDOW_SDL( "LowLevelWindow_SDL", "Failed to create an SDL window" );
+LowLevelWindow_SDL::LowLevelWindow_SDL()
+{
+    if ( SDL_Init(SDL_INIT_VIDEO) != 0)
+         RageException::Throw( "SDL Error in %s: %s",__FUNCTION__, SDL_GetError());
+
+    //SDL_GetDesktopDisplayMode(1, &g_DisplayMode);
+
+}
+
+LowLevelWindow_SDL::~LowLevelWindow_SDL()
+{
+    SDL_Quit(); // Shutting down SDL properly (will restore resolution automatically
+}
+
+std::string LowLevelWindow_SDL::TryVideoMode( const VideoModeParams &p, bool &bNewDeviceOut )
+{
+    LOG->Trace("%s called", __FUNCTION__);
+
+
+
+
+    g_DisplayMode.h = p.height;
+    g_DisplayMode.w = p.width;
+    g_DisplayMode.refresh_rate = p.rate;
+
+
+    if (g_DisplayWindow == nullptr) // If there is no Window yet create one first.
+    {
+
+        //Create window
+        g_DisplayWindow = SDL_CreateWindow( p.sWindowTitle.c_str(), SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, g_DisplayMode.w, g_DisplayMode.h, SDL_WINDOW_OPENGL | SDL_WINDOW_SHOWN );
+        if( g_DisplayWindow == NULL )
+        {
+            LOG->Warn( "%s SDL Error: %s\n",FAILED_WINDOW_SDL.GetValue().c_str(), SDL_GetError() );
+            return "Failed to create SDL window";
+        }
+        //Create context
+        auto g_Context = SDL_GL_CreateContext( g_DisplayWindow );
+        if( g_Context == NULL )
+        {
+            LOG->Warn( "OpenGL context could not be created! SDL Error: %s\n", SDL_GetError() );
+            return "Failed to create OGL context";
+        }
+
+        SDL_SysWMinfo info;
+        SDL_VERSION(&info.version);
+
+        if(SDL_GetWindowWMInfo(g_DisplayWindow,&info)) { // Retrieve the Window ID so that the X11 InputHandler can use this
+            X11Helper::Win = info.info.x11.window;
+            X11Helper::Dpy = info.info.x11.display;
+        }
+        else
+        {
+            LOG->Warn("Could not retrieve Window information: %s", SDL_GetError());
+        }
+
+    }
+
+
+    if (p.windowed)
+    {
+        SDL_SetWindowFullscreen(g_DisplayWindow, 0);
+        SDL_SetWindowSize(g_DisplayWindow, g_DisplayMode.w, g_DisplayMode.h);
+    }
+    else {
+        SDL_SetWindowFullscreen(g_DisplayWindow, SDL_WINDOW_FULLSCREEN);
+        if (SDL_SetWindowDisplayMode(g_DisplayWindow,&g_DisplayMode) != 0)
+            LOG->Warn( "Error setting DisplayMode %s", SDL_GetError());
+    }
+    CurrentParams = p;
+
+    if (g_DisplayMode.refresh_rate != 0) // If SDL does not specify a refresh rate assume 60
+        CurrentParams.rate = g_DisplayMode.refresh_rate;
+    else
+        CurrentParams.rate = 60;
+
+    if (p.vsync)
+    {
+        SDL_GL_SetSwapInterval(1);
+    }
+    else
+    {
+        SDL_GL_SetSwapInterval(0);
+    }
+
+    return ""; // Success
+}
+
+bool LowLevelWindow_SDL::IsSoftwareRenderer( std::string &sError )
+{
+    return false;
+}
+
+void LowLevelWindow_SDL::SwapBuffers()
+{
+    SDL_GL_SwapWindow(g_DisplayWindow);
+}
+
+void LowLevelWindow_SDL::GetDisplaySpecs( DisplaySpecs &out ) const
+{
+    int displayCount;
+    SDL_DisplayMode mode;
+
+    std::set<DisplayMode> outputSupported;
+
+    displayCount = SDL_GetNumVideoDisplays();
+    if (displayCount < 1)
+    {
+        LOG->Warn("SDL_GetNumVideoDisplays failed: %s", displayCount);
+        return;
+    }
+
+
+
+    for ( int i = 0; i < displayCount; i++)
+    {
+        LOG->Trace("Checking modes for display %i", i);
+        auto nummodes = SDL_GetNumDisplayModes(i);
+        for (int j = 1; j < nummodes; j++){
+            if (SDL_GetDisplayMode(i,j, &mode) != 0) {
+                LOG->Warn("SDL_GetDisplayMode failed: %s", SDL_GetError());
+                return;
+            }
+            LOG->Info(" Mode %d: %dx%d %dbpp %dHz", j, mode.w, mode.h, SDL_BITSPERPIXEL(mode.format), mode.refresh_rate);
+            DisplayMode res = { mode.w, mode.h, mode.refresh_rate };
+            outputSupported.insert( res );
+        }
+        const std::string outId(std::to_string(i));
+        const std::string outName(SDL_GetDisplayName(i));
+        out.insert( DisplaySpec( outId, outName, outputSupported ));
+    }
+
+}
+
+bool LowLevelWindow_SDL::SupportsFullscreenBorderlessWindow() const
+{
+    return true;
+}
+
+

--- a/src/arch/LowLevelWindow/LowLevelWindow_SDL.cpp
+++ b/src/arch/LowLevelWindow/LowLevelWindow_SDL.cpp
@@ -5,6 +5,12 @@
 #if defined(X11_FOUND)
 #include "archutils/Unix/X11Helper.h"
 #endif
+
+#if defined (WINDOWS)
+#include "archutils/Win32/GraphicsWindow.h"
+#include "archutils/Win32/Crash.h"
+#endif
+
 #include "PrefsManager.h" // XXX
 #include "DisplaySpec.h"
 #include "RageDisplay.h" // VideoModeParams
@@ -21,14 +27,19 @@ using namespace RageDisplay_Legacy_Helpers;
 #include <SDL_syswm.h>
 
 
+
+#include "arch/ArchHooks/ArchHooks.h"
+
+
 static SDL_Window* g_DisplayWindow;
 static SDL_DisplayMode g_DisplayMode;
 static SDL_GLContext g_Context;
+static SDL_Event g_Event;
 
 static LocalizedString FAILED_WINDOW_SDL( "LowLevelWindow_SDL", "Failed to create an SDL window" );
 LowLevelWindow_SDL::LowLevelWindow_SDL()
 {
-    if ( SDL_Init(SDL_INIT_VIDEO) != 0)
+    if ( SDL_InitSubSystem(SDL_INIT_VIDEO) != 0)
          RageException::Throw( "SDL Error in %s: %s",__FUNCTION__, SDL_GetError());
 
     //SDL_GetDesktopDisplayMode(1, &g_DisplayMode);
@@ -76,7 +87,7 @@ std::string LowLevelWindow_SDL::TryVideoMode( const VideoModeParams &p, bool &bN
     {
 
         //Create window
-        g_DisplayWindow = SDL_CreateWindow( p.sWindowTitle.c_str(), SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, g_DisplayMode.w, g_DisplayMode.h, SDL_WINDOW_OPENGL | SDL_WINDOW_SHOWN );
+        g_DisplayWindow = SDL_CreateWindow( p.sWindowTitle.c_str(), SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, g_DisplayMode.w, g_DisplayMode.h, SDL_WINDOW_OPENGL );
         if( g_DisplayWindow == NULL )
         {
             LOG->Warn( "%s SDL Error: %s\n",FAILED_WINDOW_SDL.GetValue().c_str(), SDL_GetError() );
@@ -98,6 +109,10 @@ std::string LowLevelWindow_SDL::TryVideoMode( const VideoModeParams &p, bool &bN
             X11Helper::Win = info.info.x11.window;
             X11Helper::Dpy = info.info.x11.display;
 #endif
+#if defined(WINDOWS)
+			GraphicsWindow::SetHwnd(info.info.win.window); // So that DInput knows about our SDL created window
+			//CrashHandler::SetForegroundWindow(info.info.win.window);
+#endif
         }
         else
         {
@@ -106,14 +121,16 @@ std::string LowLevelWindow_SDL::TryVideoMode( const VideoModeParams &p, bool &bN
 
     }
 
+	
     if (p.windowed && !p.bWindowIsFullscreenBorderless)
     {
         SDL_SetWindowFullscreen(g_DisplayWindow, 0);
         SDL_SetWindowSize(g_DisplayWindow, g_DisplayMode.w, g_DisplayMode.h);
+		SDL_SetWindowPosition(g_DisplayWindow, SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED);
     }
     else
     {
-        auto target = GetSDLDisplayNum( p.sDisplayId );
+		auto target = GetSDLDisplayNum( p.sDisplayId );
         SDL_DisplayMode cur_mode;
         SDL_Rect cur_bounds;
         // Reset fullscreen, move window onto desired monitor, then set fullscreen mode accordingly
@@ -172,6 +189,14 @@ bool LowLevelWindow_SDL::IsSoftwareRenderer( std::string &sError )
 void LowLevelWindow_SDL::SwapBuffers()
 {
     SDL_GL_SwapWindow(g_DisplayWindow);
+	while (SDL_PollEvent(&g_Event) != 0)
+	{
+		if (g_Event.type == SDL_QUIT)
+		{
+			LOG->Trace("SDL_QUIT: shutting down");
+			ArchHooks::SetUserQuit();
+		}
+	}
 }
 
 void LowLevelWindow_SDL::GetDisplaySpecs( DisplaySpecs &out ) const

--- a/src/arch/LowLevelWindow/LowLevelWindow_SDL.h
+++ b/src/arch/LowLevelWindow/LowLevelWindow_SDL.h
@@ -1,0 +1,36 @@
+/* LowLevelWindow_SDL - SDL2 Window driver*/
+
+#ifndef LOW_LEVEL_WINDOW_SDL_H
+#define LOW_LEVEL_WINDOW_SDL_H
+
+#include "RageDisplay.h" // VideoModeParams
+#include "LowLevelWindow.h"
+
+class LowLevelWindow_SDL : public LowLevelWindow
+{
+public:
+    LowLevelWindow_SDL();
+    ~LowLevelWindow_SDL();
+
+    void *GetProcAddress(std::string s){ return nullptr; } // TODO: Windows
+    std::string TryVideoMode(const VideoModeParams &p, bool &bNewDeviceOut);
+    bool IsSoftwareRenderer( std::string &sError );
+    void SwapBuffers();
+
+    const ActualVideoModeParams GetActualVideoModeParams() const { return CurrentParams; }
+
+    void GetDisplaySpecs(DisplaySpecs &out) const;
+
+    bool SupportsFullscreenBorderlessWindow() const;
+
+private:
+
+    ActualVideoModeParams CurrentParams;
+};
+
+#ifdef ARCH_LOW_LEVEL_WINDOW
+#error "More than one LowLevelWindow selected!"
+#endif
+#define ARCH_LOW_LEVEL_WINDOW LowLevelWindow_SDL
+
+#endif

--- a/src/arch/LowLevelWindow/LowLevelWindow_SDL.h
+++ b/src/arch/LowLevelWindow/LowLevelWindow_SDL.h
@@ -24,7 +24,7 @@ public:
     bool SupportsFullscreenBorderlessWindow() const;
 
 private:
-
+	int GetSDLDisplayNum( const std::string displayID ) const;
     ActualVideoModeParams CurrentParams;
 };
 

--- a/src/arch/arch_default.h
+++ b/src/arch/arch_default.h
@@ -24,7 +24,11 @@
 
 #elif defined(UNIX)
 #include "ArchHooks/ArchHooks_Unix.h"
+#if defined(HAVE_SDL)
+#include "LowLevelWindow/LowLevelWindow_SDL.h"
+#else
 #include "LowLevelWindow/LowLevelWindow_X11.h"
+#endif
 
 #if defined(LINUX)
 #include "MemoryCard/MemoryCardDriverThreaded_Linux.h"

--- a/src/arch/arch_default.h
+++ b/src/arch/arch_default.h
@@ -5,7 +5,11 @@
 #if defined(WINDOWS)
 #include "ArchHooks/ArchHooks_Win32.h"
 #include "LoadingWindow/LoadingWindow_Win32.h"
+#if defined(HAVE_SDL)
+#include "LowLevelWindow/LowLevelWindow_SDL.h"
+#else
 #include "LowLevelWindow/LowLevelWindow_Win32.h"
+#endif
 #include "MemoryCard/MemoryCardDriverThreaded_Windows.h"
 #define DEFAULT_INPUT_DRIVER_LIST "DirectInput,Pump,Para"
 #define DEFAULT_MOVIE_DRIVER_LIST "FFMpeg,DShow,Null"
@@ -14,8 +18,12 @@
 
 #elif defined(MACOSX)
 #include "ArchHooks/ArchHooks_MacOSX.h"
-#include "LoadingWindow/LoadingWindow_MacOSX.h"
+#if defined(HAVE_SDL)
+#include "LowLevelWindow/LowLevelWindow_SDL.h"
+#else
 #include "LowLevelWindow/LowLevelWindow_MacOSX.h"
+#endif
+#include "LoadingWindow/LoadingWindow_MacOSX.h"
 #include "MemoryCard/MemoryCardDriverThreaded_MacOSX.h"
 #define DEFAULT_INPUT_DRIVER_LIST "HID"
 #define DEFAULT_MOVIE_DRIVER_LIST "FFMpeg,Null"

--- a/src/archutils/Win32/GraphicsWindow.cpp
+++ b/src/archutils/Win32/GraphicsWindow.cpp
@@ -512,6 +512,11 @@ HWND GraphicsWindow::GetHwnd()
 	return g_hWndMain;
 }
 
+void GraphicsWindow::SetHwnd(HWND a_Handle)
+{
+	g_hWndMain = a_Handle;
+}
+
 void GraphicsWindow::GetDisplaySpecs( DisplaySpecs &out )
 {
 	const size_t DM_DRIVER_EXTRA_BYTES = 4096;

--- a/src/archutils/Win32/GraphicsWindow.h
+++ b/src/archutils/Win32/GraphicsWindow.h
@@ -35,6 +35,7 @@ namespace GraphicsWindow
 	void Update();
 
 	HWND GetHwnd();
+	void SetHwnd(HWND a_Handle);
 };
 
 #endif

--- a/src/config.in.hpp
+++ b/src/config.in.hpp
@@ -54,6 +54,9 @@
 /* Defined to 1 if the underlying system provides the strtof function. */
 #cmakedefine HAVE_STRTOF 1
 
+/* Defined to 1 if the underlying system is using X11. */
+#cmakedefine X11_FOUND 1
+
 /* Defined to 1 if the underlying system provides the posix_fadvise function. */
 #cmakedefine HAVE_POSIX_FADVISE 1
 


### PR DESCRIPTION
## Works:
- Creating SDL2 Windows for Linux and Windows and using OpenGL to render.
- Getting/Setting modes through SDL2
- Shutting down the game / Closing the Window by the X, ALT+F4 etc.
## Does not work:
- Mac OSX port
- ~~After setting a mode, the new window will be located in the left upper corner of the display making it impossible to drag it.~~ (works now)
- D3D renderer will still use the "native" way.
