### PR TITLE
Sprite:Load lua function can set additional texture hints by having a…

### DIFF
--- a/Themes/_fallback/Scripts/02 Utilities.lua
+++ b/Themes/_fallback/Scripts/02 Utilities.lua
@@ -415,6 +415,26 @@ function rec_print_table(t, indent, depth_remaining)
 	Trace(indent .. "end")
 end
 
+function rec_count_children(parent)
+	local total= 1
+	if #parent > 0 and type(parent) == "table" then
+		for i, c in ipairs(parent) do
+			total= total + rec_count_children(c)
+		end
+	elseif parent.GetChildren then
+		local pname= (parent.GetName and parent:GetName()) or ""
+		local children= parent:GetChildren()
+		for k, v in pairs(children) do
+			if #v > 0 then
+				total= total + rec_count_children(v)
+			else
+				total= total + rec_count_children(v)
+			end
+		end
+	end
+	return total
+end
+
 -- Minor text formatting functions from Kyzentun.
 -- TODO:  Figure out why BitmapText:maxwidth doesn't do what I want.
 -- Intentionally undocumented because they should be moved to BitmapText ASAP

--- a/src/Sprite.cpp
+++ b/src/Sprite.cpp
@@ -1076,6 +1076,11 @@ public:
 		else
 		{
 			RageTextureID ID( SArg(1) );
+			if(lua_isstring(L, 2))
+			{
+				RString additional_hints= SArg(2);
+				ID.AdditionalTextureHints= additional_hints;
+			}
 			p->Load( ID );
 		}
 		COMMON_RETURN_SELF;


### PR DESCRIPTION
… second argument.  Also, rec_count_children slipped in Utilities somehow.

Untested, but it compiles.