### PR TITLE
Online protocol improvements

### DIFF
--- a/src/NetworkSyncManager.cpp
+++ b/src/NetworkSyncManager.cpp
@@ -11,6 +11,9 @@ NetworkSyncManager *NSMAN;
 
 #include "ver.h"
 
+//Song file hashing --Nick12
+#include "CryptManager.h"
+
 
 #if defined(WITHOUT_NETWORKING)
 NetworkSyncManager::NetworkSyncManager( LoadingWindow *ld ) { useSMserver=false; isSMOnline = false; }
@@ -632,6 +635,14 @@ void NetworkSyncManager::ProcessInput()
 				m_sMainTitle = m_packet.ReadNT();
 				m_sArtist = m_packet.ReadNT();
 				m_sSubTitle = m_packet.ReadNT();
+				//Send songhash
+				if (m_ServerVersion >= 129) {
+					Song * song = GAMESTATE->get_curr_song();
+					vector<Steps*> steps = GAMESTATE->get_curr_song()->GetAllSteps();
+					std::string sPath = SetExtension(song->GetSongFilePath(), "sm");
+					m_packet.WriteNT(BinaryToHex(CRYPTMAN->GetSHA1ForFile(sPath)));
+				}
+
 				SCREENMAN->SendMessageToTopScreen( SM_ChangeSong );
 			}
 			break;
@@ -745,6 +756,13 @@ void NetworkSyncManager::SelectUserSong()
 	m_packet.WriteNT( m_sMainTitle );
 	m_packet.WriteNT( m_sArtist );
 	m_packet.WriteNT( m_sSubTitle );
+	//Send songhash
+	if (m_ServerVersion >= 129) {
+		Song * song = GAMESTATE->get_curr_song();
+		vector<Steps*> steps = GAMESTATE->get_curr_song()->GetAllSteps();
+		std::string sPath = SetExtension(song->GetSongFilePath(), "sm");
+		m_packet.WriteNT(BinaryToHex(CRYPTMAN->GetSHA1ForFile(sPath)));
+	}
 	NetPlayerClient->SendPack( (char*)&m_packet.Data, m_packet.Position );
 }
 

--- a/src/NetworkSyncManager.cpp
+++ b/src/NetworkSyncManager.cpp
@@ -413,6 +413,7 @@ void NetworkSyncManager::StartRequest( short position )
 
 		int rate = (int)(GAMESTATE->m_SongOptions.GetCurrent().m_fMusicRate * 100);
 		m_packet.Write1(rate);
+		m_packet.WriteNT(GAMESTATE->m_pCurSong->GetFileHash());
 	}
 	
 	//This needs to be reset before ScreenEvaluation could possibly be called

--- a/src/NetworkSyncManager.cpp
+++ b/src/NetworkSyncManager.cpp
@@ -635,31 +635,6 @@ void NetworkSyncManager::ProcessInput()
 				m_sMainTitle = m_packet.ReadNT();
 				m_sArtist = m_packet.ReadNT();
 				m_sSubTitle = m_packet.ReadNT();
-				//Send songhash
-				if (m_ServerVersion >= 129) {
-					Song * song = GAMESTATE->m_pCurSong;
-					std::string sPath = SetExtension(song->GetSongFilePath(), "sm");
-					if (!IsAFile(sPath))
-						sPath = SetExtension(song->GetSongFilePath(), "dwi");
-					if (!IsAFile(sPath))
-						sPath = SetExtension(song->GetSongFilePath(), "sma");
-					if (!IsAFile(sPath))
-						sPath = SetExtension(song->GetSongFilePath(), "bms");
-					if (!IsAFile(sPath))
-						sPath = SetExtension(song->GetSongFilePath(), "kfs");
-					if (!IsAFile(sPath))
-						sPath = SetExtension(song->GetSongFilePath(), "json");
-					if (!IsAFile(sPath))
-						sPath = SetExtension(song->GetSongFilePath(), "jso");
-					if (!IsAFile(sPath))
-						sPath = SetExtension(song->GetSongFilePath(), "ssc");
-					if (!IsAFile(sPath))
-						m_packet.WriteNT(BinaryToHex(CRYPTMAN->GetSHA1ForFile(sPath)));
-					else
-						m_packet.WriteNT("");
-				}
-
-
 				SCREENMAN->SendMessageToTopScreen( SM_ChangeSong );
 			}
 			break;

--- a/src/NetworkSyncManager.cpp
+++ b/src/NetworkSyncManager.cpp
@@ -409,10 +409,9 @@ void NetworkSyncManager::StartRequest( short position )
 			tSteps->Compress();
 		} else
 			m_packet.WriteNT("");
-		float rate = GAMESTATE->m_SongOptions.GetPreferred().m_fMusicRate;
-		std::ostringstream buff;
-		buff << rate;
-		m_packet.WriteNT(buff.str());
+		
+		int rate = (int)(GAMESTATE->m_SongOptions.GetCurrent().m_fMusicRate * 100);
+		m_packet.Write2(rate);
 	}
 	
 	//This needs to be reset before ScreenEvaluation could possibly be called

