### PR TITLE
Add support for custom songs from USB profiles.

### DIFF
--- a/Themes/_fallback/Scripts/02 lua_config_system.lua
+++ b/Themes/_fallback/Scripts/02 lua_config_system.lua
@@ -191,7 +191,7 @@ local lua_config_mt= {
 			if self.use_alternate_config_prefix then
 				return prof_dir .. self.use_alternate_config_prefix .. self.file
 			end
-			local config_prefix= "/"..THEME:GetCurThemeName().."_config/"
+			local config_prefix= THEME:GetCurThemeName().."_config/"
 			return prof_dir .. config_prefix .. self.file
 		end,
 		save= function(self, slot)

--- a/Themes/_fallback/metrics.ini
+++ b/Themes/_fallback/metrics.ini
@@ -139,6 +139,9 @@ CourseGroupColor7=color("1,1,1,1") -- white
 CourseGroupColor8=color("1,1,1,1") -- white
 CourseGroupColor9=color("1,1,1,1") -- white
 CourseGroupColor10=color("1,1,1,1") -- white
+NumProfileSongGroupColors=2
+ProfileSongGroupColor1=PlayerColor(PLAYER_1)
+ProfileSongGroupColor2=PlayerColor(PLAYER_2)
 UnlockColor=color("1,0.5,0,1")
 
 [UnlockManager]

--- a/src/GameState.cpp
+++ b/src/GameState.cpp
@@ -1,6 +1,7 @@
 #include "global.h"
 #include "GameState.h"
 #include "Actor.h"
+#include "ActorUtil.h"
 #include "AdjustSync.h"
 #include "AnnouncerManager.h"
 #include "Bookkeeper.h"
@@ -26,6 +27,7 @@
 #include "Profile.h"
 #include "ProfileManager.h"
 #include "RageFile.h"
+#include "RageFileManager.h"
 #include "RageLog.h"
 #include "RageUtil.h"
 #include "RageFmtWrap.h"
@@ -1474,6 +1476,59 @@ int GameState::GetLoadingCourseSongIndex() const
 	if( m_bLoadingNextSong )
 		++iIndex;
 	return iIndex;
+}
+
+static std::vector<std::string> const prepare_song_failures= {
+	"success",
+	"no_current_song",
+	"card_mount_failed",
+	"load_interrupted"
+};
+
+int GameState::prepare_song_for_gameplay()
+{
+	Song* curr= get_curr_song();
+	if(curr == nullptr)
+	{
+		return 1;
+	}
+	if(curr->m_LoadedFromProfile == ProfileSlot_Invalid)
+	{
+		return 0;
+	}
+	ProfileSlot prof_slot= curr->m_LoadedFromProfile;
+	PlayerNumber slot_as_pn= PlayerNumber(prof_slot);
+	if(!PROFILEMAN->ProfileWasLoadedFromMemoryCard(slot_as_pn))
+	{
+		return 0;
+	}
+	if(!MEMCARDMAN->MountCard(slot_as_pn))
+	{
+		return 2;
+	}
+	std::string prof_dir= PROFILEMAN->GetProfileDir(prof_slot);
+	// Song loading changes its paths to point to the cache area. -Kyz
+	std::string to_dir= curr->GetSongDir();
+	std::string from_dir= curr->GetPreCustomifyDir();
+	// The problem of what files to copy is complicated by steps being able to
+	// specify their own music file, and the variety of step file formats.
+	// Complex logic to figure out what files the song actually uses would be
+	// bug prone.  Just copy all audio files and step files. -Kyz
+	vector<std::string> copy_exts= ActorUtil::GetTypeExtensionList(FT_Sound);
+	copy_exts.push_back("sm");
+	copy_exts.push_back("ssc");
+	copy_exts.push_back("lrc");
+	vector<std::string> files_in_dir;
+	FILEMAN->GetDirListingWithMultipleExtensions(from_dir, copy_exts, files_in_dir);
+	for(auto&& fname : files_in_dir)
+	{
+		if(!FileCopy(from_dir + fname, to_dir + fname))
+		{
+			return 3;
+		}
+	}
+	MEMCARDMAN->UnmountCard(slot_as_pn);
+	return 0;
 }
 
 Song* GameState::get_curr_song() const
