### PR TITLE
Online protocol improvements

### DIFF
--- a/src/NetworkSyncManager.cpp
+++ b/src/NetworkSyncManager.cpp
@@ -21,6 +21,7 @@ bool NetworkSyncManager::Connect( const RString& addy, unsigned short port ) { r
 RString NetworkSyncManager::GetServerName() { return RString(); }
 void NetworkSyncManager::ReportNSSOnOff( int i ) { }
 void NetworkSyncManager::ReportScore( int playerID, int step, int score, int combo, float offset ) { }
+void NetworkSyncManager::ReportScore(int playerID, int step, int score, int combo, float offset, int numNotes) { }
 void NetworkSyncManager::ReportSongOver() { }
 void NetworkSyncManager::ReportStyle() {}
 void NetworkSyncManager::StartRequest( short position ) { }

--- a/src/NetworkSyncManager.h
+++ b/src/NetworkSyncManager.h
@@ -7,7 +7,7 @@
 
 class LoadingWindow;
 
-const int NETPROTOCOLVERSION=3;
+const int NETPROTOCOLVERSION=4;
 const int NETMAXBUFFERSIZE=1020; //1024 - 4 bytes for EzSockets
 const int NETNUMTAPSCORES=8;
 
@@ -29,6 +29,8 @@ enum NSCommand
 	NSCSMOnline,	// 12 [SMLC_SMO]
 	NSCFormatted,	// 13 [SMLC_RESERVED1]
 	NSCAttack,		// 14 [SMLC_RESERVED2]
+	XML,		// 15 [SMLC_RESERVED3]
+	FLU,		// 15 [SMLC_FriendListUpdate]
 	NUM_NS_COMMANDS
 };
 
@@ -145,6 +147,10 @@ public:
 	vector<int> m_ActivePlayer;
 	vector<RString> m_PlayerNames;
 
+	//friendlist
+	std::vector<RString> fl_PlayerNames;
+	std::vector<int> fl_PlayerStates;
+	
 	// Used for ScreenNetEvaluation
 	vector<EndOfGame_PlayerData> m_EvalPlayerData;
 
@@ -163,8 +169,11 @@ public:
 	RString m_sMainTitle;
 	RString m_sArtist;
 	RString m_sSubTitle;
+	RString m_sFileHash;
 	int m_iSelectMode;
 	void SelectUserSong();
+
+	int GetServerVersion();
 
 	RString m_sChatText;
 

--- a/src/NetworkSyncManager.h
+++ b/src/NetworkSyncManager.h
@@ -116,6 +116,7 @@ public:
 
     // If "useSMserver" then send score to server
 	void ReportScore( int playerID, int step, int score, int combo, float offset );	
+	void ReportScore(int playerID, int step, int score, int combo, float offset, int numNotes);
 	void ReportSongOver();
 	void ReportStyle(); // Report style, players, and names
 	void ReportNSSOnOff( int i );	// Report song selection screen on/off

--- a/src/NoteData.cpp
+++ b/src/NoteData.cpp
@@ -269,6 +269,12 @@ int NoteData::GetNumTracksWithTapOrHoldHead( int row ) const
 	return iNum;
 }
 
