### PR TITLE
SMO NestyPlayerOptions

### DIFF
--- a/Themes/_fallback/metrics.ini
+++ b/Themes/_fallback/metrics.ini
@@ -4189,7 +4189,7 @@ PrevScreen="ScreenNetRoom"
 NextScreen="ScreenStageInformation"
 NoSongsScreen=Branch.TitleMenu()
 RoomSelectScreen="ScreenNetRoom"
-PlayerOptionsScreen="ScreenPlayerOptions"
+PlayerOptionsScreen="ScreenNestyPlayerOptions"
 Codes="CodeDetectorOnline"
 
 ShowStyleIcon=false


### PR DESCRIPTION
I hope I am doing this right... I am making a minor fix to the fallback metrics to fix the SMO online player options. I did a test in a new build (compiled source code) and it seemed to work fine. I dunno if Kyzentun intended it to run like this but, it seems to work though.