### PR TITLE
backport macOS fullscreen fix to 5_1-new

### DIFF
--- a/src/archutils/Darwin/SMMain.mm
+++ b/src/archutils/Darwin/SMMain.mm
@@ -23,7 +23,8 @@
 @implementation SMApplication
 - (void)fullscreen:(id)sender
 {
-	ArchHooks::SetToggleWindowed();
+	// don't use ArchHooks::SetToggleWindowed(), it makes the screen black
+	[[self mainWindow] toggleFullScreen:nil];
 }
 
 - (void)sendEvent:(NSEvent *)event


### PR DESCRIPTION
This backports the recent fullscreen fix for macOS on the _master_ branch to the _5_1-new_ branch.   See: 281d36f05397752b8ad445631b9144853ea34998 

Credit goes to @aeubanks  for the original fix.