### PR TITLE
Fix crash in edit play mode

### DIFF
--- a/src/Style.cpp
+++ b/src/Style.cpp
@@ -85,7 +85,7 @@ void Style::StyleInputToGameInput( int iCol, PlayerNumber pn, vector<GameInput>&
 
 int Style::GameInputToColumn( const GameInput &GameI ) const
 {
-	if( GameI.button < GAME_BUTTON_NEXT )
+	if( GameI.button < GAME_BUTTON_NEXT || GameI.button == GameButton_Invalid )
 		return Column_Invalid;
 	int iColumnIndex = GameI.button - GAME_BUTTON_NEXT;
 	if( m_iInputColumn[GameI.controller][iColumnIndex] == NO_MAPPING )


### PR DESCRIPTION
Edit mode playback would crash if you pressed any keys not mapped.
This includes starting it with "P" if "P" is not mapped.
Problem was Style::GameInputToColumn didn't check for invalid inputs.