+void NoteData::LogNonEmptyRows() {
+	NonEmptyRowVector.clear();
+	FOREACH_NONEMPTY_ROW_ALL_TRACKS(*this, row)
+		NonEmptyRowVector.push_back(row);
+}
+
 int NoteData::GetFirstTrackWithTap( int row ) const
 {
 	for( int t=0; t<GetNumTracks(); t++ )

--- a/src/NoteData.h
+++ b/src/NoteData.h
@@ -157,9 +157,16 @@ private:
 	void RemoveATIFromList(all_tracks_iterator* iter) const;
 	void RemoveATIFromList(all_tracks_const_iterator* iter) const;
 
+	// Mina stuf (Used for chartkey hashing)
+	std::vector<int> NonEmptyRowVector;
+	
 public:
 	void Init();
 
+	// Mina stuf (Used for chartkey hashing)
+	void LogNonEmptyRows();
+	std::vector<int>& GetNonEmptyRowVector() { return NonEmptyRowVector; };
+	
 	int GetNumTracks() const { return m_TapNotes.size(); }
 	void SetNumTracks( int iNewNumTracks );
 	bool IsComposite() const;

--- a/src/ScoreKeeperNormal.cpp
+++ b/src/ScoreKeeperNormal.cpp
@@ -605,7 +605,7 @@ void ScoreKeeperNormal::HandleTapRowScore( const NoteData &nd, int iRow )
 	float offset = NoteDataWithScoring::LastTapNoteWithResult( nd, iRow ).result.fTapNoteOffset;
 	NSMAN->ReportScore( pn, scoreOfLastTap,
 			m_pPlayerStageStats->m_iScore,
-			m_pPlayerStageStats->m_iCurCombo, offset );
+			m_pPlayerStageStats->m_iCurCombo, offset, m_iNumNotesHitThisRow);
 	Message msg( "ScoreChanged" );
 	msg.SetParam( "PlayerNumber", m_pPlayerState->m_PlayerNumber );
 	msg.SetParam( "MultiPlayer", m_pPlayerState->m_mp );

--- a/src/ScreenNetSelectBase.cpp
+++ b/src/ScreenNetSelectBase.cpp
@@ -28,6 +28,7 @@
 
 AutoScreenMessage( SM_AddToChat );
 AutoScreenMessage( SM_UsersUpdate );
+AutoScreenMessage( SM_FriendsUpdate );
 AutoScreenMessage( SM_SMOnlinePack );
 
 REGISTER_SCREEN_CLASS( ScreenNetSelectBase );
@@ -134,6 +135,10 @@ void ScreenNetSelectBase::HandleScreenMessage( const ScreenMessage SM )
 	else if( SM == SM_UsersUpdate )
 	{
 		UpdateUsers();
+	}
+	else if (SM == SM_FriendsUpdate)
+	{
+		MESSAGEMAN->Broadcast("FriendsUpdate");
 	}
 
 	ScreenWithMenuElements::HandleScreenMessage( SM );

--- a/src/ScreenNetSelectMusic.cpp
+++ b/src/ScreenNetSelectMusic.cpp
@@ -181,14 +181,37 @@ void ScreenNetSelectMusic::HandleScreenMessage( const ScreenMessage SM )
 
 		vector <Song *> AllSongs = SONGMAN->GetAllSongs();
 		unsigned i;
-		for( i=0; i < AllSongs.size(); i++ )
+		bool found = false;
+		if (NSMAN->GetServerVersion() >= 129)
 		{
-			m_cSong = AllSongs[i];
-			if( ( !m_cSong->GetTranslitArtist().CompareNoCase( NSMAN->m_sArtist ) ) &&
-					( !m_cSong->GetTranslitMainTitle().CompareNoCase( NSMAN->m_sMainTitle ) ) &&
-					( !m_cSong->GetTranslitSubTitle().CompareNoCase( NSMAN->m_sSubTitle ) ) )
-					break;
+			//Dont earch by filehash if none was sent
+			if(!NSMAN->m_sFileHash.empty())
+				for (i = 0; i < AllSongs.size(); i++)
+				{
+					m_cSong = AllSongs[i];
+					if (NSMAN->m_sArtist == m_cSong->GetTranslitArtist() &&
+						NSMAN->m_sMainTitle == m_cSong->GetTranslitMainTitle() &&
+						NSMAN->m_sSubTitle == m_cSong->GetTranslitSubTitle() &&
+						NSMAN->m_sFileHash == m_cSong->GetFileHash())
+					{
+						found = true;
+						break;
+					}
+				}
+
 		}
