### PR TITLE
Add missing breaks to case statement, fix #1445

### DIFF
--- a/src/MusicWheelItem.cpp
+++ b/src/MusicWheelItem.cpp
@@ -390,26 +390,34 @@ void MusicWheelItem::HandleMessage( const Message &msg )
 			DEFAULT_FAIL( pWID->m_Type );
 			case WheelItemDataType_Song:
 				type = MusicWheelItemType_Song;
+				break;
 			case WheelItemDataType_Section:
 				if( GAMESTATE->sExpandedSectionName == pWID->m_sText )
 					type = MusicWheelItemType_SectionExpanded;
 				else
 					type = MusicWheelItemType_SectionCollapsed;
+				break;
 			case WheelItemDataType_Course:
 				type = MusicWheelItemType_Course;
+				break;
 			case WheelItemDataType_Sort:
 				if( pWID->m_pAction->m_pm != PlayMode_Invalid )
 					type = MusicWheelItemType_Mode;
 				else
 					type = MusicWheelItemType_Sort;
+				break;
 			case WheelItemDataType_Roulette:
 				type = MusicWheelItemType_Roulette;
+				break;
 			case WheelItemDataType_Random:
 				type = MusicWheelItemType_Random;
+				break;
 			case WheelItemDataType_Portal:
 				type = MusicWheelItemType_Portal;
+				break;
 			case WheelItemDataType_Custom:
 				type = MusicWheelItemType_Custom;
+				break;
 		}
 
 		Message msg( "Set" );


### PR DESCRIPTION
On default theme on fresh checkout on fresh install of Arch, I
encountered a segfault when entering the ScreenSelectMusic screen. The
fault was trying to dereference a NULL pWID->m_pAction in the
WheelItemDataType_Sort case, which we fell through to because of the
missing break statements. This is a simple fix for that, which I believe to be the same issue as #1445 