--- a/src/NetworkSyncManager.cpp
+++ b/src/NetworkSyncManager.cpp
@@ -751,7 +751,7 @@ void NetworkSyncManager::SelectUserSong()
 	m_packet.WriteNT( m_sSubTitle );
 	//Send songhash
 	if (m_ServerVersion >= 129) {
-		m_packet.WriteNT(GAMESTATE->get_curr_song()->GetFileHash());
+		m_packet.WriteNT(GAMESTATE->m_pCurSong->GetFileHash());
 	}
 	NetPlayerClient->SendPack( (char*)&m_packet.Data, m_packet.Position );
 }

--- a/src/NetworkSyncManager.cpp
+++ b/src/NetworkSyncManager.cpp
@@ -707,7 +707,6 @@ void NetworkSyncManager::ProcessInput()
 					int PStatus = m_packet.Read1();
 					fl_PlayerStates.push_back(PStatus);
 					fl_PlayerNames.push_back(m_packet.ReadNT());
-					LOG->Trace("FLU: %d %s", PStatus, fl_PlayerNames[i]);
 				}
 				SCREENMAN->SendMessageToTopScreen(SM_FriendsUpdate);
 			}

--- a/src/NetworkSyncManager.cpp
+++ b/src/NetworkSyncManager.cpp
@@ -637,11 +637,29 @@ void NetworkSyncManager::ProcessInput()
 				m_sSubTitle = m_packet.ReadNT();
 				//Send songhash
 				if (m_ServerVersion >= 129) {
-					Song * song = GAMESTATE->get_curr_song();
+					Song * song = GAMESTATE->m_pCurSong;
 					vector<Steps*> steps = GAMESTATE->get_curr_song()->GetAllSteps();
 					std::string sPath = SetExtension(song->GetSongFilePath(), "sm");
-					m_packet.WriteNT(BinaryToHex(CRYPTMAN->GetSHA1ForFile(sPath)));
+					if (!IsAFile(sPath))
+						sPath = SetExtension(song->GetSongFilePath(), "dwi");
+					if (!IsAFile(sPath))
+						sPath = SetExtension(song->GetSongFilePath(), "sma");
+					if (!IsAFile(sPath))
+						sPath = SetExtension(song->GetSongFilePath(), "bms");
+					if (!IsAFile(sPath))
+						sPath = SetExtension(song->GetSongFilePath(), "kfs");
+					if (!IsAFile(sPath))
+						sPath = SetExtension(song->GetSongFilePath(), "json");
+					if (!IsAFile(sPath))
+						sPath = SetExtension(song->GetSongFilePath(), "jso");
+					if (!IsAFile(sPath))
+						sPath = SetExtension(song->GetSongFilePath(), "ssc");
+					if (!IsAFile(sPath))
+						m_packet.WriteNT(BinaryToHex(CRYPTMAN->GetSHA1ForFile(sPath)));
+					else
+						m_packet.WriteNT("");
 				}
+
 
 				SCREENMAN->SendMessageToTopScreen( SM_ChangeSong );
 			}
@@ -758,11 +776,29 @@ void NetworkSyncManager::SelectUserSong()
 	m_packet.WriteNT( m_sSubTitle );
 	//Send songhash
 	if (m_ServerVersion >= 129) {
-		Song * song = GAMESTATE->get_curr_song();
+		Song * song = GAMESTATE->m_pCurSong;
 		vector<Steps*> steps = GAMESTATE->get_curr_song()->GetAllSteps();
 		std::string sPath = SetExtension(song->GetSongFilePath(), "sm");
-		m_packet.WriteNT(BinaryToHex(CRYPTMAN->GetSHA1ForFile(sPath)));
+		if (!IsAFile(sPath))
+			sPath = SetExtension(song->GetSongFilePath(), "dwi");
+		if (!IsAFile(sPath))
+			sPath = SetExtension(song->GetSongFilePath(), "sma");
+		if (!IsAFile(sPath))
+			sPath = SetExtension(song->GetSongFilePath(), "bms");
+		if (!IsAFile(sPath))
+			sPath = SetExtension(song->GetSongFilePath(), "kfs");
+		if (!IsAFile(sPath))
+			sPath = SetExtension(song->GetSongFilePath(), "json");
+		if (!IsAFile(sPath))
+			sPath = SetExtension(song->GetSongFilePath(), "jso");
+		if (!IsAFile(sPath))
+			sPath = SetExtension(song->GetSongFilePath(), "ssc");
+		if (!IsAFile(sPath))
+			m_packet.WriteNT(BinaryToHex(CRYPTMAN->GetSHA1ForFile(sPath)));
+		else
+			m_packet.WriteNT("");
 	}
+
 	NetPlayerClient->SendPack( (char*)&m_packet.Data, m_packet.Position );
 }
 

--- a/src/NetworkSyncManager.cpp
+++ b/src/NetworkSyncManager.cpp
@@ -55,6 +55,7 @@ AutoScreenMessage( SM_AddToChat );
 AutoScreenMessage( SM_ChangeSong );
 AutoScreenMessage( SM_GotEval );
 AutoScreenMessage( SM_UsersUpdate );
