### PR TITLE
Implemented SetActualDancePoints & SetPossibleDancePoints

### DIFF
--- a/Docs/Luadoc/Lua.xml
+++ b/Docs/Luadoc/Lua.xml
@@ -1365,9 +1365,8 @@
 			<Function name='GetTapNoteScores'/>
 			<Function name='IsDisqualified'/>
 			<Function name='MaxCombo'/>
-			<Function name='SetActualDancePoints'/>
 			<Function name='SetCurMaxScore'/>
-			<Function name='SetPossibleDancePoints'/>
+			<Function name='SetDancePointLimits'/>
 			<Function name='SetScore'/>
 		</Class>
 		<Class name='PlayerState'>

--- a/Docs/Luadoc/Lua.xml
+++ b/Docs/Luadoc/Lua.xml
@@ -1365,7 +1365,9 @@
 			<Function name='GetTapNoteScores'/>
 			<Function name='IsDisqualified'/>
 			<Function name='MaxCombo'/>
+			<Function name='SetActualDancePoints'/>
 			<Function name='SetCurMaxScore'/>
+			<Function name='SetPossibleDancePoints'/>
 			<Function name='SetScore'/>
 		</Class>
 		<Class name='PlayerState'>

--- a/Docs/Luadoc/LuaDocumentation.xml
+++ b/Docs/Luadoc/LuaDocumentation.xml
@@ -3975,6 +3975,12 @@ save yourself some time, copy this for undocumented things:
 	<Function name='IsDisqualified' return='bool' arguments=''>
 		Returns <code>true</code> if the player was disqualified from ranking.
 	</Function>
+	<Function name='SetActualDancePoints' return='void' arguments='int dp'>
+		Sets the number of Dance Points obtained by the player.
+	</Function>
+	<Function name='SetPossibleDancePoints' return='void' arguments='int dp'>
+		Sets the number of possible Dance Points.
+	</Function>
 </Class>
 <Class name='PlayerState'>
 	<Function name='ApplyPreferredOptionsToOtherLevels' return='void' arguments=''>

--- a/Docs/Luadoc/LuaDocumentation.xml
+++ b/Docs/Luadoc/LuaDocumentation.xml
@@ -3975,11 +3975,8 @@ save yourself some time, copy this for undocumented things:
 	<Function name='IsDisqualified' return='bool' arguments=''>
 		Returns <code>true</code> if the player was disqualified from ranking.
 	</Function>
-	<Function name='SetActualDancePoints' return='void' arguments='int dp'>
-		Sets the number of Dance Points obtained by the player.
-	</Function>
-	<Function name='SetPossibleDancePoints' return='void' arguments='int dp'>
-		Sets the number of possible Dance Points.
+	<Function name='SetDancePointLimits' return='void' arguments='int actual, int possible'>
+		Sets the Dance Point limits of the stage.
 	</Function>
 </Class>
 <Class name='PlayerState'>

--- a/src/PlayerStageStats.cpp
+++ b/src/PlayerStageStats.cpp
@@ -876,7 +876,7 @@ public:
 	}
 	static int SetPossibleDancePoints( T* p, lua_State *L )
 	{
-		if( IArg(1) >= 0 )
+		if( IArg(1) > 0 )
 		{
 			p->m_iPossibleDancePoints = IArg(1);
 			return 1;

--- a/src/PlayerStageStats.cpp
+++ b/src/PlayerStageStats.cpp
@@ -865,6 +865,24 @@ public:
 		}
 		COMMON_RETURN_SELF;
 	}
+	static int SetActualDancePoints( T* p, lua_State *L )                
+	{ 
+		if( IArg(1) >= 0 )
+		{ 
+			p->m_iActualDancePoints = IArg(1); 
+			return 1; 
+		} 
+		COMMON_RETURN_SELF;
+	}
+	static int SetPossibleDancePoints( T* p, lua_State *L )
+	{
+		if( IArg(1) >= 0 )
+		{
+			p->m_iPossibleDancePoints = IArg(1);
+			return 1;
+		}
+		COMMON_RETURN_SELF;
+	}
   
 	static int FailPlayer( T* p, lua_State *L )
 	{
@@ -915,6 +933,8 @@ public:
 		ADD_METHOD( SetScore );
 		ADD_METHOD( GetCurMaxScore );
 		ADD_METHOD( SetCurMaxScore );
+		ADD_METHOD( SetActualDancePoints );
+		ADD_METHOD( SetPossibleDancePoints );
 		ADD_METHOD( FailPlayer );
 		ADD_METHOD( GetSongsPassed );
 		ADD_METHOD( GetSongsPlayed );

--- a/src/PlayerStageStats.cpp
+++ b/src/PlayerStageStats.cpp
@@ -865,20 +865,21 @@ public:
 		}
 		COMMON_RETURN_SELF;
 	}
-	static int SetActualDancePoints( T* p, lua_State *L )                
-	{ 
-		if( IArg(1) >= 0 )
-		{ 
-			p->m_iActualDancePoints = IArg(1); 
-			return 1; 
-		} 
-		COMMON_RETURN_SELF;
-	}
-	static int SetPossibleDancePoints( T* p, lua_State *L )
+	static int SetDancePointLimits( T* p, lua_State *L )
 	{
-		if( IArg(1) > 0 )
+		int actual = IArg(1);
+		int possible = IArg(2);
+		if( actual >= 0 && possible > 0 )
 		{
-			p->m_iPossibleDancePoints = IArg(1);
+			p->m_iPossibleDancePoints = possible;
+			if( actual <= possible )
+			{
+				p->m_iActualDancePoints = actual;
+			}
+			else
+			{
+				p->m_iActualDancePoints = possible;
+			}
 			return 1;
 		}
 		COMMON_RETURN_SELF;
@@ -933,8 +934,7 @@ public:
 		ADD_METHOD( SetScore );
 		ADD_METHOD( GetCurMaxScore );
 		ADD_METHOD( SetCurMaxScore );
-		ADD_METHOD( SetActualDancePoints );
-		ADD_METHOD( SetPossibleDancePoints );
+		ADD_METHOD( SetDancePointLimits );
 		ADD_METHOD( FailPlayer );
 		ADD_METHOD( GetSongsPassed );
 		ADD_METHOD( GetSongsPlayed );


### PR DESCRIPTION
These two methods allow one to set the current stage's possible and actual dance points.
This would allow one to implement score 'bonuses' in simfiles with scripting, or have a minigame simfile (an example would be UKSRT8's "Sort Game") be able to have an actual score instead of 0%

Like the SetScore and SetCurMaxScore functions, a negative amount can't be used as input.