### PR TITLE
Persistent Coins

### DIFF
--- a/src/Bookkeeper.cpp
+++ b/src/Bookkeeper.cpp
@@ -127,6 +127,8 @@ void Bookkeeper::ReadFromDisk()
 
 	if ( numCoins < 0 )
 		numCoins = 0;
+	else if ( numCoins / PREFSMAN->m_iCoinsPerCredit > MAX_NUM_CREDITS )
+		numCoins = 0;
 
     LOG->Trace("Number of Coins to Load on boot: %i", numCoins);
     GAMESTATE->m_iCoins.Set(numCoins);

--- a/src/Bookkeeper.cpp
+++ b/src/Bookkeeper.cpp
@@ -4,10 +4,12 @@
 #include "RageLog.h"
 #include "IniFile.h"
 #include "GameConstantsAndTypes.h"
+#include "GameState.h"
 #include "SongManager.h"
 #include "RageFile.h"
 #include "XmlFile.h"
 #include "XmlFileUtil.h"
+#include "SpecialFiles.h"
 #include <ctime>
 
 Bookkeeper*	BOOKKEEPER = NULL;	// global and accessible from anywhere in our program
@@ -120,6 +122,15 @@ void Bookkeeper::ReadFromDisk()
 	if( !XmlFileUtil::LoadFromFileShowErrors(xml, COINS_DAT) )
 		return;
 
+    int numCoins = 0;
+    ReadCoinsFile(numCoins);
+
+	if ( numCoins < 0 )
+		numCoins = 0;
+
+    LOG->Trace("Number of Coins to Load on boot: %i", numCoins);
+    GAMESTATE->m_iCoins.Set(numCoins);
+
 	LoadFromNode( &xml );
 }
 
@@ -143,6 +154,20 @@ void Bookkeeper::CoinInserted()
 	d.Set( time(NULL) );
 
 	++m_mapCoinsForHour[d];
+}
+
+void Bookkeeper::WriteCoinsFile( int coins )
+{
+    IniFile ini;
+    ini.SetValue( "Bookkeeping", "Coins", coins);
+    ini.WriteFile( SpecialFiles::COINS_INI );
+}
+
+void Bookkeeper::ReadCoinsFile( int &coins)
+{
+    IniFile ini;
+    ini.ReadFile( SpecialFiles::COINS_INI );
+    ini.GetValue( "Bookkeeping", "Coins", coins);
 }
 
 // Return the number of coins between [beginning,ending).

--- a/src/Bookkeeper.cpp
+++ b/src/Bookkeeper.cpp
@@ -163,7 +163,7 @@ void Bookkeeper::WriteCoinsFile( int coins )
     ini.WriteFile( SpecialFiles::COINS_INI );
 }
 
-void Bookkeeper::ReadCoinsFile( int &coins)
+void Bookkeeper::ReadCoinsFile( int &coins )
 {
     IniFile ini;
     ini.ReadFile( SpecialFiles::COINS_INI );

--- a/src/Bookkeeper.h
+++ b/src/Bookkeeper.h
@@ -21,6 +21,9 @@ public:
 	void GetCoinsLastWeeks( int coins[NUM_LAST_WEEKS] ) const;
 	void GetCoinsByDayOfWeek( int coins[DAYS_IN_WEEK] ) const;
 	void GetCoinsByHour( int coins[HOURS_IN_DAY] ) const;
+	void WriteCoinsFile( int coins ) ;
+	void ReadCoinsFile( int &coins ) ;
+
 
 	void LoadFromNode( const XNode *pNode );
 	XNode* CreateNode() const;

--- a/src/GameCommand.cpp
+++ b/src/GameCommand.cpp
@@ -5,6 +5,7 @@
 #include "GameManager.h"
 #include "GameState.h"
 #include "AnnouncerManager.h"
+#include "Bookkeeper.h"
 #include "PlayerOptions.h"
 #include "ProfileManager.h"
 #include "Profile.h"
@@ -718,6 +719,9 @@ void GameCommand::ApplySelf( const vector<PlayerNumber> &vpns ) const
 			GAMESTATE->m_iCoins.Set( GAMESTATE->m_iCoins - iNumCreditsOwed * PREFSMAN->m_iCoinsPerCredit );
 			LOG->Trace( "Deducted %i coins, %i remaining",
 					iNumCreditsOwed * PREFSMAN->m_iCoinsPerCredit, GAMESTATE->m_iCoins.Get() );
+
+            //Credit Used, make sure to update CoinsFile
+            BOOKKEEPER->WriteCoinsFile(GAMESTATE->m_iCoins.Get());
 		}
 		
 		// If only one side is joined and we picked a style that requires both