+AutoScreenMessage( SM_FriendsUpdate );
 AutoScreenMessage( SM_SMOnlinePack );
 
 int NetworkSyncManager::GetSMOnlineSalt()
@@ -390,6 +391,30 @@ void NetworkSyncManager::StartRequest( short position )
 	for (int i=0; i<2-players; ++i)
 		m_packet.WriteNT("");	//Write a NULL if no player
 
+	//Send song hash/chartkey and rate
+	if (m_ServerVersion >= 129) {
+		tSteps = GAMESTATE->m_pCurSteps[PLAYER_1];
+		if (tSteps != NULL && GAMESTATE->IsPlayerEnabled(PLAYER_1)) {
+			tSteps->Decompress();
+			m_packet.WriteNT(tSteps->GenerateChartKey());
+			tSteps->Compress();
+		}
+		else
+			m_packet.WriteNT("");
+
+		tSteps = GAMESTATE->m_pCurSteps[PLAYER_2];
+		if (tSteps != NULL && GAMESTATE->IsPlayerEnabled(PLAYER_2)) {
+			tSteps->Decompress();
+			m_packet.WriteNT(tSteps->GenerateChartKey());
+			tSteps->Compress();
+		} else
+			m_packet.WriteNT("");
+		float rate = GAMESTATE->m_SongOptions.GetPreferred().m_fMusicRate;
+		std::ostringstream buff;
+		buff << rate;
+		m_packet.WriteNT(buff.str());
+	}
+	
 	//This needs to be reset before ScreenEvaluation could possibly be called
 	m_EvalPlayerData.clear();
 
@@ -666,6 +691,21 @@ void NetworkSyncManager::ProcessInput()
 					GAMESTATE->m_pPlayerState[iPlayerNumber]->LaunchAttack( a );
 				}
 				m_packet.ClearPacket();
+			}
+			break;
+		case FLU:
+			{
+				int PlayersInThisPacket = m_packet.Read1();
+				fl_PlayerNames.clear();
+				fl_PlayerStates.clear();
+				for (int i = 0; i<PlayersInThisPacket; ++i)
+				{
+					int PStatus = m_packet.Read1();
+					fl_PlayerStates.push_back(PStatus);
+					fl_PlayerNames.push_back(m_packet.ReadNT());
+					LOG->Trace("FLU: %d %s", PStatus, fl_PlayerNames[i]);
+				}
+				SCREENMAN->SendMessageToTopScreen(SM_FriendsUpdate);
 			}
 			break;
 		}

--- a/src/NetworkSyncManager.cpp
+++ b/src/NetworkSyncManager.cpp
@@ -766,7 +766,7 @@ void NetworkSyncManager::SelectUserSong()
 			sPath = SetExtension(song->GetSongFilePath(), "jso");
 		if (!IsAFile(sPath))
 			sPath = SetExtension(song->GetSongFilePath(), "ssc");
-		if (!IsAFile(sPath))
+		if (IsAFile(sPath))
 			m_packet.WriteNT(BinaryToHex(CRYPTMAN->GetSHA1ForFile(sPath)));
 		else
 			m_packet.WriteNT("");

--- a/src/NetworkSyncManager.cpp
+++ b/src/NetworkSyncManager.cpp
@@ -391,27 +391,32 @@ void NetworkSyncManager::StartRequest( short position )
 	for (int i=0; i<2-players; ++i)
 		m_packet.WriteNT("");	//Write a NULL if no player
 
-	//Send song hash/chartkey and rate
+	//Send song hash/chartkey
 	if (m_ServerVersion >= 129) {
 		tSteps = GAMESTATE->m_pCurSteps[PLAYER_1];
 		if (tSteps != NULL && GAMESTATE->IsPlayerEnabled(PLAYER_1)) {
 			tSteps->Decompress();
 			m_packet.WriteNT(tSteps->GenerateChartKey());
 			tSteps->Compress();
-		}
-		else
+		} 
+		else 
+		{
 			m_packet.WriteNT("");
+		}
 
 		tSteps = GAMESTATE->m_pCurSteps[PLAYER_2];
 		if (tSteps != NULL && GAMESTATE->IsPlayerEnabled(PLAYER_2)) {
 			tSteps->Decompress();
 			m_packet.WriteNT(tSteps->GenerateChartKey());
 			tSteps->Compress();
-		} else
+		} 
+		else 
+		{
 			m_packet.WriteNT("");
-		
+		}
+
 		int rate = (int)(GAMESTATE->m_SongOptions.GetCurrent().m_fMusicRate * 100);
-		m_packet.Write2(rate);
+		m_packet.Write1(rate);
 	}
 	
 	//This needs to be reset before ScreenEvaluation could possibly be called

