### PR TITLE
Online protocol Update

### DIFF
--- a/src/NetworkSyncManager.h
+++ b/src/NetworkSyncManager.h
@@ -7,7 +7,7 @@
 
 class LoadingWindow;
 
-const int NETPROTOCOLVERSION=3;
+const int NETPROTOCOLVERSION=4;
 const int NETMAXBUFFERSIZE=1020; //1024 - 4 bytes for EzSockets
 const int NETNUMTAPSCORES=8;
 
@@ -29,6 +29,8 @@ enum NSCommand
 	NSCSMOnline,	// 12 [SMLC_SMO]
 	NSCFormatted,	// 13 [SMLC_RESERVED1]
 	NSCAttack,		// 14 [SMLC_RESERVED2]
+	XML,		// 15 [SMLC_RESERVED3]
+	FLU,		// 15 [SMLC_FriendListUpdate]
 	NUM_NS_COMMANDS
 };
 
@@ -145,6 +147,10 @@ public:
 	std::vector<int> m_ActivePlayer;
 	std::vector<std::string> m_PlayerNames;
 
+	//friendlist
+	std::vector<std::string> fl_PlayerNames;
+	std::vector<int> fl_PlayerStates;
+	
 	// Used for ScreenNetEvaluation
 	std::vector<EndOfGame_PlayerData> m_EvalPlayerData;
 

--- a/src/NoteData.cpp
+++ b/src/NoteData.cpp
@@ -219,6 +219,12 @@ void NoteData::ClearAll()
 		m_TapNotes[t].clear();
 }
 
+void NoteData::LogNonEmptyRows() {
+	NonEmptyRowVector.clear();
+	FOREACH_NONEMPTY_ROW_ALL_TRACKS(*this, row)
+		NonEmptyRowVector.push_back(row);
+}
+
 /* Copy [rowFromBegin,rowFromEnd) from pFrom to this. (Note that this does
  * *not* overlay; all data in the range is overwritten.) */
 void NoteData::CopyRange( const NoteData& from, int rowFromBegin, int rowFromEnd, int rowToBegin )

--- a/src/NoteData.h
+++ b/src/NoteData.h
@@ -159,9 +159,16 @@ private:
 	void RemoveATIFromList(all_tracks_iterator* iter) const;
 	void RemoveATIFromList(all_tracks_const_iterator* iter) const;
 
+	// Mina stuf (Used for chartkey hashing)
+	std::vector<int> NonEmptyRowVector;
+	
 public:
 	void Init();
 
+	// Mina stuf (Used for chartkey hashing)
+	void LogNonEmptyRows();
+	std::vector<int>& GetNonEmptyRowVector() { return NonEmptyRowVector; };
+	
 	void SetOccuranceTimeForAllTaps(TimingData* timing_data);
 	void count_notes_in_columns(TimingData* timing_data,
 		std::vector<std::map<TapNoteType, int> > note_counts,

--- a/src/ScreenNetSelectBase.cpp
+++ b/src/ScreenNetSelectBase.cpp
@@ -31,6 +31,7 @@ using std::wstring;
 
 AutoScreenMessage( SM_AddToChat );
 AutoScreenMessage( SM_UsersUpdate );
+AutoScreenMessage( SM_FriendsUpdate );
 AutoScreenMessage( SM_SMOnlinePack );
 
 REGISTER_SCREEN_CLASS( ScreenNetSelectBase );
@@ -137,6 +138,10 @@ void ScreenNetSelectBase::HandleScreenMessage( const ScreenMessage SM )
 	else if( SM == SM_UsersUpdate )
 	{
 		UpdateUsers();
+	}
+	else if (SM == SM_FriendsUpdate)
+	{
+		MESSAGEMAN->Broadcast("FriendsUpdate");
 	}
 
 	ScreenWithMenuElements::HandleScreenMessage( SM );

--- a/src/Steps.cpp
+++ b/src/Steps.cpp
@@ -33,6 +33,9 @@
 /* register DisplayBPM with StringConversion */
 #include "EnumHelper.h"
 
+// For hashing hart keys - Mina
+#include "CryptManager.h"
+
 using std::vector;
 
 static const char *DisplayBPMNames[] =
@@ -628,6 +631,61 @@ void Steps::SetCachedRadarValues( const RadarValues v[NUM_PLAYERS] )
 	std::copy( v, v + NUM_PLAYERS, m_CachedRadarValues );
 	m_bAreCachedRadarValuesJustLoaded = true;
 }