+		//If we couldnt find it using file hash search for it without using it, if using SMSERVER < 129 it will go here
+		if(!found)
+			for (i = 0; i < AllSongs.size(); i++)
+			{
+				m_cSong = AllSongs[i];
+				if (NSMAN->m_sArtist == m_cSong->GetTranslitArtist() &&
+					NSMAN->m_sMainTitle == m_cSong->GetTranslitMainTitle() &&
+					NSMAN->m_sSubTitle == m_cSong->GetTranslitSubTitle())
+				{
+					break;
+				}
+			}
 
 		bool haveSong = i != AllSongs.size();
 

--- a/src/Song.cpp
+++ b/src/Song.cpp
@@ -40,6 +40,8 @@
 #include <set>
 #include <float.h>
 
+//-Nick12 Used for song file hashing
+#include <CryptManager.h>
 
 /**
  * @brief The internal version of the cache for StepMania.
@@ -1590,6 +1592,32 @@ vector<RString> Song::GetBGChanges2ToVectorString() const
 vector<RString> Song::GetFGChanges1ToVectorString() const
 {
 	return this->GetChangesToVectorString(this->GetForegroundChanges());
+}
+
+RString Song::GetFileHash()
+{
+	if (m_sFileHash.empty()) {
+		RString sPath = SetExtension(GetSongFilePath(), "sm");
+		if (!IsAFile(sPath))
+			sPath = SetExtension(GetSongFilePath(), "dwi");
+		if (!IsAFile(sPath))
+			sPath = SetExtension(GetSongFilePath(), "sma");
+		if (!IsAFile(sPath))
+			sPath = SetExtension(GetSongFilePath(), "bms");
+		if (!IsAFile(sPath))
+			sPath = SetExtension(GetSongFilePath(), "ksf");
+		if (!IsAFile(sPath))
+			sPath = SetExtension(GetSongFilePath(), "json");
+		if (!IsAFile(sPath))
+			sPath = SetExtension(GetSongFilePath(), "jso");
+		if (!IsAFile(sPath))
+			sPath = SetExtension(GetSongFilePath(), "ssc");
+		if (IsAFile(sPath))
+			m_sFileHash = BinaryToHex(CRYPTMAN->GetSHA1ForFile(sPath));
+		else
+			m_sFileHash = "";
+	}
+	return m_sFileHash;
 }
 
 vector<RString> Song::GetInstrumentTracksToVectorString() const

--- a/src/Song.h
+++ b/src/Song.h
@@ -188,6 +188,9 @@ public:
 	/** @brief The transliterated artist of the Song, if it exists. */
 	RString m_sArtistTranslit;
 
+	RString m_sFileHash;
+	RString GetFileHash();
+
 	/* If PREFSMAN->m_bShowNative is off, these are the same as GetTranslit*
 	 * below. Otherwise, they return the main titles. */
 	RString GetDisplayMainTitle() const;

--- a/src/Steps.cpp
+++ b/src/Steps.cpp
@@ -33,6 +33,9 @@
 /* register DisplayBPM with StringConversion */
 #include "EnumHelper.h"
 
+// For hashing hart keys - Mina
+#include "CryptManager.h"
+
 static const char *DisplayBPMNames[] =
 {
 	"Actual",
@@ -613,6 +616,77 @@ void Steps::SetCachedRadarValues( const RadarValues v[NUM_PLAYERS] )
 	copy( v, v + NUM_PLAYERS, m_CachedRadarValues );
 	m_bAreCachedRadarValuesJustLoaded = true;
 }