--- a/src/NetworkSyncManager.cpp
+++ b/src/NetworkSyncManager.cpp
@@ -395,9 +395,7 @@ void NetworkSyncManager::StartRequest( short position )
 	if (m_ServerVersion >= 129) {
 		tSteps = GAMESTATE->m_pCurSteps[PLAYER_1];
 		if (tSteps != NULL && GAMESTATE->IsPlayerEnabled(PLAYER_1)) {
-			tSteps->Decompress();
-			m_packet.WriteNT(tSteps->GenerateChartKey());
-			tSteps->Compress();
+			m_packet.WriteNT(tSteps->GetChartKey());
 		} 
 		else 
 		{
@@ -406,9 +404,7 @@ void NetworkSyncManager::StartRequest( short position )
 
 		tSteps = GAMESTATE->m_pCurSteps[PLAYER_2];
 		if (tSteps != NULL && GAMESTATE->IsPlayerEnabled(PLAYER_2)) {
-			tSteps->Decompress();
-			m_packet.WriteNT(tSteps->GenerateChartKey());
-			tSteps->Compress();
+			m_packet.WriteNT(tSteps->GetChartKey());
 		} 
 		else 
 		{

--- a/src/NetworkSyncManager.cpp
+++ b/src/NetworkSyncManager.cpp
@@ -741,6 +741,10 @@ void NetworkSyncManager::ReportPlayerOptions()
 	NetPlayerClient->SendPack((char*)&m_packet.Data, m_packet.Position); 
 }
 
+int NetworkSyncManager::GetServerVersion()
+{
+	return m_ServerVersion;
+}
 void NetworkSyncManager::SelectUserSong()
 {
 	m_packet.ClearPacket();

--- a/src/NetworkSyncManager.cpp
+++ b/src/NetworkSyncManager.cpp
@@ -11,9 +11,6 @@ NetworkSyncManager *NSMAN;
 
 #include "ver.h"
 
-//Song file hashing --Nick12
-#include "CryptManager.h"
-
 
 #if defined(WITHOUT_NETWORKING)
 NetworkSyncManager::NetworkSyncManager( LoadingWindow *ld ) { useSMserver=false; isSMOnline = false; }
@@ -635,6 +632,10 @@ void NetworkSyncManager::ProcessInput()
 				m_sMainTitle = m_packet.ReadNT();
 				m_sArtist = m_packet.ReadNT();
 				m_sSubTitle = m_packet.ReadNT();
+				//Read songhash
+				if (m_ServerVersion >= 129) {
+					m_sFileHash = m_packet.ReadNT();
+				}
 				SCREENMAN->SendMessageToTopScreen( SM_ChangeSong );
 			}
 			break;
@@ -750,28 +751,8 @@ void NetworkSyncManager::SelectUserSong()
 	m_packet.WriteNT( m_sSubTitle );
 	//Send songhash
 	if (m_ServerVersion >= 129) {
-		Song * song = GAMESTATE->m_pCurSong;
-		std::string sPath = SetExtension(song->GetSongFilePath(), "sm");
-		if (!IsAFile(sPath))
-			sPath = SetExtension(song->GetSongFilePath(), "dwi");
-		if (!IsAFile(sPath))
-			sPath = SetExtension(song->GetSongFilePath(), "sma");
-		if (!IsAFile(sPath))
-			sPath = SetExtension(song->GetSongFilePath(), "bms");
-		if (!IsAFile(sPath))
-			sPath = SetExtension(song->GetSongFilePath(), "kfs");
-		if (!IsAFile(sPath))
-			sPath = SetExtension(song->GetSongFilePath(), "json");
-		if (!IsAFile(sPath))
-			sPath = SetExtension(song->GetSongFilePath(), "jso");
-		if (!IsAFile(sPath))
-			sPath = SetExtension(song->GetSongFilePath(), "ssc");
-		if (IsAFile(sPath))
-			m_packet.WriteNT(BinaryToHex(CRYPTMAN->GetSHA1ForFile(sPath)));
-		else
-			m_packet.WriteNT("");
+		m_packet.WriteNT(GAMESTATE->get_curr_song()->GetFileHash());
 	}
-
 	NetPlayerClient->SendPack( (char*)&m_packet.Data, m_packet.Position );
 }
 

--- a/src/NetworkSyncManager.cpp
+++ b/src/NetworkSyncManager.cpp
@@ -638,7 +638,6 @@ void NetworkSyncManager::ProcessInput()
 				//Send songhash
 				if (m_ServerVersion >= 129) {
 					Song * song = GAMESTATE->m_pCurSong;
-					vector<Steps*> steps = GAMESTATE->get_curr_song()->GetAllSteps();
 					std::string sPath = SetExtension(song->GetSongFilePath(), "sm");
 					if (!IsAFile(sPath))
 						sPath = SetExtension(song->GetSongFilePath(), "dwi");
@@ -777,7 +776,6 @@ void NetworkSyncManager::SelectUserSong()
 	//Send songhash
 	if (m_ServerVersion >= 129) {
 		Song * song = GAMESTATE->m_pCurSong;
-		vector<Steps*> steps = GAMESTATE->get_curr_song()->GetAllSteps();
 		std::string sPath = SetExtension(song->GetSongFilePath(), "sm");
 		if (!IsAFile(sPath))
 			sPath = SetExtension(song->GetSongFilePath(), "dwi");

--- a/src/NetworkSyncManager.h
+++ b/src/NetworkSyncManager.h
@@ -29,7 +29,6 @@ enum NSCommand
 	NSCSMOnline,	// 12 [SMLC_SMO]
 	NSCFormatted,	// 13 [SMLC_RESERVED1]
 	NSCAttack,		// 14 [SMLC_RESERVED2]
- 	NSCAttack,		// 14 [SMLC_RESERVED2]
 	XML,		// 15 [SMLC_RESERVED3]
 	FLU,		// 15 [SMLC_FriendListUpdate]
 	NUM_NS_COMMANDS

--- a/src/NetworkSyncManager.h
+++ b/src/NetworkSyncManager.h
@@ -7,7 +7,7 @@
 
 class LoadingWindow;
 
-const int NETPROTOCOLVERSION=3;
+const int NETPROTOCOLVERSION=4;
 const int NETMAXBUFFERSIZE=1020; //1024 - 4 bytes for EzSockets
 const int NETNUMTAPSCORES=8;
 
@@ -29,6 +29,9 @@ enum NSCommand
 	NSCSMOnline,	// 12 [SMLC_SMO]
 	NSCFormatted,	// 13 [SMLC_RESERVED1]
 	NSCAttack,		// 14 [SMLC_RESERVED2]
+ 	NSCAttack,		// 14 [SMLC_RESERVED2]
+	XML,		// 15 [SMLC_RESERVED3]
+	FLU,		// 15 [SMLC_FriendListUpdate]
 	NUM_NS_COMMANDS
 };
 
@@ -145,6 +148,10 @@ public:
 	vector<int> m_ActivePlayer;
 	vector<RString> m_PlayerNames;
 
+	//friendlist
+	std::vector<std::string> fl_PlayerNames;
+	std::vector<int> fl_PlayerStates;
+	
 	// Used for ScreenNetEvaluation
 	vector<EndOfGame_PlayerData> m_EvalPlayerData;
 

--- a/src/NetworkSyncManager.h
+++ b/src/NetworkSyncManager.h
@@ -169,8 +169,11 @@ public:
 	RString m_sMainTitle;
 	RString m_sArtist;
 	RString m_sSubTitle;
+	RString m_sFileHash;
 	int m_iSelectMode;
 	void SelectUserSong();
+
+	int GetServerVersion();
 
 	RString m_sChatText;
 

--- a/src/NoteData.cpp
+++ b/src/NoteData.cpp
@@ -269,6 +269,12 @@ int NoteData::GetNumTracksWithTapOrHoldHead( int row ) const
 	return iNum;
 }
 
+void NoteData::LogNonEmptyRows() {
+	NonEmptyRowVector.clear();
+	FOREACH_NONEMPTY_ROW_ALL_TRACKS(*this, row)
+		NonEmptyRowVector.push_back(row);
+}
+
 int NoteData::GetFirstTrackWithTap( int row ) const
 {
 	for( int t=0; t<GetNumTracks(); t++ )

--- a/src/NoteData.h
+++ b/src/NoteData.h
@@ -157,9 +157,16 @@ private:
 	void RemoveATIFromList(all_tracks_iterator* iter) const;
 	void RemoveATIFromList(all_tracks_const_iterator* iter) const;
 
+	// Mina stuf (Used for chartkey hashing)
+	std::vector<int> NonEmptyRowVector;
+	
 public:
 	void Init();
 
+	// Mina stuf (Used for chartkey hashing)
+	void LogNonEmptyRows();
+	std::vector<int>& GetNonEmptyRowVector() { return NonEmptyRowVector; };
+	
 	int GetNumTracks() const { return m_TapNotes.size(); }
 	void SetNumTracks( int iNewNumTracks );
 	bool IsComposite() const;

--- a/src/ScreenNetSelectBase.cpp
+++ b/src/ScreenNetSelectBase.cpp
@@ -28,6 +28,7 @@
 
 AutoScreenMessage( SM_AddToChat );
 AutoScreenMessage( SM_UsersUpdate );
+AutoScreenMessage( SM_FriendsUpdate );
 AutoScreenMessage( SM_SMOnlinePack );
 
 REGISTER_SCREEN_CLASS( ScreenNetSelectBase );
@@ -134,6 +135,10 @@ void ScreenNetSelectBase::HandleScreenMessage( const ScreenMessage SM )
 	else if( SM == SM_UsersUpdate )
 	{
 		UpdateUsers();
+	}
+	else if (SM == SM_FriendsUpdate)
+	{
+		MESSAGEMAN->Broadcast("FriendsUpdate");
 	}
 
 	ScreenWithMenuElements::HandleScreenMessage( SM );

--- a/src/ScreenNetSelectMusic.cpp
+++ b/src/ScreenNetSelectMusic.cpp
@@ -182,25 +182,6 @@ void ScreenNetSelectMusic::HandleScreenMessage( const ScreenMessage SM )
 		vector <Song *> AllSongs = SONGMAN->GetAllSongs();
 		unsigned i;
 		bool found = false;
-		if (NSMAN->GetServerVersion() >= 129)
-		{
-			Rage::ci_ascii_string ciFileHash{ NSMAN->m_sFileHash.c_str() };
-			//Dont earch by filehash if none was sent
-			if(!NSMAN->m_sFileHash.empty())
-				for (i = 0; i < AllSongs.size(); i++)
-				{
-					m_cSong = AllSongs[i];
-					if (ciArtist == m_cSong->GetTranslitArtist() &&
-						ciMain == m_cSong->GetTranslitMainTitle() &&
-						ciSub == m_cSong->GetTranslitSubTitle() &&
-						ciFileHash == m_cSong->GetFileHash())
-					{
-						found = true;
-						break;
-					}
-				}
-
-		}
 		//If we couldnt find it using file hash search for it without it, if using SMSERVER < 129 it will also go here
 		if(!found)
 			for (i = 0; i < AllSongs.size(); i++)
@@ -209,6 +190,37 @@ void ScreenNetSelectMusic::HandleScreenMessage( const ScreenMessage SM )
 				if (ciArtist == m_cSong->GetTranslitArtist() &&
 					ciMain == m_cSong->GetTranslitMainTitle() &&
 					ciSub == m_cSong->GetTranslitSubTitle())
+				{
+					break;
+				}
+			}
+
+		if (NSMAN->GetServerVersion() >= 129)
+		{
+			//Dont earch by filehash if none was sent
+			if(!NSMAN->m_sFileHash.empty())
+				for (i = 0; i < AllSongs.size(); i++)
+				{
+					m_cSong = AllSongs[i];
+					if (NSMAN->m_sArtist == m_cSong->GetTranslitArtist() &&
+						NSMAN->m_sMainTitle == m_cSong->GetTranslitMainTitle() &&
+						NSMAN->m_sSubTitle == m_cSong->GetTranslitSubTitle() &&
+						NSMAN->m_sFileHash == m_cSong->GetFileHash())
+					{
+						found = true;
+						break;
+					}
+				}
+
+		}
+		//If we couldnt find it using file hash search for it without using it, if using SMSERVER < 129 it will go here
+		if(!found)
+			for (i = 0; i < AllSongs.size(); i++)
+			{
+				m_cSong = AllSongs[i];
+				if (NSMAN->m_sArtist == m_cSong->GetTranslitArtist() &&
+					NSMAN->m_sMainTitle == m_cSong->GetTranslitMainTitle() &&
+					NSMAN->m_sSubTitle == m_cSong->GetTranslitSubTitle())
 				{
 					break;
 				}

--- a/src/ScreenNetSelectMusic.cpp
+++ b/src/ScreenNetSelectMusic.cpp
@@ -182,19 +182,6 @@ void ScreenNetSelectMusic::HandleScreenMessage( const ScreenMessage SM )
 		vector <Song *> AllSongs = SONGMAN->GetAllSongs();
 		unsigned i;
 		bool found = false;
-		//If we couldnt find it using file hash search for it without it, if using SMSERVER < 129 it will also go here
-		if(!found)
-			for (i = 0; i < AllSongs.size(); i++)
-			{
-				m_cSong = AllSongs[i];
-				if (ciArtist == m_cSong->GetTranslitArtist() &&
-					ciMain == m_cSong->GetTranslitMainTitle() &&
-					ciSub == m_cSong->GetTranslitSubTitle())
-				{
-					break;
-				}
-			}
-
 		if (NSMAN->GetServerVersion() >= 129)
 		{
 			//Dont earch by filehash if none was sent

--- a/src/ScreenNetSelectMusic.cpp
+++ b/src/ScreenNetSelectMusic.cpp
@@ -181,14 +181,38 @@ void ScreenNetSelectMusic::HandleScreenMessage( const ScreenMessage SM )
 
 		vector <Song *> AllSongs = SONGMAN->GetAllSongs();
 		unsigned i;
-		for( i=0; i < AllSongs.size(); i++ )
+		bool found = false;
+		if (NSMAN->GetServerVersion() >= 129)
 		{
-			m_cSong = AllSongs[i];
-			if( ( !m_cSong->GetTranslitArtist().CompareNoCase( NSMAN->m_sArtist ) ) &&
-					( !m_cSong->GetTranslitMainTitle().CompareNoCase( NSMAN->m_sMainTitle ) ) &&
-					( !m_cSong->GetTranslitSubTitle().CompareNoCase( NSMAN->m_sSubTitle ) ) )
-					break;
+			Rage::ci_ascii_string ciFileHash{ NSMAN->m_sFileHash.c_str() };
+			//Dont earch by filehash if none was sent
+			if(!NSMAN->m_sFileHash.empty())
+				for (i = 0; i < AllSongs.size(); i++)
+				{
+					m_cSong = AllSongs[i];
+					if (ciArtist == m_cSong->GetTranslitArtist() &&
+						ciMain == m_cSong->GetTranslitMainTitle() &&
+						ciSub == m_cSong->GetTranslitSubTitle() &&
+						ciFileHash == m_cSong->GetFileHash())
+					{
+						found = true;
+						break;
+					}
+				}
+
 		}
+		//If we couldnt find it using file hash search for it without it, if using SMSERVER < 129 it will also go here
+		if(!found)
+			for (i = 0; i < AllSongs.size(); i++)
+			{
+				m_cSong = AllSongs[i];
+				if (ciArtist == m_cSong->GetTranslitArtist() &&
+					ciMain == m_cSong->GetTranslitMainTitle() &&
+					ciSub == m_cSong->GetTranslitSubTitle())
+				{
+					break;
+				}
+			}
 
 		bool haveSong = i != AllSongs.size();
 

--- a/src/Song.cpp
+++ b/src/Song.cpp
@@ -1592,6 +1592,32 @@ vector<RString> Song::GetFGChanges1ToVectorString() const
 	return this->GetChangesToVectorString(this->GetForegroundChanges());
 }
 
+std::string Song::GetFileHash()
+{
+	if (m_sFileHash.empty()) {
+		std::string sPath = SetExtension(GetSongFilePath(), "sm");
+		if (!IsAFile(sPath))
+			sPath = SetExtension(GetSongFilePath(), "dwi");
+		if (!IsAFile(sPath))
+			sPath = SetExtension(GetSongFilePath(), "sma");
+		if (!IsAFile(sPath))
+			sPath = SetExtension(GetSongFilePath(), "bms");
+		if (!IsAFile(sPath))
+			sPath = SetExtension(GetSongFilePath(), "ksf");
+		if (!IsAFile(sPath))
+			sPath = SetExtension(GetSongFilePath(), "json");
+		if (!IsAFile(sPath))
+			sPath = SetExtension(GetSongFilePath(), "jso");
+		if (!IsAFile(sPath))
+			sPath = SetExtension(GetSongFilePath(), "ssc");
+		if (IsAFile(sPath))
+			m_sFileHash = BinaryToHex(CRYPTMAN->GetSHA1ForFile(sPath));
+		else
+			m_sFileHash = "";
+	}
+	return m_sFileHash;
+}
+
 vector<RString> Song::GetInstrumentTracksToVectorString() const
 {
 	vector<RString> ret;

--- a/src/Song.cpp
+++ b/src/Song.cpp
@@ -40,6 +40,8 @@
 #include <set>
 #include <float.h>
 
+//-Nick12 Used for song file hashing
+#include <CryptManager.h>
 
 /**
  * @brief The internal version of the cache for StepMania.

--- a/src/Song.cpp
+++ b/src/Song.cpp
@@ -1595,7 +1595,7 @@ vector<RString> Song::GetFGChanges1ToVectorString() const
 std::string Song::GetFileHash()
 {
 	if (m_sFileHash.empty()) {
-		std::string sPath = SetExtension(GetSongFilePath(), "sm");
+		RString sPath = SetExtension(GetSongFilePath(), "sm");
 		if (!IsAFile(sPath))
 			sPath = SetExtension(GetSongFilePath(), "dwi");
 		if (!IsAFile(sPath))

--- a/src/Song.cpp
+++ b/src/Song.cpp
@@ -1592,7 +1592,7 @@ vector<RString> Song::GetFGChanges1ToVectorString() const
 	return this->GetChangesToVectorString(this->GetForegroundChanges());
 }
 
-std::string Song::GetFileHash()
+RString Song::GetFileHash()
 {
 	if (m_sFileHash.empty()) {
 		RString sPath = SetExtension(GetSongFilePath(), "sm");

--- a/src/Song.h
+++ b/src/Song.h
@@ -188,6 +188,9 @@ public:
 	/** @brief The transliterated artist of the Song, if it exists. */
 	RString m_sArtistTranslit;
 
+	RString m_sFileHash;
+	RString GetFileHash();
+
 	/* If PREFSMAN->m_bShowNative is off, these are the same as GetTranslit*
 	 * below. Otherwise, they return the main titles. */
 	RString GetDisplayMainTitle() const;

--- a/src/Steps.cpp
+++ b/src/Steps.cpp
@@ -656,7 +656,9 @@ std::string Steps::GenerateChartKey(NoteData &nd, TimingData *td)
 					firstHalf.append(os.str());
 				}
 				bpm = td->GetBPMAtRow(row);
-				firstHalf.append(std::to_string(static_cast<int>(bpm + 0.374643f)));
+				std::ostringstream os;
+				os << static_cast<int>(bpm + 0.374643f);
+				firstHalf.append(os.str());
 			}
 		}
 
