### PR TITLE
Cherry-pick "Instantiate MESSAGEMAN first" to fix a crash in release build

### DIFF
--- a/src/MessageManager.cpp
+++ b/src/MessageManager.cpp
@@ -207,8 +207,7 @@ void MessageManager::Unsubscribe( IMessageSubscriber* pSubscriber, MessageID m )
 
 void MessageManager::Broadcast( Message &msg ) const
 {
-	// GAMESTATE is created before MESSAGEMAN, and has several BroadcastOnChangePtr members, so they all broadcast when they're initialized.
-	if(this != NULL && m_Logging)
+	if(m_Logging)
 	{
 		LOG->Trace("MESSAGEMAN:Broadcast: %s", msg.GetName().c_str());
 	}

--- a/src/StepMania.cpp
+++ b/src/StepMania.cpp
@@ -1041,8 +1041,10 @@ int sm_main(int argc, char* argv[])
 	// This needs PREFSMAN.
 	Dialog::Init();
 
-	// Create game objects
+	// Set up the messaging system early to have well defined code.
+	MESSAGEMAN	= new MessageManager;
 
+	// Create game objects
 	GAMESTATE	= new GameState;
 
 	// This requires PREFSMAN, for PREFSMAN->m_bShowLoadingWindow.
@@ -1162,7 +1164,6 @@ int sm_main(int argc, char* argv[])
 	SONGMAN->UpdatePopular();
 	SONGMAN->UpdatePreferredSort();
 	NSMAN 		= new NetworkSyncManager( pLoadingWindow );
-	MESSAGEMAN	= new MessageManager;
 	STATSMAN	= new StatsManager;
 
 	// Initialize which courses are ranking courses here.


### PR DESCRIPTION
[I hit Enter too soon on the original submission... Edited.]

I did a release build (`-DCMAKE_BUILD_TYPE=Release`) of StepMania from the 5_0 branch using the latest g++ (6.3.1) on Fedora 25, and StepMania crashed on startup with the following stack trace:

```
#0  0x00000000006d4651 in MessageManager::Broadcast(Message&) const ()
#1  0x00000000006d48c2 in MessageManager::Broadcast(StdString::CStdStr<char> const&) const ()
#2  0x00000000006a37f3 in GameState::GameState() ()
#3  0x000000000068241a in sm_main(int, char**) ()
#4  0x00007ffff1bb6401 in __libc_start_main () at /lib64/libc.so.6
#5  0x00000000006795ca in _start ()
```

The relevant code:
```c++
void MessageManager::Broadcast( Message &msg ) const
{
        // GAMESTATE is created before MESSAGEMAN, and has several BroadcastOnChangePtr members, so they all broadcast when they're initialized.
        if(this != NULL && m_Logging)
        {
                LOG->Trace("MESSAGEMAN:Broadcast: %s", msg.GetName().c_str());
        }
        // ...
}
```

Disassembly:
```
Dump of assembler code for function _ZNK14MessageManager9BroadcastER7Message:
   0x00000000006d4640 <+0>:	push   %r15
   0x00000000006d4642 <+2>:	push   %r14
   0x00000000006d4644 <+4>:	push   %r13
   0x00000000006d4646 <+6>:	push   %r12
   0x00000000006d4648 <+8>:	push   %rbp
   0x00000000006d4649 <+9>:	push   %rbx
   0x00000000006d464a <+10>:	mov    %rsi,%rbp
   0x00000000006d464d <+13>:	sub    $0x58,%rsp
=> 0x00000000006d4651 <+17>:	cmpb   $0x0,(%rdi)
   0x00000000006d4654 <+20>:	lea    0x30(%rsp),%rax
   0x00000000006d4659 <+25>:	jne    0x6d4800 <_ZNK14MessageManager9BroadcastER7Message+448>
```

`(%rdi)` here represents `this->m_Logging`, which is a null dereference.  So it looks like g++ has optimized out the `this != NULL` test, I assume because calling a method on a null pointer has undefined behavior.

This code was already fixed in a565a27 on the master branch, and with the cherry-pick in this PR, StepMania ran successfully through one song.  It seems like it might be a while yet until there is a stable release from master, so please consider accepting this cherry-pick to 5_0 and applying a similar change to any other branches that might need it.  (5_1-new?  I don't know what the workflow is.)