### PR TITLE
TimingData optimization with line segments

### DIFF
--- a/Docs/Changelog_sm5_1.txt
+++ b/Docs/Changelog_sm5_1.txt
@@ -7,6 +7,17 @@ StepMania 5.1 and StepMania 5.0 have separate changelogs so that devs working
 on the different branches don't have conflicts on the changelog file.
 ________________________________________________________________________________
 
+2016/10/08
+----------
+* [TimingData] Replaced starting point lookup table system with new idea
+  based on transforming timing segments into line segments and using linear
+	interpolation.  Cuts SetOccuranceTimeForAllTaps to 1/3 as much time, which
+	means GetElapsedTimeFromBeat is much faster than before. [kyzentun]
+* [SongPosition] Removed GetWarpBeginRow and GetWarpDestination lua
+  functions.  It's impossible for SongPosition Update to result in a beat
+	that is inside a warp, so they were useless anyway. [kyzentun]
+
+
 2016/09/28
 ----------
 * [ScreenEditMenu] Added "Recently Visited Groups" submenu.  Menu now loads

--- a/Docs/Changelog_sm5_1.txt
+++ b/Docs/Changelog_sm5_1.txt
@@ -11,12 +11,11 @@ ________________________________________________________________________________
 ----------
 * [TimingData] Replaced starting point lookup table system with new idea
   based on transforming timing segments into line segments and using linear
-	interpolation.  Cuts SetOccuranceTimeForAllTaps to 1/3 as much time, which
-	means GetElapsedTimeFromBeat is much faster than before. [kyzentun]
+  interpolation.  Cuts SetOccuranceTimeForAllTaps to 1/3 as much time, which
+  means GetElapsedTimeFromBeat is much faster than before. [kyzentun]
 * [SongPosition] Removed GetWarpBeginRow and GetWarpDestination lua
   functions.  It's impossible for SongPosition Update to result in a beat
-	that is inside a warp, so they were useless anyway. [kyzentun]
-
+  that is inside a warp, so they were useless anyway. [kyzentun]
 
 2016/09/28
 ----------

--- a/Docs/Changelog_sm5_1.txt
+++ b/Docs/Changelog_sm5_1.txt
@@ -14,8 +14,7 @@ ________________________________________________________________________________
   interpolation.  Cuts SetOccuranceTimeForAllTaps to 1/3 as much time, which
   means GetElapsedTimeFromBeat is much faster than before. [kyzentun]
 * [SongPosition] Removed GetWarpBeginRow and GetWarpDestination lua
-  functions.  It's impossible for SongPosition Update to result in a beat
-  that is inside a warp, so they were useless anyway. [kyzentun]
+  functions. [kyzentun]
 
 2016/09/28
 ----------

--- a/Docs/Luadoc/Lua.xml
+++ b/Docs/Luadoc/Lua.xml
@@ -1730,8 +1730,6 @@
 			<Function name='GetSongBeat'/>
 			<Function name='GetSongBeatNoOffset'/>
 			<Function name='GetSongBeatVisible'/>
-			<Function name='GetWarpBeginRow'/>
-			<Function name='GetWarpDestination'/>
 		</Class>
 		<Class base='Actor' name='Sprite'>
 			<Function name='CropTo'/>

--- a/Docs/Luadoc/LuaDocumentation.xml
+++ b/Docs/Luadoc/LuaDocumentation.xml
@@ -5065,12 +5065,6 @@ save yourself some time, copy this for undocumented things:
 	<Function name='GetSongBeatVisible' return='float' arguments=''>
 		<!-- todo -->
 	</Function>
-	<Function name='GetWarpBeginRow' return='int' arguments=''>
-		Returns the row where a warp appears.
-	</Function>
-	<Function name='GetWarpDestination' return='float' arguments=''>
-		Returns the warp destination length.
-	</Function>
 </Class>
 <Class name='Sprite'>
 	<Function name='GetAnimationLengthSeconds' return='float' arguments=''>

