### PR TITLE
Eliminate warnings/errors found by PVS-Studio analyzer

### DIFF
--- a/src/archutils/Win32/mapconv.cpp
+++ b/src/archutils/Win32/mapconv.cpp
@@ -141,7 +141,7 @@ int main(int argc, char **argv) {
 		while(readline()) {
 			long grp, start, len;
 
-			if (3!=sscanf(line, "%lx:%lx %lx", &grp, &start, &len))
+			if (3!=sscanf(line, "%ld:%ld %ld", &grp, &start, &len))
 				break;
 
 			if (strstr(line+49, "CODE")) {
@@ -170,7 +170,7 @@ int main(int argc, char **argv) {
 			char symname[4096];
 			int i;
 
-			if (4!=sscanf(line, "%lx:%lx %4095s %lx", &grp, &start, symname, &rva))
+			if (4!=sscanf(line, "%ld:%ld %4095s %ld", &grp, &start, symname, &rva))
 				break;
 
 			if (!(codeseg_flags & (1<<grp)) && strcmp(symname, "___ImageBase") )
@@ -194,7 +194,7 @@ int main(int argc, char **argv) {
 				long grp, start, rva;
 				char symname[4096];
 
-				if (4!=sscanf(line, "%lx:%lx %4095s %lx", &grp, &start, symname, &rva))
+				if (4!=sscanf(line, "%ld:%ld %4095s %ld", &grp, &start, symname, &rva))
 					break;
 
 				if (!(codeseg_flags & (1<<grp)))
@@ -218,7 +218,7 @@ int main(int argc, char **argv) {
 			long grp, start, rva;
 			char symname[4096];
 
-			sscanf(rvabuf[i].line, "%lx:%lx %4095s %lx", &grp, &start, symname, &rva);
+			sscanf(rvabuf[i].line, "%ld:%ld %4095s %ld", &grp, &start, symname, &rva);
 
 			grpstart[grp] = rva - start;
 

--- a/src/rage/RageColor.hpp
+++ b/src/rage/RageColor.hpp
@@ -66,7 +66,7 @@ namespace Rage
 	inline Color operator*(Color lhs, Color const &rhs)
 	{
 		lhs *= rhs;
-		return rhs;
+		return lhs;
 	}
 	
 	inline Color operator*(Color lhs, float rhs)

--- a/src/rage/RageMatrix.cpp
+++ b/src/rage/RageMatrix.cpp
@@ -4,6 +4,7 @@ using namespace Rage;
 
 Matrix::Matrix()
 {
+	memset(m, 0, sizeof(float)*4*4);
 }
 
 Matrix::Matrix(Matrix const &rhs)

--- a/src/rage/RageMatrix.cpp
+++ b/src/rage/RageMatrix.cpp
@@ -1,4 +1,5 @@
 #include "RageMatrix.hpp"
+#include <cstring>
 
 using namespace Rage;
 

--- a/src/rage/RageMatrix.hpp
+++ b/src/rage/RageMatrix.hpp
@@ -62,7 +62,7 @@ namespace Rage
 	{
 		for (auto i = 0; i < 4; ++i)
 		{
-			for (auto j = 0; j < 4; ++i)
+			for (auto j = 0; j < 4; ++j)
 			{
 				if (lhs(i, j) != rhs(i, j))
 				{

--- a/src/rage/RageString.cpp
+++ b/src/rage/RageString.cpp
@@ -159,7 +159,7 @@ std::vector<S> do_split( S const &source, C const delimitor, Rage::EmptyEntries 
 		{
 			pos = source.size();
 		}
-		if( pos-startpos > 0 || shouldIgnore == Rage::EmptyEntries::include )
+		if( pos != startpos || shouldIgnore == Rage::EmptyEntries::include )
 		{
 			/* Optimization: if we're copying the whole string, avoid substr; this
 			 * allows this copy to be refcounted, which is much faster. */


### PR DESCRIPTION
Hello!
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A list of bugs, found using PVS-Studio analyzer:

- [V654](https://www.viva64.com/en/w/v654/) The condition 'j < 4' of loop is always true. ragematrix.hpp 65
- [V533](https://www.viva64.com/en/w/v533/) It is likely that a wrong variable is being incremented inside the 'for' operator. Consider reviewing 'i'. ragematrix.hpp 65
- [V576](https://www.viva64.com/en/w/v576/) Incorrect format. Consider checking the third actual argument of the 'sscanf' function. A pointer to the unsigned long type is expected. mapconv.cpp 144
- [V576](https://www.viva64.com/en/w/v576/) Incorrect format. Consider checking the third actual argument of the 'sscanf' function. A pointer to the unsigned long type is expected. mapconv.cpp 173
- [V576](https://www.viva64.com/en/w/v576/) Incorrect format. Consider checking the third actual argument of the 'sscanf' function. A pointer to the unsigned long type is expected. mapconv.cpp 197
- [V576](https://www.viva64.com/en/w/v576/) Incorrect format. Consider checking the third actual argument of the 'sscanf' function. A pointer to the unsigned long type is expected. mapconv.cpp 221
- [V555](https://www.viva64.com/en/w/v555/) The expression 'pos - startpos > 0' will work as 'pos != startpos'. ragestring.cpp 162
- [V1001](https://www.viva64.com/en/w/v1001/) The 'lhs' variable is assigned but is not used until the end of the function. ragecolor.hpp 68
- [V730](https://www.viva64.com/en/w/v730/) Not all members of a class are initialized inside the constructor. Consider inspecting: m. ragematrix.cpp 5

Did not fix, but please take a look:

- [V597](https://www.viva64.com/en/w/v597/) The compiler could delete the 'memset' function call, which is used to flush 'reap' object. The RtlSecureZeroMemory() function should be used to erase the private data. block.c 133
^--- In lots of places!

There are actually way more warnings were found but you can inspect them on your own using PVS-Studio analyzer.