@@ -3329,6 +3384,12 @@ public:
 		p->m_autogen_fargs[si]= v;
 		COMMON_RETURN_SELF;
 	}
+	static int prepare_song_for_gameplay(T* p, lua_State* L)
+	{
+		int result= p->prepare_song_for_gameplay();
+		lua_pushstring(L, prepare_song_failures[result].c_str());
+		return 1;
+	}
 
 	LunaGameState()
 	{
@@ -3455,6 +3516,7 @@ public:
 		ADD_METHOD( SetStepsForEditMode );
 		ADD_METHOD( GetAutoGenFarg );
 		ADD_METHOD( SetAutoGenFarg );
+		ADD_METHOD(prepare_song_for_gameplay);
 	}
 };
 

--- a/src/GameState.h
+++ b/src/GameState.h
@@ -244,6 +244,8 @@ public:
 	bool		m_bLoadingNextSong;
 	int		GetLoadingCourseSongIndex() const;
 
+	int prepare_song_for_gameplay();
+
 	// State Info used during gameplay
 
 	// nullptr on ScreenSelectMusic if the currently selected wheel item isn't a Song.

--- a/src/MusicWheel.cpp
+++ b/src/MusicWheel.cpp
@@ -9,6 +9,7 @@
 #include "GameState.h"
 #include "ThemeManager.h"
 #include "NetworkSyncManager.h"
+#include "ProfileManager.h"
 #include "Song.h"
 #include "Course.h"
 #include "Steps.h"
@@ -430,6 +431,17 @@ void MusicWheel::GetSongList( vector<Song*> &arraySongs, SortOrder so )
 	default:
 		apAllSongs = SONGMAN->GetAllSongs();
 		break;
+	}
+	FOREACH_PlayerNumber(pn)
+	{
+		if(GAMESTATE->IsPlayerEnabled(pn))
+		{
+			Profile* prof= PROFILEMAN->GetProfile(pn);
+			for(auto&& song : prof->m_songs)
+			{
+				apAllSongs.push_back(song);
+			}
+		}
 	}
 
 	// filter songs that we don't have enough stages to play

--- a/src/PrefsManager.cpp
+++ b/src/PrefsManager.cpp
@@ -300,6 +300,12 @@ PrefsManager::PrefsManager() :
 
 	m_bQuirksMode			( "QuirksMode",		false ),
 
+	m_custom_songs_enable("CustomSongsEnable", false),
+	m_custom_songs_max_count("CustomSongsMaxCount", 1000), // No limit. -- 2 Unlimited
+	m_custom_songs_load_timeout("CustomSongsLoadTimeout", 5.f),
+	m_custom_songs_max_seconds("CustomSongsMaxSeconds", 120.f),
+	m_custom_songs_max_megabytes("CustomSongsMaxMegabytes", 5.f),
+
 	/* Debug: */
 	m_bLogToDisk			( "LogToDisk",		true ),
 #if defined(DEBUG)

--- a/src/PrefsManager.h
+++ b/src/PrefsManager.h
@@ -317,6 +317,12 @@ public:
 	/** @brief Enable some quirky behavior used by some older versions of StepMania. */
 	Preference<bool>	m_bQuirksMode;
 
+	Preference<bool> m_custom_songs_enable;
+	Preference<unsigned int> m_custom_songs_max_count;
+	Preference<float> m_custom_songs_load_timeout;
+	Preference<float> m_custom_songs_max_seconds;
+	Preference<float> m_custom_songs_max_megabytes;
+
 	// Debug:
 	Preference<bool>	m_bLogToDisk;
 	Preference<bool>	m_bForceLogFlush;

