### PR TITLE
Oitg zoom mode global

### DIFF
--- a/Themes/_fallback/Scripts/03 Gameplay.lua
+++ b/Themes/_fallback/Scripts/03 Gameplay.lua
@@ -464,13 +464,7 @@ end
 function oitg_zoom_mode_actor()
 	return Def.Actor{
 		OnCommand= function(self)
-			local screen= SCREENMAN:GetTopScreen()
-			for i, pn in ipairs(GAMESTATE:GetEnabledPlayers()) do
-				local player= screen:GetChild("Player"..ToEnumShortString(pn))
-				if player and player.set_oitg_zoom_mode then
-					player:set_oitg_zoom_mode(true)
-				end
-			end
+			set_oitg_zoom_mode(true)
 		end,
 	}
 end

--- a/src/Actor.cpp
+++ b/src/Actor.cpp
@@ -33,6 +33,8 @@ public:
 };
 REGISTER_ACTOR_CLASS_WITH_NAME( HiddenActor, Actor );
 
+bool Actor::g_oitg_zoom_mode= false;
+
 float Actor::g_fCurrentBGMTime = 0, Actor::g_fCurrentBGMBeat;
 float Actor::g_fCurrentBGMTimeNoOffset = 0, Actor::g_fCurrentBGMBeatNoOffset = 0;
 vector<float> Actor::g_vfCurrentBGMBeatPlayer(NUM_PlayerNumber, 0);
@@ -2110,7 +2112,24 @@ public:
 	}
 };
 
-LUA_REGISTER_INSTANCED_BASE_CLASS( Actor )
+LUA_REGISTER_INSTANCED_BASE_CLASS( Actor );
+
+int LuaFunc_get_oitg_zoom_mode(lua_State* L);
+int LuaFunc_get_oitg_zoom_mode(lua_State* L)
+{
+	lua_pushboolean(L, Actor::GetOITGZoomMode());
+	return 1;
+}
+LUAFUNC_REGISTER_COMMON(get_oitg_zoom_mode);
+
+int LuaFunc_set_oitg_zoom_mode(lua_State* L);
+int LuaFunc_set_oitg_zoom_mode(lua_State* L)
+{
+	Actor::SetOITGZoomMode(BArg(1));
+	return 0;
+}
+LUAFUNC_REGISTER_COMMON(set_oitg_zoom_mode);
+
 // lua end
 
 

--- a/src/Actor.h
+++ b/src/Actor.h
@@ -392,14 +392,40 @@ public:
 	 * @brief Retrieve the zoom factor for the z coordinate of the Actor.
 	 * @return the zoom factor for the z coordinate of the Actor. */
 	float GetZoomZ() const				{ return DestTweenState().scale.z; }