@@ -671,7 +673,9 @@ std::string Steps::GenerateChartKey(NoteData &nd, TimingData *td)
 					secondHalf.append(os.str());
 				}
 				bpm = td->GetBPMAtRow(row);
-				secondHalf.append(std::to_string(static_cast<int>(bpm + 0.374643f)));
+				std::ostringstream os;
+				os << static_cast<int>(bpm + 0.374643f);
+				firstHalf.append(os.str());
 			}
 		}
 	}

--- a/src/Steps.cpp
+++ b/src/Steps.cpp
@@ -617,10 +617,18 @@ void Steps::SetCachedRadarValues( const RadarValues v[NUM_PLAYERS] )
 	m_bAreCachedRadarValuesJustLoaded = true;
 }
 
-//Chart key hashing
 std::string Steps::GenerateChartKey()
 {
 	ChartKey = this->GenerateChartKey(*m_pNoteData, this->GetTimingData());
+	return ChartKey;
+}
+std::string Steps::GetChartKey()
+{
+	if (ChartKey.empty()) {
+		this->Decompress();
+		ChartKey = this->GenerateChartKey(*m_pNoteData, this->GetTimingData());
+		this->Compress();
+	}
 	return ChartKey;
 }
 std::string Steps::GenerateChartKey(NoteData &nd, TimingData *td)