--- a/src/Profile.h
+++ b/src/Profile.h
@@ -137,6 +137,8 @@ public:
 			FOREACH_ENUM( RankingCategory,rc )
 				m_CategoryHighScores[st][rc].Init();
 	}
+	~Profile();
+	void ClearSongs();
 
 	// smart accessors
 	std::string GetDisplayNameOrHighScoreName() const;
@@ -214,6 +216,7 @@ public:
 	std::unordered_map<std::string,std::string> m_sDefaultModifiers;
 	pref_noteskin_container m_preferred_noteskins;
 	noteskin_param_container m_noteskin_params;
+	std::vector<Song*> m_songs;
 	SortOrder m_SortOrder;
 	Difficulty m_LastDifficulty;
 	CourseDifficulty m_LastCourseDifficulty;
@@ -401,6 +404,7 @@ public:
 		InitCategoryScores();
 		InitScreenshotData();
 		InitCalorieData();
+		ClearSongs();
 	}
 	void InitEditableData();
 	void init_noteskin_params();
@@ -418,6 +422,7 @@ public:
 	void HandleStatsPrefixChange( std::string dir, bool require_signature );
 	ProfileLoadResult LoadAllFromDir( std::string sDir, bool bRequireSignature );
 	ProfileLoadResult LoadStatsFromDir( std::string dir, bool require_signature );
+	void LoadSongsFromDir(std::string const& dir, ProfileSlot prof_slot);
 	void LoadTypeFromDir(std::string dir);
 	void LoadCustomFunction(std::string dir, PlayerNumber pn);
 	bool SaveAllToDir(std::string sDir, bool bSignData, PlayerNumber pn) const;

