### PR TITLE
Fix pad button to light offset

### DIFF
--- a/src/arch/Lights/LightsDriver_Linux_PIUIO_Leds.cpp
+++ b/src/arch/Lights/LightsDriver_Linux_PIUIO_Leds.cpp
@@ -31,14 +31,14 @@ namespace {
 
 	const char *dance_leds[NUM_GameController][NUM_GameButton] = {
 		{
-			nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
+			nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr
 			"/sys/class/leds/piuio::output20/brightness",
 			"/sys/class/leds/piuio::output21/brightness",
 			"/sys/class/leds/piuio::output18/brightness",
 			"/sys/class/leds/piuio::output19/brightness",
 		},
 		{
-			nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
+			nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr
 			"/sys/class/leds/piuio::output4/brightness",
 			"/sys/class/leds/piuio::output5/brightness",
 			"/sys/class/leds/piuio::output2/brightness",

--- a/src/arch/Lights/LightsDriver_Linux_PIUIO_Leds.cpp
+++ b/src/arch/Lights/LightsDriver_Linux_PIUIO_Leds.cpp
@@ -31,14 +31,14 @@ namespace {
 
 	const char *dance_leds[NUM_GameController][NUM_GameButton] = {
 		{
-			nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr
+			nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
 			"/sys/class/leds/piuio::output20/brightness",
 			"/sys/class/leds/piuio::output21/brightness",
 			"/sys/class/leds/piuio::output18/brightness",
 			"/sys/class/leds/piuio::output19/brightness",
 		},
 		{
-			nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr
+			nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
 			"/sys/class/leds/piuio::output4/brightness",
 			"/sys/class/leds/piuio::output5/brightness",
 			"/sys/class/leds/piuio::output2/brightness",
@@ -48,7 +48,7 @@ namespace {
 
 	const char *pump_leds[NUM_GameController][NUM_GameButton] = {
 		{
-			nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
+			nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
 			"/sys/class/leds/piuio::output2/brightness",
 			"/sys/class/leds/piuio::output3/brightness",
 			"/sys/class/leds/piuio::output4/brightness",
@@ -56,7 +56,7 @@ namespace {
 			"/sys/class/leds/piuio::output6/brightness",
 		},
 		{
-			nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
+			nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
 			"/sys/class/leds/piuio::output18/brightness",
 			"/sys/class/leds/piuio::output19/brightness",
 			"/sys/class/leds/piuio::output20/brightness",


### PR DESCRIPTION
PIUIO pad lights on itg2 dedicab were off by one NUM_GameButton (gb) causing the wrong lights to be triggered when stepping on panels. added another nullptr as a quick fix.


![image](https://user-images.githubusercontent.com/12830125/31314059-34ea31b0-abc4-11e7-8a35-af24d020597d.png)