+
+//Chart key hashing
+std::string Steps::GenerateChartKey()
+{
+	ChartKey = this->GenerateChartKey(*m_pNoteData, this->GetTimingData());
+	return ChartKey;
+}
+std::string Steps::GenerateChartKey(NoteData &nd, TimingData *td)
+{
+	std::string k = "";
+	std::string o = "";
+	float bpm;
+	nd.LogNonEmptyRows();
+	std::vector<int>& nerv = nd.GetNonEmptyRowVector();
+
+
+	std::string firstHalf = "";
+	std::string secondHalf = "";
+
+#pragma omp parallel sections
+	{
+#pragma omp section
+		{
+			for (size_t r = 0; r < nerv.size() / 2; r++) {
+				int row = nerv[r];
+				for (int t = 0; t < nd.GetNumTracks(); ++t) {
+					const TapNote &tn = nd.GetTapNote(t, row);
+					firstHalf.append(std::to_string(tn.type));
+				}
+				bpm = td->GetBPMAtRow(row);
+				firstHalf.append(std::to_string(static_cast<int>(bpm + 0.374643f)));
+			}
+		}
+
+#pragma omp section
+		{
+			for (size_t r = nerv.size() / 2; r < nerv.size(); r++) {
+				int row = nerv[r];
+				for (int t = 0; t < nd.GetNumTracks(); ++t) {
+					const TapNote &tn = nd.GetTapNote(t, row);
+					secondHalf.append(std::to_string(tn.type));
+				}
+				bpm = td->GetBPMAtRow(row);
+				secondHalf.append(std::to_string(static_cast<int>(bpm + 0.374643f)));
+			}
+		}
+	}
+	k = firstHalf + secondHalf;
+
+	//ChartKeyRecord = k;
+	o.append("X");	// I was thinking of using "C" to indicate chart.. however.. X is cooler... - Mina
+	o.append(BinaryToHex(CryptManager::GetSHA1ForString(k)));
+	return o;
+}
+
 
 // lua start
 #include "LuaBinding.h"

--- a/src/Steps.h
+++ b/src/Steps.h
@@ -124,6 +124,14 @@ public:
 	void SetChartStyle( std::string sChartStyle );
 	static bool MakeValidEditDescription( std::string &sPreferredDescription );	// return true if was modified
 
+	/* This is a reimplementation of the lua version of the script to generate chart keys, except this time
+	using the notedata stored in game memory immediately after reading it than parsing it using lua. - Mina */
+	std::string GenerateChartKey(NoteData &nd, TimingData *td);
+	std::string GenerateChartKey();
+	std::string ChartKey = "Invalid";
+	std::string GetChartKey() const { return ChartKey; }
+	void SetChartKey(const std::string &k) { ChartKey = k; }
+
 	void ChangeFilenamesForCustomSong();
 
 	void SetLoadedFromProfile( ProfileSlot slot )	{ m_LoadedFromProfile = slot; }


### PR DESCRIPTION
-- Send server unique chart hash
-- Send server the rate
-- Added packet FLU(friendlist update). The friendlist is kept in 2 vector in the NSMAN called fl_UserNames and fl_UserStates
Still works with csharp SMO without issues.
This makes it possible for the server to identify specific charts since we're using the notedata and not just metadata