--- a/src/ProfileManager.cpp
+++ b/src/ProfileManager.cpp
@@ -194,7 +194,12 @@ ProfileLoadResult ProfileManager::LoadProfile( PlayerNumber pn, std::string sPro
 	if(lr == ProfileLoadResult_Success)
 	{
 		Profile* prof= GetProfile(pn);
+		if(prof->m_sDisplayName.empty())
+		{
+			prof->m_sDisplayName= PlayerNumberToLocalizedString(pn);
+		}
 		prof->LoadCustomFunction(sProfileDir, pn);
+		prof->LoadSongsFromDir(sProfileDir, ProfileSlot(pn));
 	}
 
 	LOG->Trace("Done loading profile - result %d", int(lr));

--- a/src/RageUtil.cpp
+++ b/src/RageUtil.cpp
@@ -30,6 +30,8 @@ using std::istringstream;
 using std::stringstream;
 using std::isfinite;
 
+const std::string CUSTOM_SONG_PATH= "/@mem/";
+
 bool HexToBinary(const std::string&, std::string&);
 
 RandomGen g_RandomNumberGenerator;
@@ -722,6 +724,16 @@ void splitpath( const std::string &sPath, std::string &sDir, std::string &sFilen
 	{
 		sFilename = sBase;
 	}
+}
+
+std::string custom_songify_path(std::string const& path)
+{
+	vector<std::string> parts= Rage::split(path, "/", Rage::EmptyEntries::include);
+	if(parts.size() < 2)
+	{
+		return CUSTOM_SONG_PATH + path;
+	}
+	return CUSTOM_SONG_PATH + parts[parts.size()-2] + "/" + parts[parts.size()-1];
 }
 
 /* "foo.bar", "baz" -> "foo.baz"

--- a/src/RageUtil.h
+++ b/src/RageUtil.h
@@ -19,6 +19,8 @@ class RageFileDriver;
 /** @brief Get the length of the array. */
 #define ARRAYLEN(a) (sizeof(a) / sizeof((a)[0]))
 
+extern const std::string CUSTOM_SONG_PATH;
+
 // TODO: Rename this to TryClamp or something a little more accurate
 // so as to not be confusing.
 template<typename T, typename U, typename V>
@@ -345,6 +347,7 @@ struct tm GetLocalTime();
  * element will end up in Dir, not FName: "c:\games\stepmania\".
  * */
 void splitpath( const std::string &Path, std::string &Dir, std::string &Filename, std::string &Ext );
+std::string custom_songify_path(std::string const& path);
 
 std::string SetExtension( const std::string &path, const std::string &ext );
 std::string GetExtension( const std::string &sPath );

--- a/src/ScreenSelectMusic.cpp
+++ b/src/ScreenSelectMusic.cpp
@@ -1517,6 +1517,7 @@ bool ScreenSelectMusic::MenuStart( const InputEventPlus &input )
 		// Now that Steps have been chosen, set a Style that can play them.
 		GAMESTATE->SetCompatibleStylesForPlayers();
 		GAMESTATE->ForceSharedSidesMatch();
+		GAMESTATE->prepare_song_for_gameplay();
 
 		/* If we're currently waiting on song assets, abort all except the music
 		 * and start the music, so if we make a choice quickly before background

--- a/src/Song.h
+++ b/src/Song.h
@@ -66,9 +66,11 @@ struct LyricSegment
 class Song
 {
 	std::string m_sSongDir;
+	std::string m_pre_customify_song_dir;
 public:
 	void SetSongDir( const std::string sDir ) { m_sSongDir = sDir; }
 	std::string GetSongDir() { return m_sSongDir; }
+	std::string GetPreCustomifyDir() { return m_pre_customify_song_dir; }
 
 	/** @brief When should this song be displayed in the music wheel? */
 	enum SelectionDisplay
@@ -87,7 +89,8 @@ public:
 	 *
 	 * This assumes that there is no song present right now.
 	 * @param sDir the song directory from which to load. */
-	bool LoadFromSongDir( std::string sDir, bool load_autosave= false );
+	bool LoadFromSongDir(std::string sDir, bool load_autosave= false,
+		ProfileSlot from_profile= ProfileSlot_Invalid);
 	// This one takes the effort to reuse Steps pointers as best as it can
 	bool ReloadFromSongDir( std::string sDir );
 	bool ReloadFromSongDir() { return ReloadFromSongDir(GetSongDir()); }

--- a/src/SongManager.cpp
+++ b/src/SongManager.cpp
@@ -63,6 +63,7 @@ static Preference<bool> g_bHideIncompleteCourses( "HideIncompleteCourses", false
 
 std::string SONG_GROUP_COLOR_NAME( size_t i )   { return fmt::sprintf( "SongGroupColor%i", (int) i+1 ); }
 std::string COURSE_GROUP_COLOR_NAME( size_t i ) { return fmt::sprintf( "CourseGroupColor%i", (int) i+1 ); }
+std::string profile_song_group_color_name(size_t i) { return fmt::sprintf("ProfileSongGroupColor%i", (int)i+1); }
 
 static const float next_loading_window_update= 0.02f;
 
@@ -81,6 +82,8 @@ SongManager::SongManager()
 	SONG_GROUP_COLOR		.Load( "SongManager", SONG_GROUP_COLOR_NAME, NUM_SONG_GROUP_COLORS );
 	NUM_COURSE_GROUP_COLORS	.Load( "SongManager", "NumCourseGroupColors" );
 	COURSE_GROUP_COLOR		.Load( "SongManager", COURSE_GROUP_COLOR_NAME, NUM_COURSE_GROUP_COLORS );
+	num_profile_song_group_colors.Load("SongManager", "NumProfileSongGroupColors");
+	profile_song_group_colors.Load("SongManager", profile_song_group_color_name, num_profile_song_group_colors);
 }
 
 SongManager::~SongManager()
@@ -514,6 +517,17 @@ Rage::Color SongManager::GetSongGroupColor(std::string const& group_name) const
 	{
 		return SONG_GROUP_COLOR.GetValue(entry->second.id % NUM_SONG_GROUP_COLORS);
 	}
+	FOREACH_EnabledPlayer(pn)
+	{
+		Profile* prof= PROFILEMAN->GetProfile(pn);
+		if(prof != nullptr)
+		{
+			if(prof->GetDisplayNameOrHighScoreName() == group_name)
+			{
+				return profile_song_group_colors.GetValue(pn % num_profile_song_group_colors);
+			}
+		}
+	}
 
 	LuaHelpers::ReportScriptError(fmt::sprintf(
 			"requested color for song group '%s' that doesn't exist",
@@ -685,6 +699,17 @@ const vector<Song*> &SongManager::GetSongs( const std::string &sGroupName ) cons
 	auto iter = m_mapSongGroupIndex.find(sGroupName);
 	if ( iter != m_mapSongGroupIndex.end() )
 		return iter->second;
+	FOREACH_EnabledPlayer(pn)
+	{
+		Profile* prof= PROFILEMAN->GetProfile(pn);
+		if(prof != nullptr)
+		{
+			if(prof->GetDisplayNameOrHighScoreName() == sGroupName)
+			{
+				return prof->m_songs;
+			}
+		}
+	}
 	return vEmpty;
 }
 

--- a/src/SongManager.h
+++ b/src/SongManager.h
@@ -229,6 +229,8 @@ protected:
 	ThemeMetric1D<Rage::Color>	SONG_GROUP_COLOR;
 	ThemeMetric<int>		NUM_COURSE_GROUP_COLORS;
 	ThemeMetric1D<Rage::Color>	COURSE_GROUP_COLOR;
+	ThemeMetric<int> num_profile_song_group_colors;
+	ThemeMetric1D<Rage::Color> profile_song_group_colors;
 };
 
 extern SongManager*	SONGMAN;	// global and accessible from anywhere in our program

--- a/src/Steps.cpp
+++ b/src/Steps.cpp
@@ -354,6 +354,15 @@ void Steps::CalculateRadarValues( float fMusicLengthSeconds )
 	GAMESTATE->SetProcessedTimingData(nullptr);
 }
 