+
+RString Steps::GenerateChartKey()
+{
+	ChartKey = this->GenerateChartKey(*m_pNoteData, this->GetTimingData());
+	return ChartKey;
+}
+RString Steps::GetChartKey()
+{
+	if (ChartKey.empty()) {
+		this->Decompress();
+		ChartKey = this->GenerateChartKey(*m_pNoteData, this->GetTimingData());
+		this->Compress();
+	}
+	return ChartKey;
+}
+RString Steps::GenerateChartKey(NoteData &nd, TimingData *td)
+{
+	RString k = "";
+	RString o = "";
+	float bpm;
+	nd.LogNonEmptyRows();
+	std::vector<int>& nerv = nd.GetNonEmptyRowVector();
+
+
+	RString firstHalf = "";
+	RString secondHalf = "";
+
+#pragma omp parallel sections
+	{
+#pragma omp section
+		{
+			for (size_t r = 0; r < nerv.size() / 2; r++) {
+				int row = nerv[r];
+				for (int t = 0; t < nd.GetNumTracks(); ++t) {
+					const TapNote &tn = nd.GetTapNote(t, row);
+					std::ostringstream os;
+					os << tn.type;
+					firstHalf.append(os.str());
+				}
+				bpm = td->GetBPMAtRow(row);
+				std::ostringstream os;
+				os << static_cast<int>(bpm + 0.374643f);
+				firstHalf.append(os.str());
+			}
+		}
+
+#pragma omp section
+		{
+			for (size_t r = nerv.size() / 2; r < nerv.size(); r++) {
+				int row = nerv[r];
+				for (int t = 0; t < nd.GetNumTracks(); ++t) {
+					const TapNote &tn = nd.GetTapNote(t, row);
+					std::ostringstream os;
+					os << tn.type;
+					secondHalf.append(os.str());
+				}
+				bpm = td->GetBPMAtRow(row);
+				std::ostringstream os;
+				os << static_cast<int>(bpm + 0.374643f);
+				firstHalf.append(os.str());
+			}
+		}
+	}
+	k = firstHalf + secondHalf;
+
+	//ChartKeyRecord = k;
+	o.append("X");	// I was thinking of using "C" to indicate chart.. however.. X is cooler... - Mina
+	o.append(BinaryToHex(CryptManager::GetSHA1ForString(k)));
+	return o;
+}
+
 
 // lua start
 #include "LuaBinding.h"

--- a/src/Steps.h
+++ b/src/Steps.h
@@ -124,6 +124,14 @@ public:
 	void SetChartStyle( RString sChartStyle );
 	static bool MakeValidEditDescription( RString &sPreferredDescription );	// return true if was modified
 
+	/* This is a reimplementation of the lua version of the script to generate chart keys, except this time
+	using the notedata stored in game memory immediately after reading it than parsing it using lua. - Mina */
+	RString GenerateChartKey(NoteData &nd, TimingData *td);
+	RString GenerateChartKey();
+	RString ChartKey;
+	RString GetChartKey();
+	void SetChartKey(const RString &k) { ChartKey = k; }
+
 	void SetLoadedFromProfile( ProfileSlot slot )	{ m_LoadedFromProfile = slot; }
 	void SetMeter( int meter );
 	void SetCachedRadarValues( const RadarValues v[NUM_PLAYERS] );


### PR DESCRIPTION
-- Send server the chart hash on song start (Can be used by the server to identify specific charts)
-- Send server the song's file hash on song select (To send to the other players in the room and so the server can identify what song was selected)
-- Send server the song's file hash on song start (So the server can identify the song, in case the user moved from the song he selected first to another one with the same metadata)
-- Recieve song's file hash when a song is selected
-- Find the song using the file hash(If no filehash was sent or the song isn't found using the filehash then search again without using the filehash)
-- Send the server the rate on song start
-- Added packet FLU(friendlist update). The friendlist is kept in 2 vector in the NSMAN called fl_UserNames and fl_UserStates
-- Send row size(jump/hand/etc)
Still works with csharp SMO without issues.
This makes it possible for the server to identify specific charts/simfiles since we're using the notedata and not just metadata in the hashes. And also allows SM to select the correct song when we have 2 songs with the same metadata (The server must support song filehashs and the user that picked the song must support song filehashs)