### PR TITLE
Fix Mac OS full screen

### DIFF
--- a/src/archutils/Darwin/SMMain.mm
+++ b/src/archutils/Darwin/SMMain.mm
@@ -23,7 +23,8 @@
 @implementation SMApplication
 - (void)fullscreen:(id)sender
 {
-	ArchHooks::SetToggleWindowed();
+//	ArchHooks::SetToggleWindowed();
+	[[self mainWindow] toggleFullScreen:nil];
 }
 
 - (void)sendEvent:(NSEvent *)event

--- a/src/archutils/Darwin/SMMain.mm
+++ b/src/archutils/Darwin/SMMain.mm
@@ -23,7 +23,7 @@
 @implementation SMApplication
 - (void)fullscreen:(id)sender
 {
-//	ArchHooks::SetToggleWindowed();
+	// don't use ArchHooks::SetToggleWindowed(), it makes the screen black
 	[[self mainWindow] toggleFullScreen:nil];
 }
 


### PR DESCRIPTION
Before, going into full screen mode would give a black screen on Mac OS. You could get around it by clicking the green dot in the window bar, which uses Mac OS's full screen mode. This change uses the same fullscreen feature when toggling fullscreen with Alt+Enter or the toolbar option.