+void Steps::ChangeFilenamesForCustomSong()
+{
+	m_sFilename= custom_songify_path(m_sFilename);
+	if(!m_MusicFile.empty())
+	{
+		m_MusicFile= custom_songify_path(m_MusicFile);
+	}
+}
+
 void Steps::Decompress() const
 {
 	const_cast<Steps *>(this)->Decompress();

--- a/src/Steps.h
+++ b/src/Steps.h
@@ -124,6 +124,8 @@ public:
 	void SetChartStyle( std::string sChartStyle );
 	static bool MakeValidEditDescription( std::string &sPreferredDescription );	// return true if was modified
 
+	void ChangeFilenamesForCustomSong();
+
 	void SetLoadedFromProfile( ProfileSlot slot )	{ m_LoadedFromProfile = slot; }
 	void SetMeter( int meter );
 	void SetCachedRadarValues( const RadarValues v[NUM_PLAYERS] );


### PR DESCRIPTION
Profile::LoadSongsFromDir blocks without updating.

GameState::prepare_song_for_gameplay blocks without updating.

Sometimes scores on custom songs get removed when the song is played again.  _sometimes_

Scores that are in the player's profile seem to show up in the machine's high score list until the song is played.  No clue why.
## Preferences

CustomSongsEnable=0
CustomSongsLoadTimeout=5
CustomSongsMaxCount=1000
CustomSongsMaxMegabytes=5
CustomSongsMaxSeconds=120
## Metrics

NumProfileSongGroupColors=2
ProfileSongGroupColor1=PlayerColor(PLAYER_1)
ProfileSongGroupColor2=PlayerColor(PLAYER_2)