--- a/src/ActorUtil.cpp
+++ b/src/ActorUtil.cpp
@@ -141,7 +141,7 @@ namespace
 			if (hackFile == "songbackground")
 			{
 				XNodeStringValue *pVal = new XNodeStringValue;
-				Song *pSong = GAMESTATE->m_pCurSong;
+				Song *pSong = GAMESTATE->get_curr_song();
 				if (pSong && pSong->HasBackground())
 					pVal->SetValue(pSong->GetBackgroundPath());
 				else
@@ -152,7 +152,7 @@ namespace
 			else if ( hackFile == "songbanner")
 			{
 				XNodeStringValue *pVal = new XNodeStringValue;
-				Song *pSong = GAMESTATE->m_pCurSong;
+				Song *pSong = GAMESTATE->get_curr_song();
 				if (pSong && pSong->HasBanner())
 					pVal->SetValue(pSong->GetBannerPath());
 				else

--- a/src/AdjustSync.cpp
+++ b/src/AdjustSync.cpp
@@ -59,10 +59,10 @@ void AdjustSync::ResetOriginalSyncData()
 {
 	s_vpTimingDataOriginal.clear();
 
-	if( GAMESTATE->m_pCurSong )
+	if( GAMESTATE->get_curr_song() )
 	{
-		s_vpTimingDataOriginal.push_back(GAMESTATE->m_pCurSong->m_SongTiming);
-		auto const & vpSteps = GAMESTATE->m_pCurSong->GetAllSteps();
+		s_vpTimingDataOriginal.push_back(GAMESTATE->get_curr_song()->m_SongTiming);
+		auto const & vpSteps = GAMESTATE->get_curr_song()->GetAllSteps();
 		for (auto *s: vpSteps)
 		{
 			s_vpTimingDataOriginal.push_back(s->m_Timing);
@@ -103,7 +103,7 @@ void AdjustSync::SaveSyncChanges()
 
 	/* TODO: Save all of the timing data changes.
 	 * Luckily, only the song timing data needs comparing here. */
-	if( GAMESTATE->m_pCurSong && s_vpTimingDataOriginal[0] != GAMESTATE->m_pCurSong->m_SongTiming )
+	if( GAMESTATE->get_curr_song() && s_vpTimingDataOriginal[0] != GAMESTATE->get_curr_song()->m_SongTiming )
 	{
 		if( GAMESTATE->IsEditing() )
 		{
@@ -111,7 +111,7 @@ void AdjustSync::SaveSyncChanges()
 		}
 		else
 		{
-			GAMESTATE->m_pCurSong->Save();
+			GAMESTATE->get_curr_song()->Save();
 		}
 	}
 	if( s_fGlobalOffsetSecondsOriginal != PREFSMAN->m_fGlobalOffsetSeconds )
@@ -128,10 +128,10 @@ void AdjustSync::RevertSyncChanges()
 	PREFSMAN->m_fGlobalOffsetSeconds.Set( s_fGlobalOffsetSecondsOriginal );
 
 	// The first one is ALWAYS the song timing.
-	GAMESTATE->m_pCurSong->m_SongTiming = s_vpTimingDataOriginal[0];
+	GAMESTATE->get_curr_song()->m_SongTiming = s_vpTimingDataOriginal[0];
 
 	unsigned location = 1;
-	auto const & vpSteps = GAMESTATE->m_pCurSong->GetAllSteps();
+	auto const & vpSteps = GAMESTATE->get_curr_song()->GetAllSteps();
 	for (auto *s: vpSteps)
 	{
 		s->m_Timing = s_vpTimingDataOriginal[location];
@@ -201,8 +201,8 @@ void AdjustSync::AutosyncOffset()
 		{
 			case AutosyncType_Song:
 			{
-				GAMESTATE->m_pCurSong->m_SongTiming.m_fBeat0OffsetInSeconds += mean;
-				auto const & vpSteps = GAMESTATE->m_pCurSong->GetAllSteps();
+				GAMESTATE->get_curr_song()->m_SongTiming.m_fBeat0OffsetInSeconds += mean;
+				auto const & vpSteps = GAMESTATE->get_curr_song()->GetAllSteps();
 				for (auto *s: vpSteps)
 				{
 					// Empty TimingData means it's inherited
@@ -257,9 +257,9 @@ void AdjustSync::AutosyncTempo()
 		if( !CalcLeastSquares( s_vAutosyncTempoData, fSlope, fIntercept, fFilteredError ) )
 			return;
 
-		GAMESTATE->m_pCurSong->m_SongTiming.m_fBeat0OffsetInSeconds += fIntercept;
+		GAMESTATE->get_curr_song()->m_SongTiming.m_fBeat0OffsetInSeconds += fIntercept;
 		const float fScaleBPM = 1.0f/(1.0f - fSlope);
-		TimingData &timing = GAMESTATE->m_pCurSong->m_SongTiming;
+		TimingData &timing = GAMESTATE->get_curr_song()->m_SongTiming;
 
 		const vector<TimingSegment *> &bpms = timing.GetTimingSegments(SEGMENT_BPM);
 		for (unsigned i = 0; i < bpms.size(); i++)
@@ -329,7 +329,7 @@ void AdjustSync::GetSyncChangeTextGlobal( vector<std::string> &vsAddTo )
 // XXX: needs cleanup still -- vyhd
 void AdjustSync::GetSyncChangeTextSong( vector<std::string> &vsAddTo )
 {
-	if( GAMESTATE->m_pCurSong.Get() )
+	if(GAMESTATE->get_curr_song())
 	{
 #define SEGMENTS_MISMATCH_MESSAGE(orig, test, segments_name) \
 	if(orig.size() != test.size()) \
@@ -339,7 +339,7 @@ void AdjustSync::GetSyncChangeTextSong( vector<std::string> &vsAddTo )
 
 		unsigned int iOriginalSize = vsAddTo.size();
 		TimingData &original = s_vpTimingDataOriginal[0];
-		TimingData &testing = GAMESTATE->m_pCurSong->m_SongTiming;
+		TimingData &testing = GAMESTATE->get_curr_song()->m_SongTiming;
 
 		{
 			float fOld = Quantize( original.m_fBeat0OffsetInSeconds, 0.001f );

--- a/src/ArrowDefects.cpp
+++ b/src/ArrowDefects.cpp
@@ -165,10 +165,7 @@ void ArrowDefects::update(float music_beat, float music_second)
 	float const* accels= m_options->m_fAccels;
 	if(accels[PlayerOptions::ACCEL_EXPAND] != 0.f)
 	{
-		TimingData::GetBeatArgs beat_data;
-		beat_data.elapsed_time= m_music_second;
-		m_timing_data->GetBeatAndBPSFromElapsedTime(beat_data);
-		m_expand_seconds= fmodf(m_music_second - beat_data.total_stop_time, Rage::PI * 2.0);
+		m_expand_seconds= fmodf(m_timing_data->GetExpandSeconds(m_music_second), Rage::PI * 2.0);
 	}
 	if(effects[PlayerOptions::EFFECT_TORNADO] != 0.f)
 	{

--- a/src/AutoKeysounds.cpp
+++ b/src/AutoKeysounds.cpp
@@ -44,7 +44,7 @@ void AutoKeysounds::LoadAutoplaySoundsInto( RageSoundReader_Chain *pChain )
 	//
 	// Load sounds.
 	//
-	Song* pSong = GAMESTATE->m_pCurSong;
+	Song* pSong = GAMESTATE->get_curr_song();
 	std::string sSongDir = pSong->GetSongDir();
 
 	/*
@@ -259,7 +259,7 @@ void AutoKeysounds::FinishLoading()
 {
 	m_sSound.Unload();
 
-	Song* pSong = GAMESTATE->m_pCurSong;
+	Song* pSong = GAMESTATE->get_curr_song();
 
 	vector<RageSoundReader *> apSounds;
 	LoadTracks( pSong, m_pSharedSound, m_pPlayerSounds[0], m_pPlayerSounds[1] );
@@ -340,7 +340,7 @@ void AutoKeysounds::Update( float fDelta )
 	bool bCrossedABeat = false;
 	{
 		float fPositionSeconds = GAMESTATE->m_fMusicSeconds;
-		float fSongBeat = GAMESTATE->m_pCurSong->GetBeatFromElapsedTime( fPositionSeconds );
+		float fSongBeat = GAMESTATE->get_curr_song()->GetBeatFromElapsedTime( fPositionSeconds );
 
 		int iRowNow = BeatToNoteRowNotRounded( fSongBeat );
 		iRowNow = std::max( 0, iRowNow );

--- a/src/BGAnimationLayer.cpp
+++ b/src/BGAnimationLayer.cpp
@@ -75,7 +75,7 @@ void BGAnimationLayer::LoadFromAniLayerFile( const std::string& sPath )
 
 	if( lcPath.find("usesongbg") != std::string::npos )
 	{
-		const Song* pSong = GAMESTATE->m_pCurSong;
+		const Song* pSong = GAMESTATE->get_curr_song();
 		std::string sSongBGPath;
 		if( pSong && pSong->HasBackground() )
 			sSongBGPath = pSong->GetBackgroundPath();

--- a/src/BPMDisplay.cpp
+++ b/src/BPMDisplay.cpp
@@ -253,12 +253,12 @@ void BPMDisplay::SetVarious()
 
 void BPMDisplay::SetFromGameState()
 {
-	if( GAMESTATE->m_pCurSong.Get() )
+	if(GAMESTATE->get_curr_song())
 	{
 		if( GAMESTATE->IsAnExtraStageAndSelectionLocked() )
 			CycleRandomly();
 		else
-			SetBpmFromSong( GAMESTATE->m_pCurSong );
+			SetBpmFromSong( GAMESTATE->get_curr_song() );
 		return;
 	}
 	if( GAMESTATE->m_pCurCourse.Get() )

--- a/src/Background.cpp
+++ b/src/Background.cpp
@@ -953,7 +953,7 @@ void BrightnessOverlay::SetActualBrightness()
 	// anything. -Kyz
 	/*
 	// HACK: Always show training in full brightness
-	if( GAMESTATE->m_pCurSong && GAMESTATE->m_pCurSong->IsTutorial() )
+	if( GAMESTATE->get_curr_song() && GAMESTATE->get_curr_song()->IsTutorial() )
 		fBaseBGBrightness = 1.0f;
 	*/
 

--- a/src/Background.cpp
+++ b/src/Background.cpp
@@ -737,15 +737,13 @@ void BackgroundImpl::Layer::UpdateCurBGChange( const Song *pSong, float fLastMus
 	if( m_aBGChanges.size() == 0 )
 		return;
 
-	TimingData::GetBeatArgs beat_info;
-	beat_info.elapsed_time= fCurrentTime;
-	pSong->m_SongTiming.GetBeatAndBPSFromElapsedTime(beat_info);
+	float curr_beat= pSong->m_SongTiming.GetBeatFromElapsedTime(fCurrentTime);
 
 	// Calls to Update() should *not* be scaled by music rate; fCurrentTime is. Undo it.
 	const float fRate = GAMESTATE->m_SongOptions.GetCurrent().m_fMusicRate;
 
 	// Find the BGSegment we're in
-	const int i = FindBGSegmentForBeat(beat_info.beat);
+	const int i = FindBGSegmentForBeat(curr_beat);
 
 	float fDeltaTime = fCurrentTime - fLastMusicSeconds;
 	if( i != -1  &&  i != m_iCurBGChangeIndex )	// we're changing backgrounds

--- a/src/CourseUtil.cpp
+++ b/src/CourseUtil.cpp
@@ -470,7 +470,7 @@ void EditCourseUtil::UpdateAndSetTrail()
 
 void EditCourseUtil::PrepareForPlay()
 {
-	GAMESTATE->m_pCurSong.Set( nullptr );	// CurSong will be set if we back out.  Set it back to nullptr so that ScreenStage won't show the last song.
+	GAMESTATE->set_curr_song(nullptr);	// CurSong will be set if we back out.  Set it back to nullptr so that ScreenStage won't show the last song.
 	GAMESTATE->m_PlayMode.Set( PLAY_MODE_ENDLESS );
 	GAMESTATE->m_bSideIsJoined[0] = true;
 

--- a/src/DancingCharacters.cpp
+++ b/src/DancingCharacters.cpp
@@ -171,8 +171,8 @@ void DancingCharacters::LoadNextSong()
 	m_fThisCameraStartBeat = 0;
 	m_fThisCameraEndBeat = 0;
 
-	ASSERT( GAMESTATE->m_pCurSong != nullptr );
-	m_fThisCameraEndBeat = GAMESTATE->m_pCurSong->GetFirstBeat();
+	ASSERT( GAMESTATE->get_curr_song() != nullptr );
+	m_fThisCameraEndBeat = GAMESTATE->get_curr_song()->GetFirstBeat();
 
 	FOREACH_PlayerNumber( p )
 		if( GAMESTATE->IsPlayerEnabled(p) )
@@ -218,7 +218,7 @@ void DancingCharacters::Update( float fDelta )
 	bWasGameplayStarting = bGameplayStarting;
 
 	static float fLastBeat = GAMESTATE->m_Position.m_fSongBeat;
-	float firstBeat = GAMESTATE->m_pCurSong->GetFirstBeat();
+	float firstBeat = GAMESTATE->get_curr_song()->GetFirstBeat();
 	float fThisBeat = GAMESTATE->m_Position.m_fSongBeat;
 	if( fLastBeat < firstBeat && fThisBeat >= firstBeat )
 	{

--- a/src/DifficultyList.cpp
+++ b/src/DifficultyList.cpp
@@ -268,7 +268,7 @@ void StepsDisplayList::PositionItems()
 
 void StepsDisplayList::SetFromGameState()
 {
-	const Song *pSong = GAMESTATE->m_pCurSong;
+	const Song *pSong = GAMESTATE->get_curr_song();
 	unsigned i = 0;
 
 	if( pSong == nullptr )

--- a/src/GameCommand.cpp
+++ b/src/GameCommand.cpp
@@ -133,7 +133,7 @@ bool GameCommand::DescribesCurrentMode( PlayerNumber pn ) const
 			return false;
 	}
 
-	if( m_pSong && GAMESTATE->m_pCurSong.Get() != m_pSong )
+	if(m_pSong && GAMESTATE->get_curr_song() != m_pSong)
 		return false;
 	if( m_pSteps && GAMESTATE->m_pCurSteps[pn].Get() != m_pSteps )
 		return false;
@@ -298,7 +298,7 @@ void GameCommand::LoadOne( const Command& cmd )
 		// This must be processed after "song" and "style" commands.
 		if( !m_bInvalid )
 		{
-			Song *pSong = (m_pSong != nullptr)? m_pSong:GAMESTATE->m_pCurSong;
+			Song *pSong = (m_pSong != nullptr)? m_pSong:GAMESTATE->get_curr_song();
 			const Style *pStyle = m_pStyle ? m_pStyle : GAMESTATE->GetCurrentStyle(GAMESTATE->GetMasterPlayerNumber());
 			if( pSong == nullptr || pStyle == nullptr )
 			{
@@ -800,7 +800,7 @@ void GameCommand::ApplySelf( const vector<PlayerNumber> &vpns ) const
 	}
 	if( m_pSong )
 	{
-		GAMESTATE->m_pCurSong.Set( m_pSong );
+		GAMESTATE->set_curr_song(m_pSong);
 		GAMESTATE->m_pPreferredSong = m_pSong;
 	}
 	if( m_pSteps )

--- a/src/GameSoundManager.cpp
+++ b/src/GameSoundManager.cpp
@@ -618,7 +618,7 @@ void GameSoundManager::Update( float fDeltaTime )
 	}
 
 	// Send crossed messages
-	if( GAMESTATE->m_pCurSong )
+	if( GAMESTATE->get_curr_song() )
 	{
 		static int iBeatLastCrossed = 0;
 

--- a/src/GameState.cpp
+++ b/src/GameState.cpp
@@ -1481,17 +1481,17 @@ Song* GameState::get_curr_song() const
 	return m_curr_song.Get();
 }
 
-void GameState::set_curr_song(Song* snog)
+void GameState::set_curr_song(Song* new_song)
 {
 	Song* curr= m_curr_song.Get();
 	if(curr != nullptr)
 	{
 		curr->m_SongTiming.ReleaseLookup();
 	}
-	m_curr_song.Set(snog);
-	if(snog != nullptr)
+	m_curr_song.Set(new_song);
+	if(new_song != nullptr)
 	{
-		snog->m_SongTiming.PrepareLookup();
+		new_song->m_SongTiming.PrepareLookup();
 	}
 }
 
@@ -2729,10 +2729,10 @@ public:
 	}
 	static int GetCurrentSong( T* p, lua_State *L )
 	{
-		Song* snog= p->get_curr_song();
-		if(snog != nullptr)
+		Song* curr_song= p->get_curr_song();
+		if(curr_song != nullptr)
 		{
-			snog->PushSelf(L);
+			curr_song->PushSelf(L);
 		}
 		else
 		{

--- a/src/GameState.cpp
+++ b/src/GameState.cpp
@@ -1491,7 +1491,7 @@ void GameState::set_curr_song(Song* new_song)
 	m_curr_song.Set(new_song);
 	if(new_song != nullptr)
 	{
-		new_song->m_SongTiming.PrepareLookup();
+		new_song->m_SongTiming.RequestLookup();
 	}
 }
 

--- a/src/GameState.cpp
+++ b/src/GameState.cpp
@@ -134,7 +134,7 @@ GameState::GameState() :
 	m_PreferredDifficulty(	Message_PreferredDifficultyP1Changed ),
 	m_PreferredCourseDifficulty(	Message_PreferredCourseDifficultyP1Changed ),
 	m_SortOrder(			Message_SortOrderChanged ),
-	m_pCurSong(				Message_CurrentSongChanged ),
+	m_curr_song(Message_CurrentSongChanged),
 	m_pCurSteps(			Message_CurrentStepsP1Changed ),
 	m_pCurCourse(			Message_CurrentCourseChanged ),
 	m_pCurTrail(			Message_CurrentTrailP1Changed ),
@@ -360,7 +360,7 @@ void GameState::Reset()
 
 	m_AdjustTokensBySongCostForFinalStageCheck= true;
 
-	m_pCurSong.Set( GetDefaultSong() );
+	set_curr_song(GetDefaultSong());
 	m_pPreferredSong = nullptr;
 	m_pCurCourse.Set( nullptr );
 	m_pPreferredCourse = nullptr;
@@ -735,14 +735,14 @@ int GameState::GetNumStagesForCurrentSongAndStepsOrCourse() const
 {
 	using std::max;
 	int iNumStagesOfThisSong = 1;
-	if( m_pCurSong )
+	if(get_curr_song() != nullptr)
 	{
 		/* Extra stages need to only count as one stage in case a multi-stage
 		 * song is chosen. */
 		if( IsAnExtraStage() )
 			iNumStagesOfThisSong = 1;
 		else
-			iNumStagesOfThisSong = GameState::GetNumStagesMultiplierForSong( m_pCurSong );
+		iNumStagesOfThisSong = GameState::GetNumStagesMultiplierForSong(get_curr_song());
 	}
 	else if( m_pCurCourse )
 		iNumStagesOfThisSong = PREFSMAN->m_iSongsPerPlay;
@@ -957,7 +957,7 @@ bool GameState::CanSafelyEnterGameplay(std::string& reason)
 {
 	if(!IsCourseMode())
 	{
-		Song const* song= m_pCurSong;
+		Song const* song= get_curr_song();
 		if(song == nullptr)
 		{
 			reason= "Current song is nullptr.";
@@ -997,7 +997,7 @@ bool GameState::CanSafelyEnterGameplay(std::string& reason)
 					GAMEMAN->GetStepsTypeInfo(style->m_StepsType).stepTypeName);
 				return false;
 			}
-			if(steps->m_pSong != m_pCurSong)
+			if(steps->m_pSong != get_curr_song())
 			{
 				reason= fmt::sprintf("Steps for player %d are not for the current song.",
 					pn+1);
@@ -1335,8 +1335,8 @@ update player position code goes here
 float GameState::GetSongPercent( float beat ) const
 {
 	// 0 = first step; 1 = last step
-	float curTime = this->m_pCurSong->m_SongTiming.GetElapsedTimeFromBeat(beat);
-	return (curTime - m_pCurSong->GetFirstSecond()) / m_pCurSong->GetLastSecond();
+	float curTime = get_curr_song()->m_SongTiming.GetElapsedTimeFromBeat(beat);
+	return (curTime - get_curr_song()->GetFirstSecond()) / get_curr_song()->GetLastSecond();
 }
 
 int GameState::GetNumStagesLeft( PlayerNumber pn ) const
@@ -1367,13 +1367,13 @@ bool GameState::IsFinalStageForAnyHumanPlayer() const
 bool GameState::IsFinalStageForEveryHumanPlayer() const
 {
 	int song_cost= 1;
-	if(m_pCurSong != nullptr)
+	if(get_curr_song() != nullptr)
 	{
-		if(m_pCurSong->IsLong())
+		if(get_curr_song()->IsLong())
 		{
 			song_cost= 2;
 		}
-		else if(m_pCurSong->IsMarathon())
+		else if(get_curr_song()->IsMarathon())
 		{
 			song_cost= 3;
 		}
@@ -1474,6 +1474,25 @@ int GameState::GetLoadingCourseSongIndex() const
 	if( m_bLoadingNextSong )
 		++iIndex;
 	return iIndex;
+}
+
+Song* GameState::get_curr_song() const
+{
+	return m_curr_song.Get();
+}
+
+void GameState::set_curr_song(Song* snog)
+{
+	Song* curr= m_curr_song.Get();
+	if(curr != nullptr)
+	{
+		curr->m_SongTiming.ReleaseLookup();
+	}
+	m_curr_song.Set(snog);
+	if(snog != nullptr)
+	{
+		snog->m_SongTiming.PrepareLookup();
+	}
 }
 
 static LocalizedString PLAYER1	("GameState","Player 1");
@@ -1921,9 +1940,13 @@ bool GameState::CurrentOptionsDisqualifyPlayer( PlayerNumber pn )
 	// Check the stored player options for disqualify.  Don't disqualify because
 	// of mods that were forced.
 	if( IsCourseMode() )
-		return po.IsEasierForCourseAndTrail(  m_pCurCourse, m_pCurTrail[pn] );
+	{
+		return po.IsEasierForCourseAndTrail(m_pCurCourse, m_pCurTrail[pn]);
+	}
 	else
-		return po.IsEasierForSongAndSteps(  m_pCurSong, m_pCurSteps[pn], pn);
+	{
+		return po.IsEasierForSongAndSteps(get_curr_song(), m_pCurSteps[pn], pn);
+	}
 }
 
 void GameState::RemoveAllActiveAttacks()	// called on end of song
@@ -2704,11 +2727,30 @@ public:
 		p->m_noteskin_params[pn].SetFromStack(L);
 		COMMON_RETURN_SELF;
 	}
-	static int GetCurrentSong( T* p, lua_State *L )			{ if(p->m_pCurSong) p->m_pCurSong->PushSelf(L); else lua_pushnil(L); return 1; }
+	static int GetCurrentSong( T* p, lua_State *L )
+	{
+		Song* snog= p->get_curr_song();
+		if(snog != nullptr)
+		{
+			snog->PushSelf(L);
+		}
+		else
+		{
+			lua_pushnil(L);
+		}
+		return 1;
+	}
 	static int SetCurrentSong( T* p, lua_State *L )
 	{
-		if( lua_isnil(L,1) ) { p->m_pCurSong.Set( nullptr ); }
-		else { Song *pS = Luna<Song>::check( L, 1, true ); p->m_pCurSong.Set( pS ); }
+		if(lua_isnil(L,1))
+		{
+			p->set_curr_song(nullptr);
+		}
+		else
+		{
+			Song *pS = Luna<Song>::check(L, 1, true);
+			p->set_curr_song(pS);
+		}
 		COMMON_RETURN_SELF;
 	}
 	static int CanSafelyEnterGameplay(T* p, lua_State* L)
@@ -2933,7 +2975,7 @@ public:
 
 	static int GetCurrentStepsCredits( T* t, lua_State *L )
 	{
-		const Song* pSong = t->m_pCurSong;
+		const Song* pSong = t->get_curr_song();
 		if( pSong == nullptr )
 			return 0;
 
@@ -3220,7 +3262,7 @@ public:
 		// Form 1.
 		if(steps != nullptr && lua_gettop(L) == 2)
 		{
-			p->m_pCurSong.Set(song);
+			p->set_curr_song(song);
 			p->m_pCurSteps[PLAYER_1].Set(steps);
 			p->SetCurrentStyle(GAMEMAN->GetEditorStyleForStepsType(
 					steps->m_StepsType), PLAYER_INVALID);
@@ -3253,7 +3295,7 @@ public:
 		new_steps->SetDifficulty(diff);
 		new_steps->SetDescription(edit_name);
 		song->AddSteps(new_steps);
-		p->m_pCurSong.Set(song);
+		p->set_curr_song(song);
 		p->m_pCurSteps[PLAYER_1].Set(new_steps);
 		p->SetCurrentStyle(GAMEMAN->GetEditorStyleForStepsType(
 				new_steps->m_StepsType), PLAYER_INVALID);

--- a/src/GameState.h
+++ b/src/GameState.h
@@ -247,7 +247,15 @@ public:
 	// State Info used during gameplay
 
 	// nullptr on ScreenSelectMusic if the currently selected wheel item isn't a Song.
-	BroadcastOnChangePtr<Song>	m_pCurSong;
+	// m_curr_song is private so that when it changes the timing data lookup
+	// table can be built and released.  Being able to use the lookup table
+	// should mean less time spent in SongPosition::Update when on SelectMusic
+	// and playing the sample music. -Kyz
+	private:
+	BroadcastOnChangePtr<Song>	m_curr_song;
+	public:
+	Song* get_curr_song() const;
+	void set_curr_song(Song* snog);
 	// The last Song that the user manually changed to.
 	Song*		m_pPreferredSong;
 	BroadcastOnChangePtr1D<Steps,NUM_PLAYERS> m_pCurSteps;

--- a/src/GameState.h
+++ b/src/GameState.h
@@ -255,7 +255,7 @@ public:
 	BroadcastOnChangePtr<Song>	m_curr_song;
 	public:
 	Song* get_curr_song() const;
-	void set_curr_song(Song* snog);
+	void set_curr_song(Song* new_song);
 	// The last Song that the user manually changed to.
 	Song*		m_pPreferredSong;
 	BroadcastOnChangePtr1D<Steps,NUM_PLAYERS> m_pCurSteps;

--- a/src/Inventory.cpp
+++ b/src/Inventory.cpp
@@ -127,7 +127,7 @@ void Inventory::Update( float fDelta )
 		}
 	}
 
-	Song &song = *GAMESTATE->m_pCurSong;
+	Song &song = *GAMESTATE->get_curr_song();
 	// use items if this player is CPU-controlled
 	if( m_pPlayerState->m_PlayerController != PC_HUMAN &&
 		GAMESTATE->m_Position.m_fSongBeat < song.GetLastBeat() )

--- a/src/LifeMeterTime.cpp
+++ b/src/LifeMeterTime.cpp
@@ -107,7 +107,7 @@ void LifeMeterTime::OnLoadSong()
 	{
 		// Placeholderish, at least this way it won't crash when someone tries it
 		// out in non-course mode. -Kyz
-		Song* song= GAMESTATE->m_pCurSong;
+		Song* song= GAMESTATE->get_curr_song();
 		ASSERT(song != nullptr);
 		float song_len= song->m_fMusicLengthSeconds;
 		Steps* steps= GAMESTATE->m_pCurSteps[m_pPlayerState->m_PlayerNumber];

--- a/src/LyricDisplay.cpp
+++ b/src/LyricDisplay.cpp
@@ -46,7 +46,7 @@ void LyricDisplay::Update( float fDeltaTime )
 
 	ActorFrame::Update( fDeltaTime );
 
-	if( GAMESTATE->m_pCurSong == nullptr )
+	if( GAMESTATE->get_curr_song() == nullptr )
 		return;
 
 	// If the song has changed (in a course), reset.
@@ -54,10 +54,10 @@ void LyricDisplay::Update( float fDeltaTime )
 		Init();
 	m_fLastSecond = GAMESTATE->m_Position.m_fMusicSeconds;
 
-	if( m_iCurLyricNumber >= GAMESTATE->m_pCurSong->m_LyricSegments.size() )
+	if( m_iCurLyricNumber >= GAMESTATE->get_curr_song()->m_LyricSegments.size() )
 		return;
 
-	const Song *pSong = GAMESTATE->m_pCurSong;
+	const Song *pSong = GAMESTATE->get_curr_song();
 	const float fStartTime = (pSong->m_LyricSegments[m_iCurLyricNumber].m_fStartTime) - IN_LENGTH.GetValue();
 
 	if( GAMESTATE->m_Position.m_fMusicSeconds < fStartTime )
@@ -65,7 +65,7 @@ void LyricDisplay::Update( float fDeltaTime )
 
 	// Clamp this lyric to the beginning of the next or the end of the music.
 	float fEndTime;
-	if( m_iCurLyricNumber+1 < GAMESTATE->m_pCurSong->m_LyricSegments.size() )
+	if( m_iCurLyricNumber+1 < GAMESTATE->get_curr_song()->m_LyricSegments.size() )
 		fEndTime = pSong->m_LyricSegments[m_iCurLyricNumber+1].m_fStartTime;
 	else
 		fEndTime = pSong->GetLastSecond();
@@ -81,7 +81,7 @@ void LyricDisplay::Update( float fDeltaTime )
 	// Make lyrics show faster for faster song rates.
 	fShowLength /= GAMESTATE->m_SongOptions.GetCurrent().m_fMusicRate;
 
-	const LyricSegment &seg = GAMESTATE->m_pCurSong->m_LyricSegments[m_iCurLyricNumber];
+	const LyricSegment &seg = GAMESTATE->get_curr_song()->m_LyricSegments[m_iCurLyricNumber];
 
 	LuaThreadVariable var1( "LyricText", seg.m_sLyric );
 	LuaThreadVariable var2( "LyricDuration", LuaReference::Create(fShowLength) );

--- a/src/MeterDisplay.cpp
+++ b/src/MeterDisplay.cpp
@@ -79,10 +79,10 @@ void MeterDisplay::SetStreamWidth( float fStreamWidth )
 
 void SongMeterDisplay::Update( float fDeltaTime )
 {
-	if( GAMESTATE->m_pCurSong )
+	if( GAMESTATE->get_curr_song() )
 	{
-		float fSongStartSeconds = GAMESTATE->m_pCurSong->GetFirstSecond();
-		float fSongEndSeconds = GAMESTATE->m_pCurSong->GetLastSecond();
+		float fSongStartSeconds = GAMESTATE->get_curr_song()->GetFirstSecond();
+		float fSongEndSeconds = GAMESTATE->get_curr_song()->GetLastSecond();
 		float fPercentPositionSong = Rage::scale( GAMESTATE->m_Position.m_fMusicSeconds, fSongStartSeconds, fSongEndSeconds, 0.0f, 1.0f );
 		fPercentPositionSong = Rage::clamp( fPercentPositionSong, 0.f, 1.f );
 

--- a/src/MusicWheel.cpp
+++ b/src/MusicWheel.cpp
@@ -190,7 +190,7 @@ void MusicWheel::BeginScreen()
 		{
 			vector<Song*> vTemp = SONGMAN->GetSongs(GAMESTATE->m_sPreferredSongGroup);
 			ASSERT(vTemp.size() > 0);
-			GAMESTATE->m_pCurSong.Set(vTemp[0]);
+			GAMESTATE->set_curr_song(vTemp[0]);
 		};
 		SetOpenSection(GAMESTATE->m_sPreferredSongGroup);
 		SelectSongOrCourse();
@@ -220,11 +220,11 @@ void MusicWheel::BeginScreen()
 
 	/* Invalidate current Song if it can't be played
 	 * because there are not enough stages remaining. */
-	if(GAMESTATE->m_pCurSong != nullptr &&
-		GameState::GetNumStagesMultiplierForSong(GAMESTATE->m_pCurSong) >
+	if(GAMESTATE->get_curr_song() != nullptr &&
+		GameState::GetNumStagesMultiplierForSong(GAMESTATE->get_curr_song()) >
 		GAMESTATE->GetSmallestNumStagesLeftForAnyHumanPlayer())
 	{
-		GAMESTATE->m_pCurSong.Set(nullptr);
+		GAMESTATE->set_curr_song(nullptr);
 	}
 
 	/* Invalidate current Steps if it can't be played
@@ -234,9 +234,9 @@ void MusicWheel::BeginScreen()
 		if(GAMESTATE->m_pCurSteps[p] != nullptr)
 		{
 			vector<Steps*> vpPossibleSteps;
-			if(GAMESTATE->m_pCurSong != nullptr)
+			if(GAMESTATE->get_curr_song() != nullptr)
 			{
-				SongUtil::GetPlayableSteps(GAMESTATE->m_pCurSong, vpPossibleSteps);
+				SongUtil::GetPlayableSteps(GAMESTATE->get_curr_song(), vpPossibleSteps);
 			}
 			bool bStepsIsPossible = find(vpPossibleSteps.begin(), vpPossibleSteps.end(), GAMESTATE->m_pCurSteps[p]) == vpPossibleSteps.end();
 			if(!bStepsIsPossible)
@@ -284,7 +284,7 @@ bool MusicWheel::SelectSongOrCourse()
 {
 	if( GAMESTATE->m_pPreferredSong && SelectSong( GAMESTATE->m_pPreferredSong ) )
 		return true;
-	if( GAMESTATE->m_pCurSong && SelectSong( GAMESTATE->m_pCurSong ) )
+	if( GAMESTATE->get_curr_song() && SelectSong( GAMESTATE->get_curr_song() ) )
 		return true;
 	if( GAMESTATE->m_pPreferredCourse && SelectCourse( GAMESTATE->m_pPreferredCourse ) )
 		return true;
@@ -451,7 +451,7 @@ void MusicWheel::GetSongList( vector<Song*> &arraySongs, SortOrder so )
 			continue;
 
 		// If we're on an extra stage, and this song is selected, ignore #SELECTABLE.
-		if( pSong != GAMESTATE->m_pCurSong || !GAMESTATE->IsAnExtraStage() )
+		if( pSong != GAMESTATE->get_curr_song() || !GAMESTATE->IsAnExtraStage() )
 		{
 			// Hide songs that asked to be hidden via #SELECTABLE.
 			if( iLocked & LOCKED_SELECTABLE )
@@ -993,7 +993,7 @@ void MusicWheel::FilterWheelItemDatas(vector<MusicWheelItemData *> &aUnFilteredD
 			}
 
 			/* If we're on an extra stage, and this song is selected, ignore #SELECTABLE. */
-			if( pSong != GAMESTATE->m_pCurSong || !GAMESTATE->IsAnExtraStage() )
+			if( pSong != GAMESTATE->get_curr_song() || !GAMESTATE->IsAnExtraStage() )
 			{
 				/* Hide songs that asked to be hidden via #SELECTABLE. */
 				if( iLocked & LOCKED_SELECTABLE )

--- a/src/NetworkSyncManager.cpp
+++ b/src/NetworkSyncManager.cpp
@@ -369,11 +369,11 @@ void NetworkSyncManager::StartRequest( short position )
 	ctr = char( position*16 );
 	m_packet.Write1( ctr );
 
-	if( GAMESTATE->m_pCurSong != nullptr )
+	if( GAMESTATE->get_curr_song() != nullptr )
 	{
-		m_packet.WriteNT( GAMESTATE->m_pCurSong->m_sMainTitle );
-		m_packet.WriteNT( GAMESTATE->m_pCurSong->m_sSubTitle );
-		m_packet.WriteNT( GAMESTATE->m_pCurSong->m_sArtist );
+		m_packet.WriteNT( GAMESTATE->get_curr_song()->m_sMainTitle );
+		m_packet.WriteNT( GAMESTATE->get_curr_song()->m_sSubTitle );
+		m_packet.WriteNT( GAMESTATE->get_curr_song()->m_sArtist );
 	}
 	else
 	{

--- a/src/NoteData.cpp
+++ b/src/NoteData.cpp
@@ -28,7 +28,7 @@ void NoteData::Init()
 void NoteData::SetOccuranceTimeForAllTaps(TimingData* timing_data)
 {
 	ASSERT_M(timing_data != nullptr, "SetOccuranceTimeForAllTaps cannot run without timing data.");
-	timing_data->PrepareLookup();
+	timing_data->RequestLookup();
 	int curr_row= -1;
 	NoteData::all_tracks_iterator curr_note=
 		GetTapNoteRangeAllTracks(0, MAX_NOTE_ROW);

--- a/src/NoteField.cpp
+++ b/src/NoteField.cpp
@@ -2599,7 +2599,7 @@ void NoteField::draw_beat_bars_internal()
 	draw_all_segments(FloatToString(seg->GetLength()), Fake, FAKE);
 #undef draw_all_segments
 
-	Song* curr_song= GAMESTATE->m_pCurSong;
+	Song* curr_song= GAMESTATE->get_curr_song();
 	if(curr_song != nullptr)
 	{
 		BackgroundLayer const fg_layer_number= BACKGROUND_LAYER_Invalid;

--- a/src/OptionRow.cpp
+++ b/src/OptionRow.cpp
@@ -229,9 +229,9 @@ std::string OptionRow::GetRowTitle() const
 		if( bShowBpmInSpeedTitle )
 		{
 			DisplayBpms bpms;
-			if( GAMESTATE->m_pCurSong )
+			if( GAMESTATE->get_curr_song() )
 			{
-				const Song* pSong = GAMESTATE->m_pCurSong;
+				const Song* pSong = GAMESTATE->get_curr_song();
 				pSong->GetDisplayBpms( bpms );
 			}
 			else if( GAMESTATE->m_pCurCourse )

--- a/src/OptionRowHandler.cpp
+++ b/src/OptionRowHandler.cpp
@@ -413,12 +413,12 @@ class OptionRowHandlerListSteps : public OptionRowHandlerList
 				m_aListEntries.push_back( mc );
 			}
 		}
-		else if(GAMESTATE->GetCurrentStyle(GAMESTATE->GetMasterPlayerNumber()) && GAMESTATE->m_pCurSong) // playing a song
+		else if(GAMESTATE->GetCurrentStyle(GAMESTATE->GetMasterPlayerNumber()) && GAMESTATE->get_curr_song()) // playing a song
 		{
 			m_Def.m_layoutType = StringToLayoutType( STEPS_ROW_LAYOUT_TYPE );
 
 			vector<Steps*> vpSteps;
-			Song *pSong = GAMESTATE->m_pCurSong;
+			Song *pSong = GAMESTATE->get_curr_song();
 			SongUtil::GetSteps( pSong, vpSteps, GAMESTATE->GetCurrentStyle(GAMESTATE->GetMasterPlayerNumber())->m_StepsType );
 			StepsUtil::RemoveLockedSteps( pSong, vpSteps );
 			StepsUtil::SortNotesArrayByDifficulty( vpSteps );
@@ -526,17 +526,17 @@ public:
 		m_vDifficulties.clear();
 		m_vSteps.clear();
 
-		if( GAMESTATE->m_pCurSong )
+		if( GAMESTATE->get_curr_song() )
 		{
 			FOREACH_ENUM( Difficulty, dc )
 			{
 				if( dc == Difficulty_Edit )
 					continue;
 				m_vDifficulties.push_back( dc );
-				Steps* pSteps = SongUtil::GetStepsByDifficulty( GAMESTATE->m_pCurSong, *m_pst, dc );
+				Steps* pSteps = SongUtil::GetStepsByDifficulty( GAMESTATE->get_curr_song(), *m_pst, dc );
 				m_vSteps.push_back( pSteps );
 			}
-			SongUtil::GetSteps( GAMESTATE->m_pCurSong, m_vSteps, *m_pst, Difficulty_Edit );
+			SongUtil::GetSteps( GAMESTATE->get_curr_song(), m_vSteps, *m_pst, Difficulty_Edit );
 			m_vDifficulties.resize( m_vSteps.size(), Difficulty_Edit );
 
 			if( sParam == "EditSteps" )
@@ -761,8 +761,10 @@ class OptionRowHandlerListSongsInCurrentSongGroup: public OptionRowHandlerList
 	{
 		const vector<Song*> &vpSongs = SONGMAN->GetSongs( GAMESTATE->m_sPreferredSongGroup );
 
-		if( GAMESTATE->m_pCurSong == nullptr )
-			GAMESTATE->m_pCurSong.Set( vpSongs[0] );
+		if(GAMESTATE->get_curr_song() == nullptr)
+		{
+			GAMESTATE->set_curr_song(vpSongs[0]);
+		}
 
 		m_Def.m_sName = "SongsInCurrentSongGroup";
 		m_Def.m_bOneChoiceForAllPlayers = true;

--- a/src/PaneDisplay.cpp
+++ b/src/PaneDisplay.cpp
@@ -127,7 +127,7 @@ void PaneDisplay::LoadFromNode( const XNode *pNode )
 
 void PaneDisplay::GetPaneTextAndLevel( PaneCategory c, std::string & sTextOut, float & fLevelOut )
 {
-	const Song *pSong = GAMESTATE->m_pCurSong;
+	const Song *pSong = GAMESTATE->get_curr_song();
 	const Steps *pSteps = GAMESTATE->m_pCurSteps[m_PlayerNumber];
 	const Course *pCourse = GAMESTATE->m_pCurCourse;
 	const Trail *pTrail = GAMESTATE->m_pCurTrail[m_PlayerNumber];

--- a/src/Player.cpp
+++ b/src/Player.cpp
@@ -482,8 +482,8 @@ float Player::calc_read_bpm()
 	}
 	else
 	{
-		ASSERT(GAMESTATE->m_pCurSong != nullptr);
-		GAMESTATE->m_pCurSong->GetDisplayBpms(bpms);
+		ASSERT(GAMESTATE->get_curr_song() != nullptr);
+		GAMESTATE->get_curr_song()->GetDisplayBpms(bpms);
 	}
 
 	float fMaxBPM = 0;
@@ -531,11 +531,11 @@ float Player::calc_read_bpm()
 		{
 			if(M_MOD_HIGH_CAP > 0)
 			{
-				GAMESTATE->m_pCurSong->m_SongTiming.GetActualBPM(fThrowAway, fMaxBPM, M_MOD_HIGH_CAP);
+				GAMESTATE->get_curr_song()->m_SongTiming.GetActualBPM(fThrowAway, fMaxBPM, M_MOD_HIGH_CAP);
 			}
 			else
 			{
-				GAMESTATE->m_pCurSong->m_SongTiming.GetActualBPM(fThrowAway, fMaxBPM);
+				GAMESTATE->get_curr_song()->m_SongTiming.GetActualBPM(fThrowAway, fMaxBPM);
 			}
 		}
 	}
@@ -668,7 +668,7 @@ void Player::Load()
 	/* Apply transforms. */
 	NoteDataUtil::TransformNoteData(m_NoteData, *m_Timing, m_pPlayerState->m_PlayerOptions.GetStage(), GAMESTATE->GetCurrentStyle(GetPlayerState()->m_PlayerNumber)->m_StepsType);
 
-	const Song* pSong = GAMESTATE->m_pCurSong;
+	const Song* pSong = GAMESTATE->get_curr_song();
 
 	switch( GAMESTATE->m_PlayMode )
 	{
@@ -819,7 +819,7 @@ void Player::Update( float fDeltaTime )
 
 	//LOG->Trace( "Player::Update(%f)", fDeltaTime );
 
-	if( GAMESTATE->m_pCurSong==nullptr || IsOniDead() )
+	if( GAMESTATE->get_curr_song()==nullptr || IsOniDead() )
 		return;
 
 	ActorFrame::Update( fDeltaTime );
@@ -1483,11 +1483,11 @@ void Player::ApplyWaitingTransforms()
 		po.FromString( mod.sModifiers );
 
 		float fStartBeat, fEndBeat;
-		mod.GetRealtimeAttackBeats( GAMESTATE->m_pCurSong, m_pPlayerState, fStartBeat, fEndBeat );
+		mod.GetRealtimeAttackBeats( GAMESTATE->get_curr_song(), m_pPlayerState, fStartBeat, fEndBeat );
 		fEndBeat = min( fEndBeat, m_NoteData.GetLastBeat() );
 
 		LOG->Trace( "Applying transform '%s' from %f to %f to '%s'", mod.sModifiers.c_str(), fStartBeat, fEndBeat,
-			GAMESTATE->m_pCurSong->GetTranslitMainTitle().c_str() );
+			GAMESTATE->get_curr_song()->GetTranslitMainTitle().c_str() );
 
 		NoteDataUtil::TransformNoteData(m_NoteData, *m_Timing, po, GAMESTATE->GetCurrentStyle(GetPlayerState()->m_PlayerNumber)->m_StepsType, BeatToNoteRow(fStartBeat), BeatToNoteRow(fEndBeat));
 	}
@@ -1924,9 +1924,9 @@ void Player::Step( int col, int row, const RageTimer &tm, bool bHeld, bool bRele
 
 	float fSongBeat = m_pPlayerState->m_Position.m_fSongBeat;
 
-	if( GAMESTATE->m_pCurSong )
+	if( GAMESTATE->get_curr_song() )
 	{
-		fSongBeat = GAMESTATE->m_pCurSong->m_SongTiming.GetBeatFromElapsedTime( fPositionSeconds );
+		fSongBeat = GAMESTATE->get_curr_song()->m_SongTiming.GetBeatFromElapsedTime( fPositionSeconds );
 
 		if( GAMESTATE->m_pCurSteps[m_pPlayerState->m_PlayerNumber] )
 			fSongBeat = m_Timing->GetBeatFromElapsedTime( fPositionSeconds );
@@ -3182,7 +3182,7 @@ void Player::SetCombo( unsigned int iCombo, unsigned int iMisses )
 	else
 	{
 		bPastBeginning = m_pPlayerState->m_Position.m_fMusicSeconds
-			> GAMESTATE->m_pCurSong->m_fMusicLengthSeconds * PERCENT_UNTIL_COLOR_COMBO;
+			> GAMESTATE->get_curr_song()->m_fMusicLengthSeconds * PERCENT_UNTIL_COLOR_COMBO;
 	}
 
 	if( m_bSendJudgmentAndComboMessages )

--- a/src/Player.cpp
+++ b/src/Player.cpp
@@ -2392,9 +2392,9 @@ void Player::UpdateTapNotesMissedOlderThan( float fMissIfOlderThanSeconds )
 	int iMissIfOlderThanThisRow;
 	const float fEarliestTime = m_pPlayerState->m_Position.m_fMusicSeconds - fMissIfOlderThanSeconds;
 	{
-		TimingData::GetBeatArgs beat_info;
-		beat_info.elapsed_time= fEarliestTime;
-		m_Timing->GetBeatAndBPSFromElapsedTime(beat_info);
+		TimingData::DetailedTimeInfo beat_info;
+		beat_info.second= fEarliestTime;
+		m_Timing->GetDetailedInfoForSecond(beat_info);
 
 		iMissIfOlderThanThisRow = BeatToNoteRow(beat_info.beat);
 		if(beat_info.freeze_out || beat_info.delay_out )

--- a/src/PlayerOptions.cpp
+++ b/src/PlayerOptions.cpp
@@ -998,7 +998,7 @@ bool PlayerOptions::IsEasierForSongAndSteps( Song* pSong, Steps* pSteps, PlayerN
 		}
 		else
 		{
-			GAMESTATE->m_pCurSong->GetDisplayBpms( bpms );
+			GAMESTATE->get_curr_song()->GetDisplayBpms( bpms );
 		}
 		pSong->GetDisplayBpms( bpms );
 

--- a/src/PlayerState.cpp
+++ b/src/PlayerState.cpp
@@ -213,7 +213,7 @@ const TimingData &PlayerState::GetDisplayedTiming() const
 {
 	Steps *steps = GAMESTATE->m_pCurSteps[m_PlayerNumber];
 	if( steps == nullptr )
-		return GAMESTATE->m_pCurSong->m_SongTiming;
+		return GAMESTATE->get_curr_song()->m_SongTiming;
 	return *steps->GetTimingData();
 }
 

--- a/src/ScoreKeeperNormal.cpp
+++ b/src/ScoreKeeperNormal.cpp
@@ -173,7 +173,7 @@ void ScoreKeeperNormal::OnNextSong( int iSongInCourseIndex, const Steps* pSteps,
 	else
 	{
 		// long ver and marathon ver songs have higher max possible scores
-		int iLengthMultiplier = GameState::GetNumStagesMultiplierForSong( GAMESTATE->m_pCurSong );
+		int iLengthMultiplier = GameState::GetNumStagesMultiplierForSong( GAMESTATE->get_curr_song() );
 
 		/* This is no longer just simple additive/subtractive scoring,
 		 * but start with capping the score at the size of the score counter. */

--- a/src/ScreenDebugOverlay.cpp
+++ b/src/ScreenDebugOverlay.cpp
@@ -1145,7 +1145,7 @@ class DebugLineConvertXML : public IDebugLine
 	virtual std::string GetPageName() const { return "Theme"; }
 	virtual void DoAndLog( std::string &sMessageOut )
 	{
-		Song* cur_song= GAMESTATE->m_pCurSong;
+		Song* cur_song= GAMESTATE->get_curr_song();
 		if(cur_song)
 		{
 			convert_xmls_in_dir(cur_song->GetSongDir() + "/");

--- a/src/ScreenDemonstration.cpp
+++ b/src/ScreenDemonstration.cpp
@@ -58,7 +58,7 @@ void ScreenDemonstration::Init()
 
 	ScreenJukebox::Init();
 
-	if( GAMESTATE->m_pCurSong == nullptr )	// we didn't find a song.
+	if( GAMESTATE->get_curr_song() == nullptr )	// we didn't find a song.
 	{
 		PostScreenMessage( SM_GoToNextScreen, 0 );	// Abort demonstration.
 		return;

--- a/src/ScreenEdit.cpp
+++ b/src/ScreenEdit.cpp
@@ -1486,6 +1486,8 @@ void ScreenEdit::Init()
 
 	this->AddChild( &m_Background );
 
+	m_pSteps->GetTimingData()->RequestLookup();
+
 	// The option menu actor takes care of setting the noteskin. -Kyz
 	m_pSteps->GetNoteData(m_NoteDataEdit);
 	m_NoteFieldEdit.set_note_data(&m_NoteDataEdit, m_pSteps->GetTimingData(), m_pSteps->m_StepsType);
@@ -1588,6 +1590,7 @@ void ScreenEdit::Init()
 
 ScreenEdit::~ScreenEdit()
 {
+	m_pSteps->GetTimingData()->ReleaseLookup();
 	// UGLY: Don't delete the Song's steps.
 	m_SongLastSave.DetachSteps();
 

--- a/src/ScreenEdit.cpp
+++ b/src/ScreenEdit.cpp
@@ -1429,7 +1429,7 @@ void ScreenEdit::Init()
 	SubscribeToMessage( "Judgment" );
 	SubscribeToMessage("NoteskinChanged");
 
-	ASSERT( GAMESTATE->m_pCurSong != nullptr );
+	ASSERT( GAMESTATE->get_curr_song() != nullptr );
 	ASSERT( GAMESTATE->m_pCurSteps[PLAYER_1] != nullptr );
 
 	EDIT_MODE.Load( m_sName, "EditMode" );
@@ -1454,7 +1454,7 @@ void ScreenEdit::Init()
 	}
 	GAMESTATE->m_bSideIsJoined[PLAYER_1] = true;
 
-	m_pSong = GAMESTATE->m_pCurSong;
+	m_pSong = GAMESTATE->get_curr_song();
 	m_pSteps = GAMESTATE->m_pCurSteps[PLAYER_1];
 
 	/*	The user will most likely switch into Step Timing after laying down
@@ -1516,14 +1516,14 @@ void ScreenEdit::Init()
 
 	m_Clipboard.SetNumTracks( m_NoteDataEdit.GetNumTracks() );
 
-	clipboardFullTiming = GAMESTATE->m_pCurSong->m_SongTiming; // always have a backup.
+	clipboardFullTiming = GAMESTATE->get_curr_song()->m_SongTiming; // always have a backup.
 	clipboard_full_timing= &clipboardFullTiming;
 
 	m_bHasUndo = false;
 	m_Undo.SetNumTracks( m_NoteDataEdit.GetNumTracks() );
 
 	SetDirty(m_NoteDataEdit.IsEmpty()); // require saving if empty.
-	if(GAMESTATE->m_pCurSong->WasLoadedFromAutosave())
+	if(GAMESTATE->get_curr_song()->WasLoadedFromAutosave())
 	{
 		SetDirty(true);
 	}
@@ -1615,7 +1615,7 @@ void ScreenEdit::EndScreen()
 	// complete. -Kyz
 	if(m_should_invalidate)
 	{
-		SONGMAN->Invalidate(GAMESTATE->m_pCurSong);
+		SONGMAN->Invalidate(GAMESTATE->get_curr_song());
 	}
 	ScreenWithMenuElements::EndScreen();
 
@@ -1698,7 +1698,7 @@ void ScreenEdit::Update( float fDeltaTime )
 	{
 		RageTimer tm;
 		const float fSeconds = m_pSoundMusic->GetPositionSeconds( nullptr, &tm );
-		GAMESTATE->UpdateSongPosition( fSeconds, GAMESTATE->m_pCurSong->m_SongTiming, tm );
+		GAMESTATE->UpdateSongPosition( fSeconds, GAMESTATE->get_curr_song()->m_SongTiming, tm );
 	}
 
 	if(m_EditState == STATE_EDITING)
@@ -2508,7 +2508,7 @@ bool ScreenEdit::InputEdit( const InputEventPlus &input, EditButton EditB )
 			// Get all Steps of this StepsType
 			const StepsType st = pSteps->m_StepsType;
 			vector<Steps*> vSteps;
-			SongUtil::GetSteps( GAMESTATE->m_pCurSong, vSteps, st );
+			SongUtil::GetSteps( GAMESTATE->get_curr_song(), vSteps, st );
 
 			// Sort them by difficulty.
 			StepsUtil::SortStepsByTypeAndDifficulty( vSteps );
@@ -2711,8 +2711,8 @@ bool ScreenEdit::InputEdit( const InputEventPlus &input, EditButton EditB )
 			}
 			else
 			{
-				GAMESTATE->m_pCurSong->m_Attacks.UpdateStartTimes(fDelta);
-				GAMESTATE->m_pCurSong->m_fMusicSampleStartSeconds += fDelta;
+				GAMESTATE->get_curr_song()->m_Attacks.UpdateStartTimes(fDelta);
+				GAMESTATE->get_curr_song()->m_fMusicSampleStartSeconds += fDelta;
 			}
 			SetDirty( true );
 		}
@@ -3369,7 +3369,7 @@ bool ScreenEdit::InputPlay( const InputEventPlus &input, EditButton EditB )
 			GetAppropriateTimingForUpdate().m_fBeat0OffsetInSeconds += fOffsetDelta;
 			if (!GAMESTATE->m_bIsUsingStepTiming)
 			{
-				GAMESTATE->m_pCurSong->m_fMusicSampleStartSeconds += fOffsetDelta;
+				GAMESTATE->get_curr_song()->m_fMusicSampleStartSeconds += fOffsetDelta;
 			}
 		}
 			return true;
@@ -3804,8 +3804,8 @@ void ScreenEdit::HandleScreenMessage( const ScreenMessage SM )
 		}
 		else
 		{
-			GAMESTATE->m_pCurSong->m_Attacks.UpdateStartTimes(delta);
-			GAMESTATE->m_pCurSong->m_fMusicSampleStartSeconds += delta;
+			GAMESTATE->get_curr_song()->m_Attacks.UpdateStartTimes(delta);
+			GAMESTATE->get_curr_song()->m_fMusicSampleStartSeconds += delta;
 		}
 
 		SetDirty( true );
@@ -3951,7 +3951,7 @@ void ScreenEdit::HandleScreenMessage( const ScreenMessage SM )
 			int iCourseEntryIndex = -1;
 			for (auto i = pCourse->m_vEntries.begin(); i != pCourse->m_vEntries.end(); ++i)
 			{
-				if( i->songID.ToSong() == GAMESTATE->m_pCurSong.Get() )
+				if(i->songID.ToSong() == GAMESTATE->get_curr_song())
 					iCourseEntryIndex = i - pCourse->m_vEntries.begin();
 			}
 
@@ -4479,7 +4479,7 @@ void ScreenEdit::HandleScreenMessage( const ScreenMessage SM )
 		 * saved on quit. -aj */
 
 		// At this point, the last good song copy is in use.
-		Song *pSong = GAMESTATE->m_pCurSong;
+		Song *pSong = GAMESTATE->get_curr_song();
 		const vector<Steps*> &apSteps = pSong->GetAllSteps();
 		vector<Steps*> apToDelete;
 		for (auto *s: apSteps)
@@ -4555,8 +4555,8 @@ void ScreenEdit::PerformSave(bool autosave)
 	m_pSteps->SetNoteData( m_NoteDataEdit );
 
 	// don't forget the attacks.
-	m_pSong->m_Attacks = GAMESTATE->m_pCurSong->m_Attacks;
-	m_pSong->m_sAttackString = GAMESTATE->m_pCurSong->m_Attacks.ToVectorString();
+	m_pSong->m_Attacks = GAMESTATE->get_curr_song()->m_Attacks;
+	m_pSong->m_sAttackString = GAMESTATE->get_curr_song()->m_Attacks.ToVectorString();
 	m_pSteps->m_Attacks = GAMESTATE->m_pCurSteps[PLAYER_1]->m_Attacks;
 	m_pSteps->m_sAttackString = GAMESTATE->m_pCurSteps[PLAYER_1]->m_Attacks.ToVectorString();
 
@@ -4682,37 +4682,37 @@ static void ChangeStepMusic(const std::string& sNew)
 
 static void ChangeMainTitle( const std::string &sNew )
 {
-	Song* pSong = GAMESTATE->m_pCurSong;
+	Song* pSong = GAMESTATE->get_curr_song();
 	pSong->m_sMainTitle = sNew;
 }
 
 static void ChangeSubTitle( const std::string &sNew )
 {
-	Song* pSong = GAMESTATE->m_pCurSong;
+	Song* pSong = GAMESTATE->get_curr_song();
 	pSong->m_sSubTitle = sNew;
 }
 
 static void ChangeArtist( const std::string &sNew )
 {
-	Song* pSong = GAMESTATE->m_pCurSong;
+	Song* pSong = GAMESTATE->get_curr_song();
 	pSong->m_sArtist = sNew;
 }
 
 static void ChangeGenre( const std::string &sNew )
 {
-	Song* pSong = GAMESTATE->m_pCurSong;
+	Song* pSong = GAMESTATE->get_curr_song();
 	pSong->m_sGenre = sNew;
 }
 
 static void ChangeCredit( const std::string &sNew )
 {
-	Song* pSong = GAMESTATE->m_pCurSong;
+	Song* pSong = GAMESTATE->get_curr_song();
 	pSong->m_sCredit = sNew;
 }
 
 static void ChangePreview(const std::string& sNew)
 {
-	Song* pSong = GAMESTATE->m_pCurSong;
+	Song* pSong = GAMESTATE->get_curr_song();
 	if(!sNew.empty())
 	{
 		std::string error;
@@ -4736,41 +4736,41 @@ static void ChangePreview(const std::string& sNew)
 
 static void ChangeMainTitleTranslit( const std::string &sNew )
 {
-	Song* pSong = GAMESTATE->m_pCurSong;
+	Song* pSong = GAMESTATE->get_curr_song();
 	pSong->m_sMainTitleTranslit = sNew;
 }
 
 static void ChangeSubTitleTranslit( const std::string &sNew )
 {
-	Song* pSong = GAMESTATE->m_pCurSong;
+	Song* pSong = GAMESTATE->get_curr_song();
 	pSong->m_sSubTitleTranslit = sNew;
 }
 
 static void ChangeArtistTranslit( const std::string &sNew )
 {
-	Song* pSong = GAMESTATE->m_pCurSong;
+	Song* pSong = GAMESTATE->get_curr_song();
 	pSong->m_sArtistTranslit = sNew;
 }
 
 static void ChangeLastSecondHint( const std::string &sNew )
 {
-	Song &s = *GAMESTATE->m_pCurSong;
+	Song &s = *GAMESTATE->get_curr_song();
 	s.SetSpecifiedLastSecond(StringToFloat(sNew));
 }
 
 static void ChangePreviewStart( const std::string &sNew )
 {
-	GAMESTATE->m_pCurSong->m_fMusicSampleStartSeconds = StringToFloat( sNew );
+	GAMESTATE->get_curr_song()->m_fMusicSampleStartSeconds = StringToFloat( sNew );
 }
 
 static void ChangePreviewLength( const std::string &sNew )
 {
-	GAMESTATE->m_pCurSong->m_fMusicSampleLengthSeconds = StringToFloat( sNew );
+	GAMESTATE->get_curr_song()->m_fMusicSampleLengthSeconds = StringToFloat( sNew );
 }
 
 static void ChangeMinBPM( const std::string &sNew )
 {
-	GAMESTATE->m_pCurSong->m_fSpecifiedBPMMin = StringToFloat( sNew );
+	GAMESTATE->get_curr_song()->m_fSpecifiedBPMMin = StringToFloat( sNew );
 }
 
 static void ChangeStepsMinBPM(const std::string &sNew)
@@ -4781,7 +4781,7 @@ static void ChangeStepsMinBPM(const std::string &sNew)
 
 static void ChangeMaxBPM( const std::string &sNew )
 {
-	GAMESTATE->m_pCurSong->m_fSpecifiedBPMMax = StringToFloat( sNew );
+	GAMESTATE->get_curr_song()->m_fSpecifiedBPMMax = StringToFloat( sNew );
 }
 
 static void ChangeStepsMaxBPM(const std::string &sNew)
@@ -4897,7 +4897,7 @@ int ScreenEdit::GetSongOrNotesEnd()
 	using std::max;
 	return max(m_iStartPlayingAt, max(m_NoteDataEdit.GetLastRow(),
 			BeatToNoteRow(m_pSteps->GetTimingData()->GetBeatFromElapsedTime(
-					GAMESTATE->m_pCurSong->m_fMusicLengthSeconds))));
+					GAMESTATE->get_curr_song()->m_fMusicLengthSeconds))));
 }
 
 void ScreenEdit::HandleMainMenuChoice( MainMenuChoice c, const vector<int> &iAnswers )
@@ -5109,7 +5109,7 @@ void ScreenEdit::HandleMainMenuChoice( MainMenuChoice c, const vector<int> &iAns
 			break;
 		case edit_song_info:
 			{
-				const Song* pSong = GAMESTATE->m_pCurSong;
+				const Song* pSong = GAMESTATE->get_curr_song();
 				g_SongInformation.rows[main_title].SetOneUnthemedChoice( pSong->m_sMainTitle );
 				g_SongInformation.rows[sub_title].SetOneUnthemedChoice( pSong->m_sSubTitle );
 				g_SongInformation.rows[artist].SetOneUnthemedChoice( pSong->m_sArtist );
@@ -5446,8 +5446,8 @@ void ScreenEdit::HandleAlterMenuChoice(AlterMenuChoice c, const vector<int> &ans
 				selection_start);
 			float fMarkerEnd = GetAppropriateTiming().GetElapsedTimeFromBeat(
 				selection_end);
-			GAMESTATE->m_pCurSong->m_fMusicSampleStartSeconds = fMarkerStart;
-			GAMESTATE->m_pCurSong->m_fMusicSampleLengthSeconds = fMarkerEnd - fMarkerStart;
+			GAMESTATE->get_curr_song()->m_fMusicSampleStartSeconds = fMarkerStart;
+			GAMESTATE->get_curr_song()->m_fMusicSampleLengthSeconds = fMarkerEnd - fMarkerStart;
 			break;
 		}
 		case convert_to_pause:
@@ -5711,7 +5711,7 @@ void ScreenEdit::HandleAreaMenuChoice( AreaMenuChoice c, const vector<int> &iAns
 		case last_second_at_beat:
 		{
 			const TimingData &timing = GetAppropriateTiming();
-			Song &s = *GAMESTATE->m_pCurSong;
+			Song &s = *GAMESTATE->get_curr_song();
 			s.SetSpecifiedLastSecond(timing.GetElapsedTimeFromBeat(GetBeat()));
 			break;
 		}
@@ -5863,7 +5863,7 @@ static LocalizedString ENTER_PREVIEW_START		("ScreenEdit","Enter a new preview s
 static LocalizedString ENTER_PREVIEW_LENGTH		("ScreenEdit","Enter a new preview length.");
 void ScreenEdit::HandleSongInformationChoice( SongInformationChoice c, const vector<int> &iAnswers )
 {
-	Song* pSong = GAMESTATE->m_pCurSong;
+	Song* pSong = GAMESTATE->get_curr_song();
 	pSong->m_DisplayBPMType = static_cast<DisplayBPM>(iAnswers[display_bpm]);
 
 	switch( c )
@@ -6091,7 +6091,7 @@ void ScreenEdit::HandleTimingDataInformationChoice( TimingDataInformationChoice 
 		}
 		else
 		{
-			GAMESTATE->m_pCurSong->m_SongTiming = clipboardFullTiming;
+			GAMESTATE->get_curr_song()->m_SongTiming = clipboardFullTiming;
 		}
 		SetDirty(true);
 		break;
@@ -6287,11 +6287,11 @@ void ScreenEdit::SetupCourseAttacks()
 	else
 	{
 		const PlayerOptions &p = GAMESTATE->m_pPlayerState[PLAYER_1]->m_PlayerOptions.GetCurrent();
-		if (GAMESTATE->m_pCurSong && p.m_fNoAttack == 0 && p.m_fRandAttack == 0 )
+		if (GAMESTATE->get_curr_song() && p.m_fNoAttack == 0 && p.m_fRandAttack == 0 )
 		{
 			AttackArray &attacks = GAMESTATE->m_bIsUsingStepTiming ?
 				GAMESTATE->m_pCurSteps[PLAYER_1]->m_Attacks :
-				GAMESTATE->m_pCurSong->m_Attacks;
+				GAMESTATE->get_curr_song()->m_Attacks;
 
 			if (attacks.size() > 0)
 			{
@@ -6311,11 +6311,11 @@ void ScreenEdit::SetupCourseAttacks()
 
 void ScreenEdit::CopyToLastSave()
 {
-	ASSERT( GAMESTATE->m_pCurSong != nullptr );
+	ASSERT( GAMESTATE->get_curr_song() != nullptr );
 	ASSERT( GAMESTATE->m_pCurSteps[PLAYER_1] != nullptr );
-	m_SongLastSave = *GAMESTATE->m_pCurSong;
+	m_SongLastSave = *GAMESTATE->get_curr_song();
 	m_vStepsLastSave.clear();
-	const vector<Steps*> &vSteps = GAMESTATE->m_pCurSong->GetStepsByStepsType( GAMESTATE->m_pCurSteps[PLAYER_1]->m_StepsType );
+	const vector<Steps*> &vSteps = GAMESTATE->get_curr_song()->GetStepsByStepsType( GAMESTATE->m_pCurSteps[PLAYER_1]->m_StepsType );
 	for (auto *it: vSteps)
 	{
 		m_vStepsLastSave.push_back( *it );
@@ -6327,8 +6327,8 @@ void ScreenEdit::CopyFromLastSave()
 	// We are assuming two things here:
 	// 1) No steps can be created by ScreenEdit
 	// 2) No steps can be deleted by ScreenEdit (except possibly when we exit)
-	*GAMESTATE->m_pCurSong = m_SongLastSave;
-	const vector<Steps*> &vSteps = GAMESTATE->m_pCurSong->GetStepsByStepsType( GAMESTATE->m_pCurSteps[PLAYER_1]->m_StepsType );
+	*GAMESTATE->get_curr_song() = m_SongLastSave;
+	const vector<Steps*> &vSteps = GAMESTATE->get_curr_song()->GetStepsByStepsType( GAMESTATE->m_pCurSteps[PLAYER_1]->m_StepsType );
 	ASSERT_M( vSteps.size() == m_vStepsLastSave.size(), fmt::sprintf("Step sizes don't match: %d, %d", int(vSteps.size()), int(m_vStepsLastSave.size())) );
 	for( unsigned i = 0; i < vSteps.size(); ++i )
 		*vSteps[i] = m_vStepsLastSave[i];
@@ -6344,20 +6344,20 @@ void ScreenEdit::RevertFromDisk()
 	// If m_bInStepEditor is true while the song is reloaded, it screws up
 	// loading and results in the steps being cleared.  -Kyz
 	GAMESTATE->m_bInStepEditor= false;
-	GAMESTATE->m_pCurSong->ReloadFromSongDir();
+	GAMESTATE->get_curr_song()->ReloadFromSongDir();
 	GAMESTATE->m_bInStepEditor= true;
 
-	Steps *pNewSteps = id.ToSteps( GAMESTATE->m_pCurSong, true );
+	Steps *pNewSteps = id.ToSteps( GAMESTATE->get_curr_song(), true );
 	if( !pNewSteps )
 	{
 		// If the Steps we were currently editing vanished when we did the revert,
 		// put a blank Steps in its place.  Note that this does not have to be the
 		// work of someone maliciously changing the simfile; it could happen to
 		// someone editing a new stepchart and reverting from disk, for example.
-		pNewSteps = GAMESTATE->m_pCurSong->CreateSteps();
+		pNewSteps = GAMESTATE->get_curr_song()->CreateSteps();
 		pNewSteps->CreateBlank( id.GetStepsType() );
 		pNewSteps->SetDifficulty( id.GetDifficulty() );
-		GAMESTATE->m_pCurSong->AddSteps( pNewSteps );
+		GAMESTATE->get_curr_song()->AddSteps( pNewSteps );
 	}
 	GAMESTATE->m_pCurSteps[PLAYER_1].Set( pNewSteps );
 	m_pSteps = pNewSteps;
@@ -6405,7 +6405,7 @@ void ScreenEdit::CheckNumberOfNotesAndUndo()
 		return;
 
 	const float fBeat = GAMESTATE->m_pPlayerState[PLAYER_1]->m_Position.m_fSongBeat;
-	const TimeSignatureSegment * curTime = GAMESTATE->m_pCurSong->m_SongTiming.GetTimeSignatureSegmentAtBeat( fBeat );
+	const TimeSignatureSegment * curTime = GAMESTATE->get_curr_song()->m_SongTiming.GetTimeSignatureSegmentAtBeat( fBeat );
 	int rowsPerMeasure = curTime->GetDen() * curTime->GetNum();
 
 	for( int row=0; row<=m_NoteDataEdit.GetLastRow(); row+=rowsPerMeasure )
@@ -6444,7 +6444,7 @@ float ScreenEdit::GetMaximumBeatForNewNote() const
 	case EditMode_CourseMods:
 	case EditMode_Home:
 		{
-			Song &s = *GAMESTATE->m_pCurSong;
+			Song &s = *GAMESTATE->get_curr_song();
 			float fEndBeat = s.GetLastBeat();
 
 			/* Round up to the next measure end.  Some songs end on weird beats

--- a/src/ScreenEnding.cpp
+++ b/src/ScreenEnding.cpp
@@ -33,10 +33,10 @@ ScreenEnding::ScreenEnding()
 		GAMESTATE->SetCurrentStyle( GAMEMAN->GameAndStringToStyle( GAMEMAN->GetDefaultGame(),"versus"), PLAYER_INVALID );
 		GAMESTATE->JoinPlayer( PLAYER_1 );
 		GAMESTATE->JoinPlayer( PLAYER_2 );
-		GAMESTATE->m_pCurSong.Set( SONGMAN->GetRandomSong() );
+		GAMESTATE->set_curr_song(SONGMAN->GetRandomSong());
 		GAMESTATE->m_pCurCourse.Set( SONGMAN->GetRandomCourse() );
-		GAMESTATE->m_pCurSteps[PLAYER_1].Set( GAMESTATE->m_pCurSong->GetAllSteps()[0] );
-		GAMESTATE->m_pCurSteps[PLAYER_2].Set( GAMESTATE->m_pCurSong->GetAllSteps()[0] );
+		GAMESTATE->m_pCurSteps[PLAYER_1].Set( GAMESTATE->get_curr_song()->GetAllSteps()[0] );
+		GAMESTATE->m_pCurSteps[PLAYER_2].Set( GAMESTATE->get_curr_song()->GetAllSteps()[0] );
 		STATSMAN->m_CurStageStats.m_player[PLAYER_1].m_vpPossibleSteps.push_back( GAMESTATE->m_pCurSteps[PLAYER_1] );
 		STATSMAN->m_CurStageStats.m_player[PLAYER_2].m_vpPossibleSteps.push_back( GAMESTATE->m_pCurSteps[PLAYER_2] );
 		STATSMAN->m_CurStageStats.m_player[PLAYER_1].m_iStepsPlayed = 1;

--- a/src/ScreenEvaluation.cpp
+++ b/src/ScreenEvaluation.cpp
@@ -112,9 +112,9 @@ void ScreenEvaluation::Init()
 		enum_add( ss.m_Stage, rand()%3 );
 		ss.m_EarnedExtraStage = (EarnedExtraStage)(rand() % NUM_EarnedExtraStage);
 		GAMESTATE->SetMasterPlayerNumber(PLAYER_1);
-		GAMESTATE->m_pCurSong.Set( SONGMAN->GetRandomSong() );
-		ss.m_vpPlayedSongs.push_back( GAMESTATE->m_pCurSong );
-		ss.m_vpPossibleSongs.push_back( GAMESTATE->m_pCurSong );
+		GAMESTATE->set_curr_song(SONGMAN->GetRandomSong());
+		ss.m_vpPlayedSongs.push_back( GAMESTATE->get_curr_song() );
+		ss.m_vpPossibleSongs.push_back( GAMESTATE->get_curr_song() );
 		GAMESTATE->m_pCurCourse.Set( SONGMAN->GetRandomCourse() );
 		GAMESTATE->m_iCurrentStageIndex = 0;
 		FOREACH_ENUM( PlayerNumber, p )
@@ -128,7 +128,7 @@ void ScreenEvaluation::Init()
 			SO_GROUP_ASSIGN( GAMESTATE->m_SongOptions, ModsLevel_Stage, m_fMusicRate, 1.1f );
 
 			GAMESTATE->JoinPlayer( p );
-			GAMESTATE->m_pCurSteps[p].Set( GAMESTATE->m_pCurSong->GetAllSteps()[0] );
+			GAMESTATE->m_pCurSteps[p].Set( GAMESTATE->get_curr_song()->GetAllSteps()[0] );
 			if( GAMESTATE->m_pCurCourse )
 			{
 				vector<Trail*> apTrails;
@@ -152,7 +152,7 @@ void ScreenEvaluation::Init()
 
 		FOREACH_PlayerNumber( p )
 		{
-			float fSeconds = GAMESTATE->m_pCurSong->GetStepsSeconds();
+			float fSeconds = GAMESTATE->get_curr_song()->GetStepsSeconds();
 			ss.m_player[p].m_iActualDancePoints = RandomInt( 3 );
 			ss.m_player[p].m_iPossibleDancePoints = 2;
 			if( RandomInt(2) )
@@ -289,7 +289,7 @@ void ScreenEvaluation::Init()
 			if( GAMESTATE->IsCourseMode() )
 				m_LargeBanner.LoadFromCourse( GAMESTATE->m_pCurCourse );
 			else
-				m_LargeBanner.LoadFromSong( GAMESTATE->m_pCurSong );
+				m_LargeBanner.LoadFromSong( GAMESTATE->get_curr_song() );
 			m_LargeBanner.ScaleToClipped( BANNER_WIDTH, BANNER_HEIGHT );
 			m_LargeBanner.SetName( "LargeBanner" );
 			ActorUtil::LoadAllCommands( m_LargeBanner, m_sName );

--- a/src/ScreenGameplay.cpp
+++ b/src/ScreenGameplay.cpp
@@ -407,7 +407,7 @@ void ScreenGameplay::Init()
 
 	m_pCombinedLifeMeter = nullptr;
 
-	if( GAMESTATE->m_pCurSong == nullptr && GAMESTATE->m_pCurCourse == nullptr )
+	if( GAMESTATE->get_curr_song() == nullptr && GAMESTATE->m_pCurCourse == nullptr )
 		return;	// ScreenDemonstration will move us to the next screen.  We just need to survive for one update without crashing.
 
 	/* Save settings to the profile now.  Don't do this on extra stages, since the
@@ -895,7 +895,7 @@ void ScreenGameplay::InitSongQueues()
 	}
 	else
 	{
-		m_apSongsQueue.push_back( GAMESTATE->m_pCurSong );
+		m_apSongsQueue.push_back( GAMESTATE->get_curr_song() );
 		FOREACH_EnabledPlayerInfo( m_vPlayerInfo, pi )
 		{
 			Steps *pSteps = GAMESTATE->m_pCurSteps[ pi->GetStepsAndTrailIndex() ];
@@ -1197,8 +1197,8 @@ void ScreenGameplay::LoadNextSong()
 
 	int iPlaySongIndex = GAMESTATE->GetCourseSongIndex();
 	iPlaySongIndex %= m_apSongsQueue.size();
-	GAMESTATE->m_pCurSong.Set( m_apSongsQueue[iPlaySongIndex] );
-	STATSMAN->m_CurStageStats.m_vpPlayedSongs.push_back( GAMESTATE->m_pCurSong );
+	GAMESTATE->set_curr_song(m_apSongsQueue[iPlaySongIndex]);
+	STATSMAN->m_CurStageStats.m_vpPlayedSongs.push_back( GAMESTATE->get_curr_song() );
 
 	// No need to do this here.  We do it in SongFinished().
 	//GAMESTATE->RemoveAllActiveAttacks();
@@ -1219,7 +1219,7 @@ void ScreenGameplay::LoadNextSong()
 
 	SetupSong( iPlaySongIndex );
 
-	Song* pSong = GAMESTATE->m_pCurSong;
+	Song* pSong = GAMESTATE->get_curr_song();
 	FOREACH_EnabledPlayerInfo( m_vPlayerInfo, pi )
 	{
 		Steps* pSteps = GAMESTATE->m_pCurSteps[ pi->GetStepsAndTrailIndex() ];
@@ -1313,8 +1313,8 @@ void ScreenGameplay::LoadNextSong()
 	// Load lyrics
 	// XXX: don't load this here (who and why? -aj)
 	LyricsLoader LL;
-	if( GAMESTATE->m_pCurSong->HasLyrics()  )
-		LL.LoadFromLRCFile(GAMESTATE->m_pCurSong->GetLyricsPath(), *GAMESTATE->m_pCurSong);
+	if( GAMESTATE->get_curr_song()->HasLyrics()  )
+		LL.LoadFromLRCFile(GAMESTATE->get_curr_song()->GetLyricsPath(), *GAMESTATE->get_curr_song());
 
 	// Set up song-specific graphics.
 
@@ -1342,7 +1342,7 @@ void ScreenGameplay::LoadNextSong()
 
 		// BeginnerHelper disabled, or failed to load.
 		if( m_pSongBackground )
-			m_pSongBackground->LoadFromSong( GAMESTATE->m_pCurSong );
+			m_pSongBackground->LoadFromSong( GAMESTATE->get_curr_song() );
 
 		if( !GAMESTATE->m_bDemonstrationOrJukebox )
 		{
@@ -1381,7 +1381,7 @@ void ScreenGameplay::LoadNextSong()
 		m_pCombinedLifeMeter->OnLoadSong();
 
 	if( m_pSongForeground )
-		m_pSongForeground->LoadFromSong( GAMESTATE->m_pCurSong );
+		m_pSongForeground->LoadFromSong( GAMESTATE->get_curr_song() );
 
 	m_fTimeSinceLastDancingComment = 0;
 
@@ -1418,9 +1418,9 @@ void ScreenGameplay::LoadLights()
 
 	// First, check if the song has explicit lights
 	m_CabinetLightsNoteData.Init();
-	ASSERT( GAMESTATE->m_pCurSong != nullptr );
+	ASSERT( GAMESTATE->get_curr_song() != nullptr );
 
-	const Steps *pSteps = SongUtil::GetClosestNotes( GAMESTATE->m_pCurSong, StepsType_lights_cabinet, Difficulty_Medium );
+	const Steps *pSteps = SongUtil::GetClosestNotes( GAMESTATE->get_curr_song(), StepsType_lights_cabinet, Difficulty_Medium );
 	if( pSteps != nullptr )
 	{
 		pSteps->GetNoteData( m_CabinetLightsNoteData );
@@ -1456,7 +1456,7 @@ void ScreenGameplay::LoadLights()
 			d1 = StringToDifficulty( asDifficulties[0] );
 	}
 
-	pSteps = SongUtil::GetClosestNotes( GAMESTATE->m_pCurSong, st, d1 );
+	pSteps = SongUtil::GetClosestNotes( GAMESTATE->get_curr_song(), st, d1 );
 
 	// If we can't find anything at all, stop.
 	if( pSteps == nullptr )
@@ -1481,7 +1481,7 @@ void ScreenGameplay::StartPlayingSong( float fMinTimeToNotes, float fMinTimeToMu
 	p.StopMode = RageSoundParams::M_CONTINUE;
 
 	{
-		const float fFirstSecond = GAMESTATE->m_pCurSong->GetFirstSecond();
+		const float fFirstSecond = GAMESTATE->get_curr_song()->GetFirstSecond();
 		float fStartDelay = fMinTimeToNotes - fFirstSecond;
 		fStartDelay = max( fStartDelay, fMinTimeToMusic );
 		p.m_StartSecond = -fStartDelay * p.m_fSpeed;
@@ -1492,7 +1492,7 @@ void ScreenGameplay::StartPlayingSong( float fMinTimeToNotes, float fMinTimeToMu
 		float fSecondsToStartFadingOutMusic, fSecondsToStartTransitioningOut;
 		GetMusicEndTiming( fSecondsToStartFadingOutMusic, fSecondsToStartTransitioningOut );
 
-		if( fSecondsToStartFadingOutMusic < GAMESTATE->m_pCurSong->m_fMusicLengthSeconds )
+		if( fSecondsToStartFadingOutMusic < GAMESTATE->get_curr_song()->m_fMusicLengthSeconds )
 		{
 			p.m_fFadeOutSeconds = MUSIC_FADE_OUT_SECONDS;
 			p.m_LengthSeconds = fSecondsToStartFadingOutMusic + MUSIC_FADE_OUT_SECONDS - p.m_StartSecond;
@@ -1575,8 +1575,8 @@ void ScreenGameplay::PlayAnnouncer( const std::string &type, float fSeconds, flo
 	/* Don't play before the first beat, or after we're finished. */
 	if( m_DancingState != STATE_DANCING )
 		return;
-	if(GAMESTATE->m_pCurSong == nullptr  ||	// this will be true on ScreenDemonstration sometimes
-	   GAMESTATE->m_Position.m_fSongBeat < GAMESTATE->m_pCurSong->GetFirstBeat())
+	if(GAMESTATE->get_curr_song() == nullptr  ||	// this will be true on ScreenDemonstration sometimes
+	   GAMESTATE->m_Position.m_fSongBeat < GAMESTATE->get_curr_song()->GetFirstBeat())
 		return;
 
 	if( *fDeltaSeconds < fSeconds )
@@ -1594,12 +1594,12 @@ void ScreenGameplay::UpdateSongPosition( float fDeltaTime )
 	RageTimer tm;
 	const float fSeconds = m_pSoundMusic->GetPositionSeconds( nullptr, &tm );
 	const float fAdjust = SOUND->GetFrameTimingAdjustment( fDeltaTime );
-	GAMESTATE->UpdateSongPosition( fSeconds+fAdjust, GAMESTATE->m_pCurSong->m_SongTiming, tm+fAdjust );
+	GAMESTATE->UpdateSongPosition( fSeconds+fAdjust, GAMESTATE->get_curr_song()->m_SongTiming, tm+fAdjust );
 }
 
 void ScreenGameplay::BeginScreen()
 {
-	if( GAMESTATE->m_pCurSong == nullptr  )
+	if( GAMESTATE->get_curr_song() == nullptr  )
 		return;
 
 	ScreenWithMenuElements::BeginScreen();
@@ -1648,7 +1648,7 @@ bool ScreenGameplay::AllAreFailing()
 void ScreenGameplay::GetMusicEndTiming( float &fSecondsToStartFadingOutMusic, float &fSecondsToStartTransitioningOut )
 {
 	using std::max;
-	float fLastStepSeconds = GAMESTATE->m_pCurSong->GetLastSecond();
+	float fLastStepSeconds = GAMESTATE->get_curr_song()->GetLastSecond();
 	fLastStepSeconds += Player::GetMaxStepDistanceSeconds();
 
 	float fTransitionLength;
@@ -1661,10 +1661,10 @@ void ScreenGameplay::GetMusicEndTiming( float &fSecondsToStartFadingOutMusic, fl
 
 	// Align the end of the music fade to the end of the transition.
 	float fSecondsToFinishFadingOutMusic = fSecondsToStartTransitioningOut + fTransitionLength;
-	if( fSecondsToFinishFadingOutMusic < GAMESTATE->m_pCurSong->m_fMusicLengthSeconds )
+	if( fSecondsToFinishFadingOutMusic < GAMESTATE->get_curr_song()->m_fMusicLengthSeconds )
 		fSecondsToStartFadingOutMusic = fSecondsToFinishFadingOutMusic - MUSIC_FADE_OUT_SECONDS;
 	else
-		fSecondsToStartFadingOutMusic = GAMESTATE->m_pCurSong->m_fMusicLengthSeconds; // don't fade
+		fSecondsToStartFadingOutMusic = GAMESTATE->get_curr_song()->m_fMusicLengthSeconds; // don't fade
 
 	/* Make sure we keep going long enough to register a miss for the last note, and
 	 * never start fading before the last note. */
@@ -1677,7 +1677,7 @@ void ScreenGameplay::GetMusicEndTiming( float &fSecondsToStartFadingOutMusic, fl
 
 void ScreenGameplay::Update( float fDeltaTime )
 {
-	if( GAMESTATE->m_pCurSong == nullptr  )
+	if( GAMESTATE->get_curr_song() == nullptr  )
 	{
 		/* ScreenDemonstration will move us to the next screen.  We just need to
 		 * survive for one update without crashing.  We need to call Screen::Update
@@ -1700,11 +1700,11 @@ void ScreenGameplay::Update( float fDeltaTime )
 
 	/* This happens if ScreenDemonstration::HandleScreenMessage sets a new screen when
 	 * PREFSMAN->m_bDelayedScreenLoad. */
-	if( GAMESTATE->m_pCurSong == nullptr )
+	if( GAMESTATE->get_curr_song() == nullptr )
 		return;
 	/* This can happen if ScreenDemonstration::HandleScreenMessage sets a new screen when
 	 * !PREFSMAN->m_bDelayedScreenLoad.  (The new screen was loaded when we called Screen::Update,
-	 * and the ctor might set a new GAMESTATE->m_pCurSong, so the above check can fail.) */
+	 * and the ctor might set a new GAMESTATE->get_curr_song(), so the above check can fail.) */
 	if( SCREENMAN->GetTopScreen() != this )
 		return;
 
@@ -1853,7 +1853,7 @@ void ScreenGameplay::Update( float fDeltaTime )
 			// update fGameplaySeconds
 			STATSMAN->m_CurStageStats.m_fGameplaySeconds += fUnscaledDeltaTime;
 			float curBeat = GAMESTATE->m_Position.m_fSongBeat;
-			Song &s = *GAMESTATE->m_pCurSong;
+			Song &s = *GAMESTATE->get_curr_song();
 
 			if( curBeat >= s.GetFirstBeat() && curBeat < s.GetLastBeat() )
 			{
@@ -2250,7 +2250,7 @@ void ScreenGameplay::UpdateLights()
 	}
 
 	// Before the first beat of the song, all cabinet lights solid on (except for menu buttons).
-	Song &s = *GAMESTATE->m_pCurSong;
+	Song &s = *GAMESTATE->get_curr_song();
 	bool bOverrideCabinetBlink = (GAMESTATE->m_Position.m_fSongBeat < s.GetFirstBeat());
 	FOREACH_CabinetLight( cl )
 	{
@@ -2280,7 +2280,7 @@ void ScreenGameplay::SendCrossedMessages()
 		static int iRowLastCrossed = 0;
 
 		float fPositionSeconds = GAMESTATE->m_Position.m_fMusicSeconds;
-		float fSongBeat = GAMESTATE->m_pCurSong->m_SongTiming.GetBeatFromElapsedTime( fPositionSeconds );
+		float fSongBeat = GAMESTATE->get_curr_song()->m_SongTiming.GetBeatFromElapsedTime( fPositionSeconds );
 
 		int iRowNow = BeatToNoteRowNotRounded( fSongBeat );
 		iRowNow = max( 0, iRowNow );
@@ -2318,7 +2318,7 @@ void ScreenGameplay::SendCrossedMessages()
 			float fNoteWillCrossInSeconds = MESSAGE_SPACING_SECONDS * i;
 
 			float fPositionSeconds = GAMESTATE->m_Position.m_fMusicSeconds + fNoteWillCrossInSeconds;
-			float fSongBeat = GAMESTATE->m_pCurSong->m_SongTiming.GetBeatFromElapsedTime( fPositionSeconds );
+			float fSongBeat = GAMESTATE->get_curr_song()->m_SongTiming.GetBeatFromElapsedTime( fPositionSeconds );
 
 			int iRowNow = BeatToNoteRowNotRounded( fSongBeat );
 			iRowNow = max( 0, iRowNow );
@@ -2616,7 +2616,7 @@ bool ScreenGameplay::Input( const InputEventPlus &input )
  */
 void ScreenGameplay::SaveStats()
 {
-	float fMusicLen = GAMESTATE->m_pCurSong->m_fMusicLengthSeconds;
+	float fMusicLen = GAMESTATE->get_curr_song()->m_fMusicLengthSeconds;
 
 	FOREACH_EnabledPlayerInfo( m_vPlayerInfo, pi )
 	{
@@ -3213,10 +3213,10 @@ void ScreenGameplay::SaveReplay()
 
 			// song information node
 			SongID songID;
-			songID.FromSong(GAMESTATE->m_pCurSong);
+			songID.FromSong(GAMESTATE->get_curr_song());
 			XNode *pSongInfoNode = songID.CreateNode();
-			pSongInfoNode->AppendChild("Title", GAMESTATE->m_pCurSong->GetDisplayFullTitle());
-			pSongInfoNode->AppendChild("Artist", GAMESTATE->m_pCurSong->GetDisplayArtist());
+			pSongInfoNode->AppendChild("Title", GAMESTATE->get_curr_song()->GetDisplayFullTitle());
+			pSongInfoNode->AppendChild("Artist", GAMESTATE->get_curr_song()->GetDisplayArtist());
 			p->AppendChild(pSongInfoNode);
 
 			// steps information
@@ -3224,7 +3224,7 @@ void ScreenGameplay::SaveReplay()
 			stepsID.FromSteps( GAMESTATE->m_pCurSteps[pn] );
 			XNode *pStepsInfoNode = stepsID.CreateNode();
 			// hashing = argh
-			//pStepsInfoNode->AppendChild("StepsHash", stepsID.ToSteps(GAMESTATE->m_pCurSong,false)->GetHash());
+			//pStepsInfoNode->AppendChild("StepsHash", stepsID.ToSteps(GAMESTATE->get_curr_song(),false)->GetHash());
 			p->AppendChild(pStepsInfoNode);
 
 			// player information node (rival data sup)

--- a/src/ScreenGameplay.cpp
+++ b/src/ScreenGameplay.cpp
@@ -1511,7 +1511,7 @@ void ScreenGameplay::StartPlayingSong( float fMinTimeToNotes, float fMinTimeToMu
 	{
 		if(GAMESTATE->m_pCurSteps[pn])
 		{
-			GAMESTATE->m_pCurSteps[pn]->GetTimingData()->PrepareLookup();
+			GAMESTATE->m_pCurSteps[pn]->GetTimingData()->RequestLookup();
 		}
 	}
 }

--- a/src/ScreenGameplayLesson.cpp
+++ b/src/ScreenGameplayLesson.cpp
@@ -18,7 +18,7 @@ ScreenGameplayLesson::ScreenGameplayLesson()
 void ScreenGameplayLesson::Init()
 {
 	ASSERT( GAMESTATE->GetCurrentStyle(GAMESTATE->GetMasterPlayerNumber()) != nullptr );
-	ASSERT( GAMESTATE->m_pCurSong != nullptr );
+	ASSERT( GAMESTATE->get_curr_song() != nullptr );
 
 	/* Now that we've set up, init the base class. */
 	ScreenGameplayNormal::Init();
@@ -30,7 +30,7 @@ void ScreenGameplayLesson::Init()
 	m_DancingState = STATE_DANCING;
 
 	// Load pages
-	Song *pSong = GAMESTATE->m_pCurSong;
+	Song *pSong = GAMESTATE->get_curr_song();
 	std::string sDir = pSong->GetSongDir();
 	vector<std::string> vs;
 	GetDirListing( sDir+"Page*", vs, true, true );

--- a/src/ScreenGameplaySyncMachine.cpp
+++ b/src/ScreenGameplaySyncMachine.cpp
@@ -40,7 +40,7 @@ void ScreenGameplaySyncMachine::Init()
 	m_Song.SetSongDir( Rage::dir_name(sFile) );
 	m_Song.TidyUpData();
 
-	GAMESTATE->m_pCurSong.Set( &m_Song );
+	GAMESTATE->set_curr_song(&m_Song);
 	// Needs proper StepsType -freem
 	vector<Steps*> vpSteps;
 	SongUtil::GetPlayableSteps( &m_Song, vpSteps );
@@ -107,7 +107,7 @@ void ScreenGameplaySyncMachine::HandleScreenMessage( const ScreenMessage SM )
 		}
 		GAMESTATE->m_PlayMode.Set( PlayMode_Invalid );
 		GAMESTATE->SetCurrentStyle( nullptr, PLAYER_INVALID );
-		GAMESTATE->m_pCurSong.Set( nullptr );
+		GAMESTATE->set_curr_song(nullptr);
 	}
 }
 

--- a/src/ScreenHowToPlay.cpp
+++ b/src/ScreenHowToPlay.cpp
@@ -172,7 +172,7 @@ void ScreenHowToPlay::Init()
 			pSteps->GetNoteData( tempNoteData );
 			pStyle->GetTransformedNoteDataForStyle( PLAYER_1, tempNoteData, m_NoteData );
 
-			GAMESTATE->m_pCurSong.Set( &m_Song );
+			GAMESTATE->set_curr_song(&m_Song);
 			GAMESTATE->m_pCurSteps[PLAYER_1].Set(pSteps);
 			GAMESTATE->m_bGameplayLeadIn.Set( false );
 			GAMESTATE->m_pPlayerState[PLAYER_1]->m_PlayerController = PC_AUTOPLAY;
@@ -258,10 +258,10 @@ void ScreenHowToPlay::Step()
 
 void ScreenHowToPlay::Update( float fDelta )
 {
-	if( GAMESTATE->m_pCurSong != nullptr )
+	if( GAMESTATE->get_curr_song() != nullptr )
 	{
 		RageTimer tm;
-		GAMESTATE->UpdateSongPosition( m_fFakeSecondsIntoSong, GAMESTATE->m_pCurSong->m_SongTiming, tm );
+		GAMESTATE->UpdateSongPosition( m_fFakeSecondsIntoSong, GAMESTATE->get_curr_song()->m_SongTiming, tm );
 		m_fFakeSecondsIntoSong += fDelta;
 
 		static int iLastNoteRowCounted = 0;

--- a/src/ScreenInstallOverlay.cpp
+++ b/src/ScreenInstallOverlay.cpp
@@ -402,7 +402,7 @@ void ScreenInstallOverlay::Update( float fDeltaTime )
 			GAMESTATE->m_bSideIsJoined[0] = true;
 			GAMESTATE->SetMasterPlayerNumber(PLAYER_1);
 			GAMESTATE->SetCurrentStyle( vpStyle[0], PLAYER_1 );
-			GAMESTATE->m_pCurSong.Set( pSong );
+			GAMESTATE->set_curr_song(pSong);
 			GAMESTATE->m_pPreferredSong = pSong;
 			sInitialScreen = StepMania::GetSelectMusicScreen();
 		}

--- a/src/ScreenJukebox.cpp
+++ b/src/ScreenJukebox.cpp
@@ -97,7 +97,7 @@ void ScreenJukebox::SetSong()
 			continue;	// skip
 
 		// Found something we can use!
-		GAMESTATE->m_pCurSong.Set( pSong );
+		GAMESTATE->set_curr_song(pSong);
 		// We just changed the song. Reset the original sync data.
 		AdjustSync::ResetOriginalSyncData();
 		FOREACH_PlayerNumber( p )
@@ -185,7 +185,7 @@ void ScreenJukebox::Init()
 
 	SetSong();
 
-//	ASSERT( GAMESTATE->m_pCurSong );
+//	ASSERT( GAMESTATE->get_curr_song() );
 
 	GAMESTATE->SetMasterPlayerNumber(PLAYER_1);
 
@@ -235,7 +235,7 @@ void ScreenJukebox::Init()
 	// Now that we've set up, init the base class.
 	ScreenGameplay::Init();
 
-	if( GAMESTATE->m_pCurSong == nullptr )	// we didn't find a song.
+	if( GAMESTATE->get_curr_song() == nullptr )	// we didn't find a song.
 	{
 		SCREENMAN->SystemMessage( NO_MATCHING_STEPS.GetValue() );
 		this->PostScreenMessage( SM_GoToPrevScreen, 0 );	// Abort demonstration.
@@ -300,7 +300,7 @@ void ScreenJukebox::InitSongQueues()
 	int iIndexToKeep = -1;
 	for( unsigned i=0; i<m_apSongsQueue.size(); i++ )
 	{
-		if( m_apSongsQueue[i] == GAMESTATE->m_pCurSong )
+		if( m_apSongsQueue[i] == GAMESTATE->get_curr_song() )
 		{
 			iIndexToKeep = i;
 			break;

--- a/src/ScreenNetEvaluation.cpp
+++ b/src/ScreenNetEvaluation.cpp
@@ -210,7 +210,7 @@ void ScreenNetEvaluation::UpdateStats()
 
 	StepsType st = GAMESTATE->GetCurrentStyle(PLAYER_INVALID)->m_StepsType;
 	Difficulty dc = NSMAN->m_EvalPlayerData[m_iCurrentPlayer].difficulty;
-	Steps *pSteps = SongUtil::GetOneSteps( GAMESTATE->m_pCurSong, st, dc );
+	Steps *pSteps = SongUtil::GetOneSteps( GAMESTATE->get_curr_song(), st, dc );
 
 	// broadcast a message so themes know that the active player has changed. -aj
 	Message msg("UpdateNetEvalStats");

--- a/src/ScreenNetSelectMusic.cpp
+++ b/src/ScreenNetSelectMusic.cpp
@@ -272,7 +272,7 @@ void ScreenNetSelectMusic::HandleScreenMessage( const ScreenMessage SM )
 	}
 	else if( SM == SM_SongChanged )
 	{
-		GAMESTATE->m_pCurSong.Set( m_MusicWheel.GetSelectedSong() );
+		GAMESTATE->set_curr_song(m_MusicWheel.GetSelectedSong());
 		MusicChanged();
 	}
 	else if( SM == SM_SMOnlinePack )
@@ -363,11 +363,11 @@ bool ScreenNetSelectMusic::MenuDown( const InputEventPlus &input )
 		}
 	}
 
-	if( GAMESTATE->m_pCurSong == nullptr )
+	if( GAMESTATE->get_curr_song() == nullptr )
 		return false;
 	StepsType st = GAMESTATE->GetCurrentStyle(pn)->m_StepsType;
 	vector <Steps *> MultiSteps;
-	MultiSteps = GAMESTATE->m_pCurSong->GetStepsByStepsType( st );
+	MultiSteps = GAMESTATE->get_curr_song()->GetStepsByStepsType( st );
 	if(MultiSteps.size() == 0)
 		m_DC[pn] = NUM_Difficulty;
 	else
@@ -426,7 +426,7 @@ bool ScreenNetSelectMusic::MenuStart( const InputEventPlus & )
 	if( pSong == nullptr )
 		return false;
 
-	GAMESTATE->m_pCurSong.Set( pSong );
+	GAMESTATE->set_curr_song(pSong);
 
 	if( NSMAN->useSMserver )
 	{
@@ -471,7 +471,7 @@ void ScreenNetSelectMusic::TweenOffScreen()
 void ScreenNetSelectMusic::StartSelectedSong()
 {
 	Song * pSong = m_MusicWheel.GetSelectedSong();
-	GAMESTATE->m_pCurSong.Set( pSong );
+	GAMESTATE->set_curr_song(pSong);
 	FOREACH_EnabledPlayer (pn)
 	{
 		StepsType st = GAMESTATE->GetCurrentStyle(pn)->m_StepsType; //StepsType_dance_single;
@@ -492,7 +492,7 @@ void ScreenNetSelectMusic::StartSelectedSong()
 
 void ScreenNetSelectMusic::UpdateDifficulties( PlayerNumber pn )
 {
-	if( GAMESTATE->m_pCurSong == nullptr )
+	if( GAMESTATE->get_curr_song() == nullptr )
 	{
 		m_StepsDisplays[pn].SetFromStepsTypeAndMeterAndDifficultyAndCourseType( StepsType_Invalid, 0, Difficulty_Beginner, CourseType_Invalid );
 		//m_DifficultyIcon[pn].SetFromSteps( pn, nullptr );	// It will blank it out
@@ -501,7 +501,7 @@ void ScreenNetSelectMusic::UpdateDifficulties( PlayerNumber pn )
 
 	StepsType st = GAMESTATE->GetCurrentStyle(pn)->m_StepsType;
 
-	Steps * pSteps = SongUtil::GetStepsByDifficulty( GAMESTATE->m_pCurSong, st, m_DC[pn] );
+	Steps * pSteps = SongUtil::GetStepsByDifficulty( GAMESTATE->get_curr_song(), st, m_DC[pn] );
 	GAMESTATE->m_pCurSteps[pn].Set( pSteps );
 
 	if( ( m_DC[pn] < NUM_Difficulty ) && ( m_DC[pn] >= Difficulty_Beginner ) )
@@ -512,7 +512,7 @@ void ScreenNetSelectMusic::UpdateDifficulties( PlayerNumber pn )
 
 void ScreenNetSelectMusic::MusicChanged()
 {
-	if( GAMESTATE->m_pCurSong == nullptr )
+	if( GAMESTATE->get_curr_song() == nullptr )
 	{
 		FOREACH_EnabledPlayer (pn)
 			UpdateDifficulties( pn );
@@ -528,7 +528,7 @@ void ScreenNetSelectMusic::MusicChanged()
 		m_DC[pn] = GAMESTATE->m_PreferredDifficulty[pn];
 		StepsType st = GAMESTATE->GetCurrentStyle(pn)->m_StepsType;
 		vector <Steps *> MultiSteps;
-		MultiSteps = GAMESTATE->m_pCurSong->GetStepsByStepsType( st );
+		MultiSteps = GAMESTATE->get_curr_song()->GetStepsByStepsType( st );
 		if(MultiSteps.size() == 0)
 			m_DC[pn] = NUM_Difficulty;
 		else
@@ -566,18 +566,18 @@ void ScreenNetSelectMusic::MusicChanged()
 	// Copied from ScreenSelectMusic
 	// TODO: Update me! -aj
 	SOUND->StopMusic();
-	if( GAMESTATE->m_pCurSong->HasMusic() )
+	if( GAMESTATE->get_curr_song()->HasMusic() )
 	{
 		// don't play the same sound over and over
-		if (Rage::ci_ascii_string{ SOUND->GetMusicPath().c_str() } != GAMESTATE->m_pCurSong->GetMusicPath())
+		if (Rage::ci_ascii_string{ SOUND->GetMusicPath().c_str() } != GAMESTATE->get_curr_song()->GetMusicPath())
 		{
 			SOUND->StopMusic();
 			SOUND->PlayMusic(
-				GAMESTATE->m_pCurSong->GetPreviewMusicPath(),
+				GAMESTATE->get_curr_song()->GetPreviewMusicPath(),
 				nullptr,
 				true,
-				GAMESTATE->m_pCurSong->GetPreviewStartSeconds(),
-				GAMESTATE->m_pCurSong->m_fMusicSampleLengthSeconds );
+				GAMESTATE->get_curr_song()->GetPreviewStartSeconds(),
+				GAMESTATE->get_curr_song()->m_fMusicSampleLengthSeconds );
 		}
 	}
 }

--- a/src/ScreenOptionsCourseOverview.cpp
+++ b/src/ScreenOptionsCourseOverview.cpp
@@ -93,7 +93,7 @@ void ScreenOptionsCourseOverview::BeginScreen()
 	ScreenOptions::BeginScreen();
 
 	// clear the current song in case it's set when we back out from gameplay
-	GAMESTATE->m_pCurSong.Set( nullptr );
+	GAMESTATE->set_curr_song(nullptr);
 }
 
 ScreenOptionsCourseOverview::~ScreenOptionsCourseOverview()

--- a/src/ScreenOptionsEditCourse.cpp
+++ b/src/ScreenOptionsEditCourse.cpp
@@ -38,7 +38,7 @@ public:
 		m_Def.m_vsChoices.clear();
 		m_vpSteps.clear();
 
-		Song *pSong = GAMESTATE->m_pCurSong;
+		Song *pSong = GAMESTATE->get_curr_song();
 		if( pSong ) // playing a song
 		{
 			GetStepsForSong( pSong, m_vpSteps );
@@ -383,7 +383,7 @@ void ScreenOptionsEditCourse::SetCurrentSong()
 
 	if( row.GetRowType() == OptionRow::RowType_Exit )
 	{
-		GAMESTATE->m_pCurSong.Set( nullptr );
+		GAMESTATE->set_curr_song(nullptr);
 		GAMESTATE->m_pCurSteps[PLAYER_1].Set( nullptr );
 	}
 	else
@@ -401,14 +401,14 @@ void ScreenOptionsEditCourse::SetCurrentSong()
 		}
 		if ( pSong != nullptr )
 		{
-			GAMESTATE->m_pCurSong.Set( pSong );
+			GAMESTATE->set_curr_song(pSong);
 		}
 	}
 }
 
 void ScreenOptionsEditCourse::SetCurrentSteps()
 {
-	Song *pSong = GAMESTATE->m_pCurSong;
+	Song *pSong = GAMESTATE->get_curr_song();
 	if( pSong )
 	{
 		int iRow = m_iCurrentRow[PLAYER_1];

--- a/src/ScreenOptionsManageEditSteps.cpp
+++ b/src/ScreenOptionsManageEditSteps.cpp
@@ -64,7 +64,7 @@ void ScreenOptionsManageEditSteps::BeginScreen()
 	SONGMAN->FreeAllLoadedFromProfile( ProfileSlot_Machine );
 	SONGMAN->LoadStepEditsFromProfileDir( PROFILEMAN->GetProfileDir(ProfileSlot_Machine), ProfileSlot_Machine );
 	SONGMAN->LoadCourseEditsFromProfileDir( PROFILEMAN->GetProfileDir(ProfileSlot_Machine), ProfileSlot_Machine );
-	GAMESTATE->m_pCurSong.Set( nullptr );
+	GAMESTATE->set_curr_song(nullptr);
 	GAMESTATE->m_pCurSteps[PLAYER_1].Set( nullptr );
 
 	vector<OptionRowHandler*> vHands;
@@ -194,7 +194,7 @@ void ScreenOptionsManageEditSteps::HandleScreenMessage( const ScreenMessage SM )
 				{
 					Steps *pSteps = GetStepsWithFocus();
 					Song *pSong = pSteps->m_pSong;
-					GAMESTATE->m_pCurSong.Set( pSong );
+					GAMESTATE->set_curr_song(pSong);
 					GAMESTATE->m_pCurSteps[PLAYER_1].Set( pSteps );
 
 					ScreenOptions::BeginFadingOut();
@@ -235,7 +235,7 @@ void ScreenOptionsManageEditSteps::AfterChangeRow( PlayerNumber pn )
 	Steps *pSteps = GetStepsWithFocus();
 	Song *pSong = pSteps ? pSteps->m_pSong : nullptr;
 
-	GAMESTATE->m_pCurSong.Set( pSong );
+	GAMESTATE->set_curr_song(pSong);
 	GAMESTATE->m_pCurSteps[PLAYER_1].Set( pSteps );
 
 	ScreenOptions::AfterChangeRow( pn );

--- a/src/ScreenOptionsReviewWorkout.cpp
+++ b/src/ScreenOptionsReviewWorkout.cpp
@@ -66,7 +66,7 @@ void ScreenOptionsCourseOverview::BeginScreen()
 	ScreenOptions::BeginScreen();
 
 	// clear the current song in case it's set when we back out from gameplay
-	GAMESTATE->m_pCurSong.Set( nullptr );
+	GAMESTATE->set_curr_song(nullptr);
 }
 
 ScreenOptionsCourseOverview::~ScreenOptionsCourseOverview()

--- a/src/ScreenSaveSync.cpp
+++ b/src/ScreenSaveSync.cpp
@@ -32,7 +32,7 @@ static std::string GetPromptText()
 			s += CHANGED_TIMING_OF.GetValue()+"\n" +
 				fmt::sprintf("%s:\n"
 				"\n",
-				GAMESTATE->m_pCurSong->GetDisplayFullTitle().c_str() );
+				GAMESTATE->get_curr_song()->GetDisplayFullTitle().c_str() );
 
 			s += Rage::join( "\n", vs ) + "\n\n";
 		}

--- a/src/ScreenSelectMusic.cpp
+++ b/src/ScreenSelectMusic.cpp
@@ -1033,7 +1033,7 @@ void ScreenSelectMusic::ChangeSteps( PlayerNumber pn, int dir )
 
 	ASSERT( GAMESTATE->IsHumanPlayer(pn) );
 
-	if( GAMESTATE->m_pCurSong )
+	if( GAMESTATE->get_curr_song() )
 	{
 		m_iSelection[pn] += dir;
 		if( WRAP_CHANGE_STEPS )
@@ -1604,11 +1604,11 @@ void ScreenSelectMusic::AfterStepsOrTrailChange( const vector<PlayerNumber> &vpn
 	{
 		ASSERT( GAMESTATE->IsHumanPlayer(pn) );
 
-		if( GAMESTATE->m_pCurSong )
+		if( GAMESTATE->get_curr_song() )
 		{
 			m_iSelection[pn] = Rage::clamp( m_iSelection[pn], 0, static_cast<int>(m_vpSteps.size())-1 );
 
-			Song* pSong = GAMESTATE->m_pCurSong;
+			Song* pSong = GAMESTATE->get_curr_song();
 			Steps* pSteps = m_vpSteps.empty()? nullptr: m_vpSteps[m_iSelection[pn]];
 
 			GAMESTATE->m_pCurSteps[pn].Set( pSteps );
@@ -1740,7 +1740,7 @@ void ScreenSelectMusic::AfterMusicChange()
 		m_MenuTimer->Stall();
 
 	Song* pSong = m_MusicWheel.GetSelectedSong();
-	GAMESTATE->m_pCurSong.Set( pSong );
+	GAMESTATE->set_curr_song(pSong);
 	if( pSong )
 		GAMESTATE->m_pPreferredSong = pSong;
 

--- a/src/ScreenSyncOverlay.cpp
+++ b/src/ScreenSyncOverlay.cpp
@@ -88,7 +88,7 @@ void ScreenSyncOverlay::UpdateText()
 		FAIL_M(fmt::sprintf("Invalid autosync type: %i", type));
 	}
 
-	if( GAMESTATE->m_pCurSong != nullptr  &&  !GAMESTATE->IsCourseMode() )	// sync controls available
+	if( GAMESTATE->get_curr_song() != nullptr  &&  !GAMESTATE->IsCourseMode() )	// sync controls available
 	{
 		AdjustSync::GetSyncChangeTextGlobal( vs );
 		AdjustSync::GetSyncChangeTextSong( vs );
@@ -209,12 +209,12 @@ bool ScreenSyncOverlay::Input( const InputEventPlus &input )
 				}
 				default: break;
 			}
-			if( GAMESTATE->m_pCurSong != nullptr )
+			if( GAMESTATE->get_curr_song() != nullptr )
 			{
-				TimingData &sTiming = GAMESTATE->m_pCurSong->m_SongTiming;
+				TimingData &sTiming = GAMESTATE->get_curr_song()->m_SongTiming;
 				BPMSegment * seg = sTiming.GetBPMSegmentAtBeat( GAMESTATE->m_Position.m_fSongBeat );
 				seg->SetBPS( seg->GetBPS() + fDelta );
-				auto const & vpSteps = GAMESTATE->m_pCurSong->GetAllSteps();
+				auto const & vpSteps = GAMESTATE->get_curr_song()->GetAllSteps();
 				for (auto *s: vpSteps)
 				{
 					TimingData &pTiming = s->m_Timing;
@@ -261,10 +261,10 @@ bool ScreenSyncOverlay::Input( const InputEventPlus &input )
 
 				case ChangeSongOffset:
 				{
-					if( GAMESTATE->m_pCurSong != nullptr )
+					if( GAMESTATE->get_curr_song() != nullptr )
 					{
-						GAMESTATE->m_pCurSong->m_SongTiming.m_fBeat0OffsetInSeconds += fDelta;
-						auto const & vpSteps = GAMESTATE->m_pCurSong->GetAllSteps();
+						GAMESTATE->get_curr_song()->m_SongTiming.m_fBeat0OffsetInSeconds += fDelta;
+						auto const & vpSteps = GAMESTATE->get_curr_song()->GetAllSteps();
 						for (auto *s: vpSteps)
 						{
 							// Empty means it inherits song timing,

--- a/src/ScreenUnlockCelebrate.cpp
+++ b/src/ScreenUnlockCelebrate.cpp
@@ -20,7 +20,7 @@ void ScreenUnlockCelebrate::Init()
 	UNLOCKMAN->UnlockEntryIndex( g_iUnlockEntryIndexToCelebrate );
 	Song* pSong = UNLOCKMAN->m_UnlockEntries[ g_iUnlockEntryIndexToCelebrate ].m_Song.ToSong();
 	if( pSong )
-		GAMESTATE->m_pCurSong.Set( pSong );
+		GAMESTATE->set_curr_song(pSong);
 
 	ScreenUnlockBrowse::Init();
 }

--- a/src/SongManager.cpp
+++ b/src/SongManager.cpp
@@ -1269,19 +1269,19 @@ void SongManager::GetExtraStageInfo( bool bExtra2, const Style *sd, Song*& pSong
 	std::string sGroup = GAMESTATE->m_sPreferredSongGroup;
 	if( sGroup == GROUP_ALL )
 	{
-		if( GAMESTATE->m_pCurSong == nullptr )
+		if( GAMESTATE->get_curr_song() == nullptr )
 		{
 			// This normally shouldn't happen, but it's helpful to permit it for testing.
-			LuaHelpers::ReportScriptErrorFmt( "GetExtraStageInfo() called in GROUP_ALL, but GAMESTATE->m_pCurSong == nullptr" );
-			GAMESTATE->m_pCurSong.Set( GetRandomSong() );
+			LuaHelpers::ReportScriptErrorFmt( "GetExtraStageInfo() called in GROUP_ALL, but GAMESTATE->get_curr_song() == nullptr" );
+			GAMESTATE->set_curr_song(GetRandomSong());
 		}
-		sGroup = GAMESTATE->m_pCurSong->m_sGroupName;
+		sGroup = GAMESTATE->get_curr_song()->m_sGroupName;
 	}
 
 	ASSERT_M( sGroup != "", fmt::sprintf("%p '%s' '%s'",
-		static_cast<void *>(GAMESTATE->m_pCurSong.Get()),
-		GAMESTATE->m_pCurSong? GAMESTATE->m_pCurSong->GetSongDir().c_str():"",
-		GAMESTATE->m_pCurSong? GAMESTATE->m_pCurSong->m_sGroupName.c_str():"") );
+		static_cast<void *>(GAMESTATE->get_curr_song()),
+		GAMESTATE->get_curr_song()? GAMESTATE->get_curr_song()->GetSongDir().c_str():"",
+		GAMESTATE->get_curr_song()? GAMESTATE->get_curr_song()->m_sGroupName.c_str():"") );
 
 	// Check preferred group
 	if( GetExtraStageInfoFromCourse(bExtra2, sGroup, pSongOut, pStepsOut, sd->m_StepsType) )

--- a/src/SongPosition.cpp
+++ b/src/SongPosition.cpp
@@ -11,9 +11,9 @@ void SongPosition::UpdateSongPosition( float fPositionSeconds, const TimingData 
 	else
 		m_LastBeatUpdate.Touch();
 
-	TimingData::GetBeatArgs beat_info;
-	beat_info.elapsed_time= fPositionSeconds;
-	timing.GetBeatAndBPSFromElapsedTime(beat_info);
+	TimingData::DetailedTimeInfo beat_info;
+	beat_info.second= fPositionSeconds;
+	timing.GetDetailedInfoForSecond(beat_info);
 	m_fSongBeat= beat_info.beat;
 	m_fCurBPS= beat_info.bps_out;
 	m_bFreeze= beat_info.freeze_out;

--- a/src/SongPosition.cpp
+++ b/src/SongPosition.cpp
@@ -18,8 +18,6 @@ void SongPosition::UpdateSongPosition( float fPositionSeconds, const TimingData 
 	m_fCurBPS= beat_info.bps_out;
 	m_bFreeze= beat_info.freeze_out;
 	m_bDelay= beat_info.delay_out;
-	m_iWarpBeginRow= beat_info.warp_begin_out;
-	m_fWarpDestination= beat_info.warp_dest_out;
 	
 	// "Crash reason : -243478.890625 -48695.773438"
 	// The question is why is -2000 used as the limit? -aj
@@ -32,14 +30,11 @@ void SongPosition::UpdateSongPosition( float fPositionSeconds, const TimingData 
 	m_fSongBeatNoOffset = timing.GetBeatFromElapsedTimeNoOffset( fPositionSeconds );
 	
 	m_fMusicSecondsVisible = fPositionSeconds - g_fVisualDelaySeconds.Get();
-	beat_info.elapsed_time= m_fMusicSecondsVisible;
-	timing.GetBeatAndBPSFromElapsedTime(beat_info);
-	m_fSongBeatVisible= beat_info.beat;
+	m_fSongBeatVisible= timing.GetBeatFromElapsedTime(m_fMusicSecondsVisible);
 }
 
 void SongPosition::Reset()
 {
-
 	m_fMusicSecondsVisible = 0;
 	m_fSongBeatVisible = 0;
 
@@ -51,9 +46,6 @@ void SongPosition::Reset()
 	//m_bStop = false;
 	m_bFreeze = false;
 	m_bDelay = false;
-	m_iWarpBeginRow = -1; // Set to -1 because some song may want to warp to row 0. -aj
-	m_fWarpDestination = -1; // Set when a warp is encountered. also see above. -aj
-
 }
 
 //lua start
@@ -69,8 +61,6 @@ public:
 	DEFINE_METHOD( GetCurBPS, m_fCurBPS );
 	DEFINE_METHOD( GetFreeze, m_bFreeze );
 	DEFINE_METHOD( GetDelay, m_bDelay );
-	DEFINE_METHOD( GetWarpBeginRow, m_iWarpBeginRow );
-	DEFINE_METHOD( GetWarpDestination, m_fWarpDestination );
 
 	LunaSongPosition()
 	{
@@ -82,8 +72,6 @@ public:
 		ADD_METHOD( GetCurBPS );
 		ADD_METHOD( GetFreeze );
 		ADD_METHOD( GetDelay );
-		ADD_METHOD( GetWarpBeginRow );
-		ADD_METHOD( GetWarpDestination );
 	}
 };
 

--- a/src/SongPosition.h
+++ b/src/SongPosition.h
@@ -25,10 +25,6 @@ public:
 	bool		m_bFreeze;
 	/** @brief A flag to determine if we're in the middle of a delay (Pump style stop). */
 	bool		m_bDelay;
-	/** @brief The row used to start a warp. */
-	int			m_iWarpBeginRow;
-	/** @brief The beat to warp to afterwards. */
-	float		m_fWarpDestination;
 	RageTimer	m_LastBeatUpdate; // time of last m_fSongBeat, etc. update
 	float		m_fMusicSecondsVisible;
 	float		m_fSongBeatVisible;

--- a/src/SongUtil.cpp
+++ b/src/SongUtil.cpp
@@ -1220,10 +1220,10 @@ namespace
 	}
 	int validate_edit_description(lua_State* L)
 	{
-		Song* snog= Luna<Song>::check(L, 1, true);
+		Song* check_song= Luna<Song>::check(L, 1, true);
 		StepsType stype= Enum::Check<StepsType>(L, 2);
 		std::string desc= SArg(3);
-		lua_pushboolean(L, SongUtil::IsEditDescriptionUnique(snog, stype, desc, nullptr));
+		lua_pushboolean(L, SongUtil::IsEditDescriptionUnique(check_song, stype, desc, nullptr));
 		return 1;
 	}
 

--- a/src/SongUtil.cpp
+++ b/src/SongUtil.cpp
@@ -881,7 +881,7 @@ bool SongUtil::ValidateCurrentStepsChartName(const std::string &answer, std::str
 	if (pSteps->GetChartName() == answer) return true;
 
 	// TODO next commit: borrow code from EditStepsDescription.
-	bool result = SongUtil::IsChartNameUnique(GAMESTATE->m_pCurSong, pSteps->m_StepsType,
+	bool result = SongUtil::IsChartNameUnique(GAMESTATE->get_curr_song(), pSteps->m_StepsType,
 											  answer, pSteps);
 	if (!result)
 	{
@@ -918,7 +918,7 @@ bool SongUtil::ValidateCurrentSongPreview(const std::string& answer, std::string
 {
 	if(answer.empty())
 	{ return true; }
-	Song* song= GAMESTATE->m_pCurSong;
+	Song* song= GAMESTATE->get_curr_song();
 	std::string real_file= song->m_PreviewFile;
 	song->m_PreviewFile= answer;
 	std::string path= song->GetPreviewMusicPath();

--- a/src/StageStats.cpp
+++ b/src/StageStats.cpp
@@ -237,7 +237,7 @@ void StageStats::FinalizeScores( bool bSummary )
 		const HighScore &hs = m_player[p].m_HighScore;
 		StepsType st = GAMESTATE->GetCurrentStyle(p)->m_StepsType;
 
-		const Song* pSong = GAMESTATE->m_pCurSong;
+		const Song* pSong = GAMESTATE->get_curr_song();
 		const Steps* pSteps = GAMESTATE->m_pCurSteps[p];
 
 		// Don't save DQ'd scores
@@ -306,7 +306,7 @@ void StageStats::FinalizeScores( bool bSummary )
 		}
 		else
 		{
-			Song* pSong = GAMESTATE->m_pCurSong;
+			Song* pSong = GAMESTATE->get_curr_song();
 			Steps* pSteps = GAMESTATE->m_pCurSteps[p];
 			pHSL = &pProfile->GetStepsHighScoreList( pSong, pSteps );
 		}

--- a/src/TimingData.cpp
+++ b/src/TimingData.cpp
@@ -422,7 +422,7 @@ void TimingData::ReleaseLineLookup()
 {
 	if(!m_line_segments.empty())
 	{
-		full_clear_container(m_line_segments);
+		m_line_segments.shrink_to_fit();
 		full_clear_container(m_segments_by_beat);
 		full_clear_container(m_segments_by_second);
 	}
@@ -652,7 +652,7 @@ void TimingData::ShiftRange(int start_row, int end_row,
 			// the rows of the segments, the second time removing segments that
 			// have been run over by a segment being moved.  Attempts to combine
 			// both operations into a single loop were error prone. -Kyz
-			for(size_t i= first_affected; i <= static_cast<int>(last_affected) && i < segs.size(); ++i)
+			for(size_t i= first_affected; i <= static_cast<size_t>(last_affected) && i < segs.size(); ++i)
 			{
 				int seg_row= segs[i]->GetRow();
 				if(seg_row > 0 && seg_row >= start_row && seg_row <= end_row)
@@ -662,7 +662,7 @@ void TimingData::ShiftRange(int start_row, int end_row,
 				}
 			}
 #define ERASE_SEG(s) if(segs.size() > 1) { EraseSegment(segs, s, segs[s]); --i; --last_affected; erased= true; }
-			for(size_t i= first_affected; i <= static_cast<int>(last_affected) && i < segs.size(); ++i)
+			for(size_t i= first_affected; i <= static_cast<size_t>(last_affected) && i < segs.size(); ++i)
 			{
 				bool erased= false;
 				int seg_row= segs[i]->GetRow();

--- a/src/TimingData.h
+++ b/src/TimingData.h
@@ -104,12 +104,12 @@ public:
 	std::vector<LineSegment> m_line_segments;
 	std::map<float, std::vector<LineSegment*> > m_segments_by_beat;
 	std::map<float, std::vector<LineSegment*> > m_segments_by_second;
-	public:
 
 	void PrepareLineLookup();
 	void ReleaseLineLookup();
 	float GetLineBeatFromSecond(float second) const;
 	float GetLineSecondFromBeat(float beat) const;
+	public:
 	float GetExpandSeconds(float second) const;
 
 	// GetBeatArgs, GetBeatStarts, m_beat_start_lookup, m_time_start_lookup,


### PR DESCRIPTION
Let's try a different method for optimizing GetBeatFromElapsedTime.
Each timing segment is like a line segment.
GetBeat/GetElapsedTime finds the segment at the given time, then linearly interpolates between its endpoints for the result.
This should be faster than stepping forward from a known start point.


GetBeatInternal, GetElapsedTimeInternal, and PrepareLineLookup all had similar code.  PrepareLineLookup has a search mode that can be used to fill their roles without the lookup table.

GAMESTATE->m_pCurSong has been privatized and wrapped with a function that prepares and releases the timing data lookup for the song.  It should be a trivial efficiency improvement on music selection because SongPosition uses TimingData functions when playing the sample music.