### PR TITLE
Fix extra stage MusicWheelItem crash

### DIFF
--- a/src/MusicWheelItem.cpp
+++ b/src/MusicWheelItem.cpp
@@ -305,6 +305,7 @@ void MusicWheelItem::LoadFromWheelItemData( const WheelItemBaseData *pData, int 
 
 void MusicWheelItem::RefreshGrades()
 {
+	if(!IsLoaded()) { return; }
 	const MusicWheelItemData *pWID = dynamic_cast<const MusicWheelItemData*>( m_pData );
 
 	if( pWID == NULL )
@@ -375,6 +376,7 @@ void MusicWheelItem::RefreshGrades()
 
 void MusicWheelItem::HandleMessage( const Message &msg )
 {
+	if(!IsLoaded()) { return; }
 	if( msg == Message_CurrentStepsP1Changed ||
 	    msg == Message_CurrentStepsP2Changed ||
 	    msg == Message_CurrentTrailP1Changed ||


### PR DESCRIPTION
A short jaunt through the code leading up to the crash.

ScreenSelectMusic.cpp, BeginScreen:
```c++
	PlayCommand( "Mods" );
	m_MusicWheel.BeginScreen();
```

That PlayCommand goes to this metric:
_fallback/metrics.ini
```
[ScreenSelectMusic]
ScreenModsCommand=setupmusicstagemods
```

Which goes to _fallback/Scripts/02 StageMods.lua.  That function sets the steps for each player:
```lua
		for pn in ivalues(GAMESTATE:GetHumanPlayers()) do
			GAMESTATE:SetCurrentSteps( pn, steps )
			GAMESTATE:GetPlayerState(pn):SetPlayerOptions( "ModsLevel_Stage", po )
			GAMESTATE:SetPreferredDifficulty( pn, difficulty )
			MESSAGEMAN:Broadcast( "PlayerOptionsChanged", {PlayerNumber = pn} )
		end
```

MusicWheelItem is subscribed to the CurrentSteps*Changed message, so that goes to MusicWheelItem.cpp, HandleMessage.
```c++
		const MusicWheelItemData *pWID = dynamic_cast<const MusicWheelItemData*>( m_pData );
		MusicWheelItemType type = MusicWheelItemType_Invalid;

		switch( pWID->m_Type )
```

Now look back to the first code block.  PlayCommand happens before m_MusicWheel.BeginScreen, which means none of the items are loaded.  Thus, the game segfaults trying to handle that message.

Rather than change the initialization order in ScreenSelectMusic::BeginScreen and have some other thing crash, I decided to just make MusicWheelItem ignore messages if it's not loaded.
```c++
	if(!IsLoaded()) { return; }
```