--- a/src/GameState.cpp
+++ b/src/GameState.cpp
@@ -514,6 +514,9 @@ namespace
 
 		GAMESTATE->JoinPlayer( pn );
 
+        // On Join, make sure to update Coins File
+		BOOKKEEPER->WriteCoinsFile(GAMESTATE->m_iCoins.Get());
+
 		return true;
 	}
 };

--- a/src/GameState.cpp
+++ b/src/GameState.cpp
@@ -514,7 +514,7 @@ namespace
 
 		GAMESTATE->JoinPlayer( pn );
 
-        // On Join, make sure to update Coins File
+		// On Join, make sure to update Coins File
 		BOOKKEEPER->WriteCoinsFile(GAMESTATE->m_iCoins.Get());
 
 		return true;

--- a/src/SpecialFiles.cpp
+++ b/src/SpecialFiles.cpp
@@ -19,6 +19,8 @@ const RString SpecialFiles::TYPE_TXT_FILE = "Data/Type.txt";
 const RString SpecialFiles::SONGS_DIR = "Songs/";
 const RString SpecialFiles::COURSES_DIR	= "Courses/";
 const RString SpecialFiles::NOTESKINS_DIR = "NoteSkins/";
+const RString SpecialFiles::COINS_INI = "Save/Coin.ini";
+
 
 
 /*

--- a/src/SpecialFiles.h
+++ b/src/SpecialFiles.h
@@ -39,6 +39,9 @@ namespace SpecialFiles
 	extern const RString COURSES_DIR;
 	/** @brief The default noteskins directory. */
 	extern const RString NOTESKINS_DIR;
+
+	extern const RString COINS_INI;
+
 }
 
 #endif

--- a/src/StepMania.cpp
+++ b/src/StepMania.cpp
@@ -1281,8 +1281,11 @@ void StepMania::InsertCoin( int iNum, bool bCountInBookkeeping )
 	{
 		GAMESTATE->m_iCoins.Set( MAX_NUM_CREDITS * PREFSMAN->m_iCoinsPerCredit );
 	}
-	
+
 	LOG->Trace("%i coins inserted, %i needed to play", GAMESTATE->m_iCoins.Get(), PREFSMAN->m_iCoinsPerCredit.Get() );
+
+    // On InsertCoin, make sure to update Coins file
+    BOOKKEEPER->WriteCoinsFile(GAMESTATE->m_iCoins.Get());
 
 	// If inserting coins, play an appropriate sound; if deducting coins, don't play anything.
 	if (iNum > 0)
@@ -1322,6 +1325,9 @@ void StepMania::ClearCredits()
 	LOG->Trace("%i coins cleared", GAMESTATE->m_iCoins.Get() );
 	GAMESTATE->m_iCoins.Set( 0 );
 	SCREENMAN->PlayInvalidSound();
+
+    // Update Coins file to make sure credits are cleared.
+    BOOKKEEPER->WriteCoinsFile(GAMESTATE->m_iCoins.Get());
 
 	// TODO: remove this redundant message and things that depend on it
 	Message msg( "CoinInserted" );


### PR DESCRIPTION
On Coins Insert a file Save/Coin.ini is created, if it does
not exist, which stores the number of coins currrently in
m_iCoins. Whenever m_iCoins is update, the Coin.ini is updated.

On boot, Coin.ini is read and m_iCoins is set to that value.

resolves: #1403 