@@ -643,7 +651,9 @@ std::string Steps::GenerateChartKey(NoteData &nd, TimingData *td)
 				int row = nerv[r];
 				for (int t = 0; t < nd.GetNumTracks(); ++t) {
 					const TapNote &tn = nd.GetTapNote(t, row);
-					firstHalf.append(std::to_string(tn.type));
+					std::ostringstream os;
+					os << tn.type;
+					firstHalf.append(os.str());
 				}
 				bpm = td->GetBPMAtRow(row);
 				firstHalf.append(std::to_string(static_cast<int>(bpm + 0.374643f)));
@@ -656,7 +666,9 @@ std::string Steps::GenerateChartKey(NoteData &nd, TimingData *td)
 				int row = nerv[r];
 				for (int t = 0; t < nd.GetNumTracks(); ++t) {
 					const TapNote &tn = nd.GetTapNote(t, row);
-					secondHalf.append(std::to_string(tn.type));
+					std::ostringstream os;
+					os << tn.type;
+					secondHalf.append(os.str());
 				}
 				bpm = td->GetBPMAtRow(row);
 				secondHalf.append(std::to_string(static_cast<int>(bpm + 0.374643f)));

--- a/src/Steps.h
+++ b/src/Steps.h
@@ -128,7 +128,7 @@ public:
 	using the notedata stored in game memory immediately after reading it than parsing it using lua. - Mina */
 	std::string GenerateChartKey(NoteData &nd, TimingData *td);
 	std::string GenerateChartKey();