+
+	// OITG bug:  Actor::SetZoom only sets X and Y.  When mini is applied to
+	// the notefield with SetZoom, it does not affect the range of bumpy.
+	// m_oitg_zoom_mode provides compatibility with that bug.  Only used in
+	// defective mode. -Kyz
+	// I tried having it be a member of Player and only affect the way Player
+	// applies zoom to the notefield, but that doesn't work when the gimmick
+	// simfile uses zoom on the screen.  So making it a global flag that
+	// affects all actors seems to be the only option. -Kyz
+	// This explanation and variable are intentionally here next to SetZoom to
+	// make them easy to find when reading SetZoom.
+	private:
+	static bool g_oitg_zoom_mode;
+	public:
+	static void SetOITGZoomMode(bool mode)
+	{
+		g_oitg_zoom_mode= mode;
+	}
+	static bool GetOITGZoomMode()
+	{
+		return g_oitg_zoom_mode;
+	}
+
 	/**
 	 * @brief Set the zoom factor for all dimensions of the Actor.
 	 * @param zoom the zoom factor for all dimensions. */
 	void  SetZoom( float zoom )
 	{ 
-		DestTweenState().scale.x = zoom; 
-		DestTweenState().scale.y = zoom; 
-		DestTweenState().scale.z = zoom;
+		DestTweenState().scale.x = zoom;
+		DestTweenState().scale.y = zoom;
+		if(!g_oitg_zoom_mode)
+		{
+			DestTweenState().scale.z = zoom;
+		}
 	}
 	/**
 	 * @brief Set the zoom factor for the x dimension of the Actor.

--- a/src/Player.cpp
+++ b/src/Player.cpp
@@ -236,7 +236,6 @@ Player::Player( NoteData &nd, bool bVisibleParts ) : m_NoteData(nd)
 	m_drawing_notefield_board= false;
 	m_bLoaded = false;
 	m_inside_lua_set_life= false;
-	m_oitg_zoom_mode= false;
 
 	m_pPlayerState = NULL;
 	m_pPlayerStageStats = NULL;
@@ -926,15 +925,7 @@ void Player::Update( float fDeltaTime )
 		float field_zoom = 1 - fMiniPercent*0.5f;
 		if(m_pNoteField)
 		{
-			if(m_oitg_zoom_mode)
-			{
-				m_pNoteField->SetZoomX(field_zoom);
-				m_pNoteField->SetZoomY(field_zoom);
-			}
-			else
-			{
-				m_pNoteField->SetZoom(field_zoom);
-			}
+			m_pNoteField->SetZoom(field_zoom);
 		}
 		if( m_pActorWithJudgmentPosition != NULL )
 			m_pActorWithJudgmentPosition->SetZoom( m_pActorWithJudgmentPosition->GetZoom() * fJudgmentZoom );
@@ -1631,15 +1622,7 @@ Player::PlayerNoteFieldPositioner::PlayerNoteFieldPositioner(
 		y_offset= SCALE(tilt, 0.f, -1.f, 0.f, -20.f) * reverse_mult;
 	}
 	player->m_pNoteField->SetY(original_y + y_offset);
-	if(player->m_oitg_zoom_mode)
-	{
-		player->m_pNoteField->SetZoomX(zoom);
-		player->m_pNoteField->SetZoomY(zoom);
-	}
-	else
-	{
-		player->m_pNoteField->SetZoom(zoom);
-	}
+	player->m_pNoteField->SetZoom(zoom);
 	player->m_pNoteField->SetRotationX(tilt_degrees);
 }
 
@@ -3343,7 +3326,6 @@ public:
 		p->GetPlayerTimingData().PushSelf(L);
 		return 1;
 	}
-	GET_SET_BOOL_METHOD(oitg_zoom_mode, m_oitg_zoom_mode);
 	
 	LunaPlayer()
 	{
@@ -3352,7 +3334,6 @@ public:
 		ADD_METHOD( SetActorWithJudgmentPosition );
 		ADD_METHOD( SetActorWithComboPosition );
 		ADD_METHOD( GetPlayerTimingData );
-		ADD_GET_SET_METHODS(oitg_zoom_mode);
 	}
 };
 

--- a/src/Player.h
+++ b/src/Player.h
@@ -124,12 +124,6 @@ public:
 
 	void SetSendJudgmentAndComboMessages( bool b ) { m_bSendJudgmentAndComboMessages = b; }
 
-	// OITG bug:  Actor::SetZoom only sets X and Y.  When mini is applied to
-	// the notefield with SetZoom, it does not affect the range of bumpy.
-	// m_oitg_zoom_mode provides compatibility with that bug.  Only used in
-	// defective mode. -Kyz
-	bool m_oitg_zoom_mode;
-
 	// Lua
 	virtual void PushSelf( lua_State *L );
 	

--- a/src/ScreenGameplay.cpp
+++ b/src/ScreenGameplay.cpp
@@ -1022,6 +1022,9 @@ void ScreenGameplay::InitSongQueues()
 
 ScreenGameplay::~ScreenGameplay()
 {
+	// Turn off oitg zoom mode because the side effect should not persist after
+	// the gimmick simfile that turned it on is over. -Kyz
+	Actor::SetOITGZoomMode(false);
 	GAMESTATE->m_AdjustTokensBySongCostForFinalStageCheck= true;
 	if( this->IsFirstUpdate() )
 	{


### PR DESCRIPTION
Move oitg_zoom_mode from a flag in Player that only affects the notefield to a global flag that affects all actors.  This should make conversions easier, and few if any themes use z position, so it probably won't affect themes.

MrThatKid will need to review and decide whether it's good for his conversions.