### PR TITLE
Fix crash on exit edit mode with empty chart

### DIFF
--- a/src/ScreenEdit.cpp
+++ b/src/ScreenEdit.cpp
@@ -1590,7 +1590,10 @@ void ScreenEdit::Init()
 
 ScreenEdit::~ScreenEdit()
 {
-	m_pSteps->GetTimingData()->ReleaseLookup();
+	if (m_pSteps) {
+		m_pSteps->GetTimingData()->ReleaseLookup();
+	}
+
 	// UGLY: Don't delete the Song's steps.
 	m_SongLastSave.DetachSteps();
 


### PR DESCRIPTION
Potential fix for Issues #1464 and #1466 

Worked when tested locally