### PR TITLE
Windows Name fixes

### DIFF
--- a/src/AdjustSync.cpp
+++ b/src/AdjustSync.cpp
@@ -303,7 +303,7 @@ static LocalizedString GLOBAL_OFFSET_FROM	( "AdjustSync", "Global Offset from %+
 static LocalizedString SONG_OFFSET_FROM		( "AdjustSync", "Song offset from %+.3f to %+.3f (notes %s)" );
 static LocalizedString TEMPO_SEGMENT_FROM	( "AdjustSync", "%s BPM from %.3f BPM to %.3f BPM." );
 static LocalizedString CHANGED_STOP		("AdjustSync","The stop segment #%d changed from %+.3fs to %+.3fs (change of %+.3f).");
-static LocalizedString ERROR			("AdjustSync", "Average Error %.5fs");
+static LocalizedString ERROR_			("AdjustSync", "Average Error %.5fs");
 static LocalizedString ETC              ("AdjustSync", "Etc.");
 static LocalizedString TAPS_IGNORED	("AdjustSync", "%d taps ignored.");
 
@@ -429,7 +429,7 @@ void AdjustSync::GetSyncChangeTextSong( vector<RString> &vsAddTo )
 
 		if( vsAddTo.size() > iOriginalSize && s_fAverageError > 0.0f )
 		{
-			vsAddTo.push_back( ssprintf(ERROR.GetValue(), s_fAverageError) );
+			vsAddTo.push_back( ssprintf(ERROR_.GetValue(), s_fAverageError) );
 		}
 		if( vsAddTo.size() > iOriginalSize && s_iStepsFiltered > 0 )
 		{

--- a/src/RageSound.cpp
+++ b/src/RageSound.cpp
@@ -151,7 +151,7 @@ public:
 	unsigned GetNumChannels() const { return 1; }
 	int GetNextSourceFrame() const { return 0; }
 	float GetStreamToSourceRatio() const { return 1.0f; }
-	RString GetError() const { return ""; }
+	RString GetRSRError() const { return ""; }
 };
 
 
@@ -285,9 +285,9 @@ int RageSound::GetDataToPlay( float *pBuffer, int iFrames, int64_t &iStreamFrame
 		/* Read data from our source. */
 		int iGotFrames = m_pSource->RetriedRead( pBuffer + (iFramesStored * m_pSource->GetNumChannels()), iFrames, &iSourceFrame, &fRate );
 
-		if( iGotFrames == RageSoundReader::ERROR )
+		if( iGotFrames == RageSoundReader::ERROR_ )
 		{
-			m_sError = m_pSource->GetError();
+			m_sError = m_pSource->GetRSRError();
 			LOG->Warn( "Decoding %s failed: %s", GetLoadedFilePath().c_str(), m_sError.c_str() );
 		}
 
@@ -465,7 +465,7 @@ float RageSound::GetLengthSeconds()
 
 	if( iLength < 0 )
 	{
-		LOG->Warn( "GetLengthSeconds failed on %s: %s", GetLoadedFilePath().c_str(), m_pSource->GetError().c_str() );
+		LOG->Warn( "GetLengthSeconds failed on %s: %s", GetLoadedFilePath().c_str(), m_pSource->GetRSRError().c_str() );
 		return -1;
 	}
 
@@ -538,7 +538,7 @@ bool RageSound::SetPositionFrames( int iFrames )
 	int iRet = m_pSource->SetPosition( iFrames );
 	if( iRet == -1 )
 	{
-		m_sError = m_pSource->GetError();
+		m_sError = m_pSource->GetRSRError();
 		LOG->Warn( "SetPositionFrames: seek %s failed: %s", GetLoadedFilePath().c_str(), m_sError.c_str() );
 	}
 	else if( iRet == 0 )

--- a/src/RageSoundReader.h
+++ b/src/RageSoundReader.h
@@ -20,7 +20,7 @@ public:
 	/* Return values for Read(). */
 	enum {
 		/* An error occurred; GetError() will return a description of the error. */
-		ERROR = -1,
+		ERROR_ = -1,
 		END_OF_FILE = -2,
 
 		/* A nonblocking buffer in the filter chain has underrun, and no data is
@@ -39,7 +39,7 @@ public:
 	virtual int GetNextSourceFrame() const = 0;
 	virtual float GetStreamToSourceRatio() const = 0;
 
-	virtual RString GetError() const = 0;
+	virtual RString GetRSRError() const = 0;
 	int RetriedRead( float *pBuffer, int iFrames, int *iSourceFrame = NULL, float *fRate = NULL );
 };
 

--- a/src/RageSoundReader_Chain.h
+++ b/src/RageSoundReader_Chain.h
@@ -40,7 +40,7 @@ public:
 	bool SetProperty( const RString &sProperty, float fValue );
 	int GetNextSourceFrame() const;
 	float GetStreamToSourceRatio() const;
-	RString GetError() const { return ""; }
+	RString GetRSRError() const { return ""; }
 
 private:
 	int GetSampleRateInternal() const;

--- a/src/RageSoundReader_ChannelSplit.cpp
+++ b/src/RageSoundReader_ChannelSplit.cpp
@@ -88,7 +88,7 @@ int RageSoundReader_Split::GetSampleRate() const { return m_pImpl->m_pSource->Ge
 unsigned RageSoundReader_Split::GetNumChannels() const { return m_iNumOutputChannels; }
 int RageSoundReader_Split::GetNextSourceFrame() const { return m_iPositionFrame; }
 float RageSoundReader_Split::GetStreamToSourceRatio() const { return 1.0f; }
-RString RageSoundReader_Split::GetError() const { return m_pImpl->m_pSource->GetError(); }
+RString RageSoundReader_Split::GetRSRError() const { return m_pImpl->m_pSource->GetRSRError(); }
 
 RageSoundReader_Split::RageSoundReader_Split( RageSoundSplitterImpl *pImpl )
 {

--- a/src/RageSoundReader_ChannelSplit.h
+++ b/src/RageSoundReader_ChannelSplit.h
@@ -23,7 +23,7 @@ public:
 	virtual bool SetProperty( const RString &sProperty, float fValue );
 	virtual int GetNextSourceFrame() const;
 	virtual float GetStreamToSourceRatio() const;
-	virtual RString GetError() const;
+	virtual RString GetRSRError() const;
 
 	void AddSourceChannelToSound( int iFromChannel, int iToChannel );
 

--- a/src/RageSoundReader_FileReader.cpp
+++ b/src/RageSoundReader_FileReader.cpp
@@ -45,7 +45,7 @@ RageSoundReader_FileReader *RageSoundReader_FileReader::TryOpenFile( RageFileBas
 	if( ret == OPEN_OK )
 		return Sample;
 
-	RString err = Sample->GetError();
+	RString err = Sample->GetRSRError();
 	delete Sample;
 
 	LOG->Trace( "Format %s failed: %s", format.c_str(), err.c_str() );

--- a/src/RageSoundReader_FileReader.h
+++ b/src/RageSoundReader_FileReader.h
@@ -29,7 +29,7 @@ public:
 	/* Takes ownership of pFile (even on failure). */
 	virtual OpenResult Open( RageFileBasic *pFile ) = 0;
 	virtual float GetStreamToSourceRatio() const { return 1.0f; }
-	virtual RString GetError() const { return m_sError; }
+	virtual RString GetRSRError() const { return m_sError; }
 
 	/* Open a file.  If pPrebuffer is non-NULL, and the file is sufficiently small,
 	 * the (possibly compressed) data will be loaded entirely into memory, and pPrebuffer

--- a/src/RageSoundReader_Filter.h
+++ b/src/RageSoundReader_Filter.h
@@ -23,7 +23,7 @@ public:
 	virtual int GetNextSourceFrame() const { return m_pSource->GetNextSourceFrame(); }
 	virtual float GetStreamToSourceRatio() const { return m_pSource->GetStreamToSourceRatio(); }
 	virtual RageSoundReader *GetSource() { return &*m_pSource; }
-	virtual RString GetError() const { return m_pSource->GetError(); }
+	virtual RString GetRSRError() const { return m_pSource->GetRSRError(); }
 
 protected:
 	HiddenPtr<RageSoundReader> m_pSource;

--- a/src/RageSoundReader_MP3.cpp
+++ b/src/RageSoundReader_MP3.cpp
@@ -643,7 +643,7 @@ RageSoundReader_FileReader::OpenResult RageSoundReader_MP3::Open( RageFileBasic 
 		SetError( "Failed to read any data at all" );
 		return OPEN_UNKNOWN_FILE_FORMAT;
 	case -1:
-		SetError( GetError() + " (not an MP3 stream?)" );
+		SetError( GetRSRError() + " (not an MP3 stream?)" );
 		return OPEN_UNKNOWN_FILE_FORMAT;
 	}
 
@@ -719,7 +719,7 @@ int RageSoundReader_MP3::Read( float *buf, int iFrames )
 		if( ret == 0 )
 			return END_OF_FILE;
 		if( ret == -1 )
-			return ERROR;
+			return ERROR_;
 
 		synth_output();
 	}

--- a/src/RageSoundReader_Merge.h
+++ b/src/RageSoundReader_Merge.h
@@ -20,7 +20,7 @@ public:
 	virtual bool SetProperty( const RString &sProperty, float fValue );
 	virtual int GetNextSourceFrame() const { return m_iNextSourceFrame; }
 	virtual float GetStreamToSourceRatio() const { return m_fCurrentStreamToSourceRatio; }
-	virtual RString GetError() const { return ""; }
+	virtual RString GetRSRError() const { return ""; }
 
 	void AddSound( RageSoundReader *pSound );
 

--- a/src/RageSoundReader_Preload.h
+++ b/src/RageSoundReader_Preload.h
@@ -21,7 +21,7 @@ public:
 	unsigned GetNumChannels() const { return m_iChannels; }
 	int GetNextSourceFrame() const;
 	float GetStreamToSourceRatio() const { return m_fRate; }
-	RString GetError() const { return ""; }
+	RString GetRSRError() const { return ""; }
 
 	/* Return the total number of copies of this sound.  (If 1 is returned,
 	 * this is the last copy.) */

--- a/src/RageSoundReader_Vorbisfile.cpp
+++ b/src/RageSoundReader_Vorbisfile.cpp
@@ -203,7 +203,7 @@ int RageSoundReader_Vorbisfile::Read( float *buf, int iFrames )
 			if( ret == OV_EBADLINK )
 			{
 				SetError( ssprintf("Read: OV_EBADLINK") );
-				return ERROR;
+				return ERROR_;
 			}
 
 			if( ret == 0 )
@@ -297,7 +297,7 @@ RageSoundReader_Vorbisfile *RageSoundReader_Vorbisfile::Copy() const
 	/* If we were able to open the sound in the first place, we expect to
 	 * be able to reopen it. */
 	if( ret->Open(pFile) != OPEN_OK )
-		FAIL_M( ssprintf("Copying sound failed: %s", ret->GetError().c_str()) );
+		FAIL_M( ssprintf("Copying sound failed: %s", ret->GetRSRError().c_str()) );
 
 	return ret;
 }

--- a/src/RageSoundReader_WAV.cpp
+++ b/src/RageSoundReader_WAV.cpp
@@ -364,7 +364,7 @@ public:
 			if( m_iBufferUsed == m_iBufferAvail )
 			{
 				if( !DecodeADPCMBlock() )
-					return RageSoundReader::ERROR;
+					return RageSoundReader::ERROR_;
 			}
 			if( m_iBufferAvail == 0 )
 			{

--- a/src/ScreenMiniMenu.cpp
+++ b/src/ScreenMiniMenu.cpp
@@ -61,7 +61,7 @@ void ScreenMiniMenu::BeginScreen()
 {
 	ASSERT( g_pMenuDef != NULL );
 
-	LoadMenu( g_pMenuDef );
+	LoadAMenu( g_pMenuDef );
 	m_SMSendOnOK = g_SendOnOK;
 	m_SMSendOnCancel = g_SendOnCancel;
 	g_pMenuDef = NULL;
@@ -74,7 +74,7 @@ void ScreenMiniMenu::BeginScreen()
 	m_sNextScreen = "xxx";
 }
 
-void ScreenMiniMenu::LoadMenu( const MenuDef* pDef )
+void ScreenMiniMenu::LoadAMenu( const MenuDef* pDef )
 {
 	m_vMenuRows = pDef->rows;
 

--- a/src/ScreenMiniMenu.h
+++ b/src/ScreenMiniMenu.h
@@ -174,7 +174,7 @@ protected:
 
 	virtual bool FocusedItemEndsScreen( PlayerNumber pn ) const;
 
-	void LoadMenu( const MenuDef* pDef );
+	void LoadAMenu( const MenuDef* pDef );
 
 	ScreenMessage		m_SMSendOnOK;
 	ScreenMessage		m_SMSendOnCancel;

--- a/src/ScreenServiceAction.cpp
+++ b/src/ScreenServiceAction.cpp
@@ -233,7 +233,7 @@ static LocalizedString COPIED			( "ScreenServiceAction", "%d copied" );
 static LocalizedString OVERWRITTEN		( "ScreenServiceAction", "%d overwritten" );
 static LocalizedString ADDED			( "ScreenServiceAction", "%d added" );
 static LocalizedString IGNORED			( "ScreenServiceAction", "%d ignored" );
-static LocalizedString FAILED			( "ScreenServiceAction", "%d failed" );
+static LocalizedString FAILED_			( "ScreenServiceAction", "%d failed" );
 static LocalizedString DELETED			( "ScreenServiceAction", "%d deleted" );
 
 static RString CopyEdits( const RString &sFromProfileDir, const RString &sToProfileDir, const RString &sDisplayDir )
@@ -251,7 +251,7 @@ static RString CopyEdits( const RString &sFromProfileDir, const RString &sToProf
 	if( iNumIgnored )
 		vs.push_back( ssprintf( IGNORED.GetValue(), iNumIgnored ) );
 	if( iNumErrored )
-		vs.push_back( ssprintf( FAILED.GetValue(), iNumErrored ) );
+		vs.push_back( ssprintf( FAILED_.GetValue(), iNumErrored ) );
 	return join( "\n", vs );
 }
 
@@ -355,7 +355,7 @@ static RString SyncEditsMachineToMemoryCard()
 	if( iNumDeleted )
 		sRet += RString(" ") + ssprintf( DELETED.GetValue(), iNumDeleted );
 	if( iNumFailed )
-		sRet += RString("; ") + ssprintf( FAILED.GetValue(), iNumFailed );
+		sRet += RString("; ") + ssprintf( FAILED_.GetValue(), iNumFailed );
 	return sRet;
 }
 


### PR DESCRIPTION
These files, while extending functionality on windows, have names which collide with windows names, functions, macros, etc. This renames them to avoid collisions.

Example, LoadMenu actually will start calling LoadMenuA and GetError() will get the error from windows. ERROR is a macro handler, etc.