### PR TITLE
Fix up RageTriangle's fmod usage.

### DIFF
--- a/src/RageMath.cpp
+++ b/src/RageMath.cpp
@@ -656,7 +656,7 @@ float RageSquare( float angle )
 
 float RageTriangle( float angle )
 {
-	float fAngle= fmod(angle, PI * 2.0);
+	float fAngle= fmod(angle, PI * 2.0f);
 	if(fAngle < 0.0)
 	{
 		fAngle+= PI * 2.0;


### PR DESCRIPTION
This fixes the second argument of fmod to be a float, due to the original form not compiling under XCode (resulting in errors).