-	std::string ChartKey = "Invalid";
+	std::string ChartKey;
 	std::string GetChartKey() const { return ChartKey; }
 	void SetChartKey(const std::string &k) { ChartKey = k; }
 

--- a/src/Steps.h
+++ b/src/Steps.h
@@ -124,6 +124,14 @@ public:
 	void SetChartStyle( RString sChartStyle );
 	static bool MakeValidEditDescription( RString &sPreferredDescription );	// return true if was modified
 
+	/* This is a reimplementation of the lua version of the script to generate chart keys, except this time
+	using the notedata stored in game memory immediately after reading it than parsing it using lua. - Mina */
+	std::string GenerateChartKey(NoteData &nd, TimingData *td);
+	std::string GenerateChartKey();
+	std::string ChartKey = "Invalid";
+	std::string GetChartKey() const { return ChartKey; }
+	void SetChartKey(const std::string &k) { ChartKey = k; }
+
 	void SetLoadedFromProfile( ProfileSlot slot )	{ m_LoadedFromProfile = slot; }
 	void SetMeter( int meter );
 	void SetCachedRadarValues( const RadarValues v[NUM_PLAYERS] );

--- a/src/Steps.h
+++ b/src/Steps.h
@@ -129,7 +129,7 @@ public:
 	std::string GenerateChartKey(NoteData &nd, TimingData *td);
 	std::string GenerateChartKey();
 	std::string ChartKey;
-	std::string GetChartKey() const { return ChartKey; }
+	std::string GetChartKey();
 	void SetChartKey(const std::string &k) { ChartKey = k; }
 
 	void SetLoadedFromProfile( ProfileSlot slot )	{ m_LoadedFromProfile = slot; }


### PR DESCRIPTION
-- Send server the chart hash on song start (Can be used by the server to identify specific charts)
-- Send server the song's file hash on song select (To send to the other players in the room and so the server can identify what song was selected)
-- Send server the song's file hash on song start (So the server can identify the song, in case the user moved from the song he selected first to another one with the same metadata)
-- Recieve song's file hash when a song is selected
-- Find the song using the file hash(If no filehash was sent or the song isn't found using the filehash then search again without using the filehash)
-- Send the server the rate on song start
-- Added packet FLU(friendlist update). The friendlist is kept in 2 vector in the NSMAN called fl_UserNames and fl_UserStates
-- Send hitted note row size(jump/hand/etc)
Still works with csharp SMO without issues.
This makes it possible for the server to identify specific charts/simfiles since we're using the notedata and not just metadata in the hashes. And also allows SM to select the correct song when we have 2 songs with the same metadata (The server must support song filehashs and the user that picked the song must support song filehashs)