### PR TITLE
Build with Windows SDK instead of DirectX SDK

### DIFF
--- a/StepmaniaCore.cmake
+++ b/StepmaniaCore.cmake
@@ -255,7 +255,6 @@ endif()
 
 if(WIN32)
   set(SYSTEM_PCRE_FOUND FALSE)
-  find_package(DirectX REQUIRED)
 
   if (MINGW AND WITH_FFMPEG)
     include("${SM_CMAKE_DIR}/SetupFfmpeg.cmake")

--- a/src/CMakeData-os.cmake
+++ b/src/CMakeData-os.cmake
@@ -48,6 +48,7 @@ else()
       "archutils/Win32/CrashHandlerNetworking.cpp"
       "archutils/Win32/DebugInfoHunt.cpp"
       "archutils/Win32/DialogUtil.cpp"
+	  "archutils/Win32/DirectXGuids.cpp"
       "archutils/Win32/DirectXHelpers.cpp"
       "archutils/Win32/ErrorStrings.cpp"
       "archutils/Win32/GetFileInformation.cpp"

--- a/src/RageDisplay.cpp
+++ b/src/RageDisplay.cpp
@@ -776,6 +776,13 @@ bool RageDisplay::SaveScreenshot( std::string sPath, GraphicsFileFormat format )
 	RageTimer timer;
 	RageSurface *surface = this->CreateScreenshot();
 //	LOG->Trace( "CreateScreenshot took %f seconds", timer.GetDeltaTime() );
+
+	if (nullptr == surface)
+	{
+		LOG->Trace("CreateScreenshot failed to return a surface");
+		return false;
+	}
+
 	/* Unless we're in lossless, resize the image to 640x480.  If we're saving lossy,
 	 * there's no sense in saving 1280x960 screenshots, and we don't want to output
 	 * screenshots in a strange (non-1) sample aspect ratio. */

--- a/src/RageDisplay_D3D.cpp
+++ b/src/RageDisplay_D3D.cpp
@@ -17,18 +17,15 @@
 #include "DisplaySpec.h"
 #include "LocalizedString.h"
 
-#include <D3dx9tex.h>
 #include <d3d9.h>
-#include <dxerr.h>
 
 #include "archutils/Win32/GraphicsWindow.h"
+#include "archutils/Win32/DirectXHelpers.h"
 
 // Static libraries
 // load Windows D3D9 dynamically
 #if defined(_MSC_VER)
 	#pragma comment(lib, "d3d9.lib")
-	#pragma comment(lib, "d3dx9.lib")
-	#pragma comment(lib, "DxErr.lib")
 #endif
 
 #include <math.h>
@@ -36,11 +33,6 @@
 
 using std::list;
 using std::vector;
-
-std::string GetErrorString( HRESULT hr )
-{
-	return DXGetErrorString(hr);
-}
 
 // Globals
 HMODULE				g_D3D9_Module = nullptr;
@@ -666,6 +658,7 @@ RageSurface* RageDisplay_D3D::CreateScreenshot()
 {
 	RageSurface * result = nullptr;
 
+#if 0 // FIX ME
 	// Get the back buffer.
 	IDirect3DSurface9* pSurface;
 	if( SUCCEEDED( g_pd3dDevice->GetBackBuffer( 0, 0, D3DBACKBUFFER_TYPE_MONO, &pSurface ) ) )
@@ -715,6 +708,7 @@ RageSurface* RageDisplay_D3D::CreateScreenshot()
 
 		pSurface->Release();
 	}
+#endif
 
 	return result;
 }

--- a/src/arch/InputHandler/InputHandler_DirectInput.cpp
+++ b/src/arch/InputHandler/InputHandler_DirectInput.cpp
@@ -20,6 +20,12 @@
 #include <WbemIdl.h>
 #include <OleAuto.h>
 
+// this may not be defined if we are using an older SDK. (for instance, toolsetversion v140_xp does not define it)
+// the number was taken from the documentation
+#ifndef XUSER_MAX_COUNT
+#define XUSER_MAX_COUNT 4
+#endif
+
 using std::vector;
 
 REGISTER_INPUT_HANDLER_CLASS2( DirectInput, DInput );

--- a/src/arch/InputHandler/InputHandler_DirectInputHelper.cpp
+++ b/src/arch/InputHandler/InputHandler_DirectInputHelper.cpp
@@ -8,9 +8,6 @@
 
 #if defined(_MSC_VER)
 #pragma comment(lib, "dinput8.lib")
-#if defined(_WINDOWS)
-#pragma comment(lib, "dxguid.lib")
-#endif
 #endif
 LPDIRECTINPUT8 g_dinput = nullptr;
 

--- a/src/arch/LowLevelWindow/LowLevelWindow_Win32.cpp
+++ b/src/arch/LowLevelWindow/LowLevelWindow_Win32.cpp
@@ -193,10 +193,12 @@ std::string LowLevelWindow_Win32::TryVideoMode( const VideoModeParams &p, bool &
 		/* Set the pixel format. */
 		if( !SetPixelFormat(GraphicsWindow::GetHDC(), iPixelFormat, &pixfmt) )
 		{
+			DWORD err = GetLastError();
+
 			/* Destroy the window. */
 			DestroyGraphicsWindowAndOpenGLContext();
 
-			return werr_format( GetLastError(), "Pixel format failed" );
+			return werr_format( err, "Pixel format failed" );
 		}
 
 		DescribePixelFormat( GraphicsWindow::GetHDC(), iPixelFormat, sizeof(g_CurrentPixelFormat), &g_CurrentPixelFormat );
@@ -209,14 +211,16 @@ std::string LowLevelWindow_Win32::TryVideoMode( const VideoModeParams &p, bool &
 		g_HGLRC = wglCreateContext( GraphicsWindow::GetHDC() );
 		if ( g_HGLRC == nullptr )
 		{
+			DWORD err = GetLastError();
 			DestroyGraphicsWindowAndOpenGLContext();
-			return hr_format( GetLastError(), "wglCreateContext" );
+			return werr_format( err, "wglCreateContext" );
 		}
 
 		if( !wglMakeCurrent( GraphicsWindow::GetHDC(), g_HGLRC ) )
 		{
+			DWORD err = GetLastError();
 			DestroyGraphicsWindowAndOpenGLContext();
-			return hr_format( GetLastError(), "wglCreateContext" );
+			return werr_format( err, "wglCreateContext" );
 		}
 	}
 	return std::string();	// we set the video mode successfully

--- a/src/archutils/Win32/DirectXErrorList.h
+++ b/src/archutils/Win32/DirectXErrorList.h
@@ -1,0 +1,196 @@
+// This file is intended to be included in the middle of a function after
+// defining the macro to do what you want.
+
+#if defined(__DINPUT_INCLUDED__)
+// -------------------------------------------------------------
+// dinput.h error codes
+// -------------------------------------------------------------
+DXERRMSG(DI_OK, "DI_OK")
+DXERRMSG(DI_NOTATTACHED, "DI_NOTATTACHED")
+//DXERRMSG(DI_BUFFEROVERFLOW, "DI_BUFFEROVERFLOW")
+//DXERRMSG(DI_PROPNOEFFECT, "DI_PROPNOEFFECT")
+//DXERRMSG(DI_NOEFFECT, "DI_NOEFFECT")
+DXERRMSG(DI_POLLEDDEVICE, "DI_POLLEDDEVICE")
+DXERRMSG(DI_DOWNLOADSKIPPED, "DI_DOWNLOADSKIPPED")
+DXERRMSG(DI_EFFECTRESTARTED, "DI_EFFECTRESTARTED")
+//DXERRMSG(DI_SETTINGSNOTSAVED_ACCESSDENIED, "DI_SETTINGSNOTSAVED_ACCESSDENIED")
+//DXERRMSG(DI_SETTINGSNOTSAVED_DISKFULL, "DI_SETTINGSNOTSAVED_DISKFULL")
+DXERRMSG(DI_TRUNCATED, "DI_TRUNCATED")
+DXERRMSG(DI_TRUNCATEDANDRESTARTED, "DI_TRUNCATEDANDRESTARTED")
+DXERRMSG(DI_WRITEPROTECT, "DI_WRITEPROTECT")
+DXERRMSG(DIERR_OLDDIRECTINPUTVERSION, "The application requires a newer version of DirectInput.")
+DXERRMSG(DIERR_GENERIC, "DIERR_GENERIC")
+//DXERRMSG(DIERR_OLDDIRECTINPUTVERSION, "DIERR_OLDDIRECTINPUTVERSION")
+DXERRMSG(DIERR_BETADIRECTINPUTVERSION, "The application was written for an unsupported prerelease version of DirectInput.")
+DXERRMSG(DIERR_BADDRIVERVER, "The object could not be created due to an incompatible driver version or mismatched or incomplete driver components.")
+DXERRMSG(DIERR_DEVICENOTREG, "DIERR_DEVICENOTREG")
+DXERRMSG(DIERR_NOTFOUND, "The requested object does not exist.")
+//DXERRMSG(DIERR_OBJECTNOTFOUND, "DIERR_OBJECTNOTFOUND")
+DXERRMSG(DIERR_INVALIDPARAM, "DIERR_INVALIDPARAM")
+DXERRMSG(DIERR_NOINTERFACE, "DIERR_NOINTERFACE")
+//DXERRMSG(DIERR_GENERIC, "DIERR_GENERIC")
+DXERRMSG(DIERR_OUTOFMEMORY, "DIERR_OUTOFMEMORY")
+DXERRMSG(DIERR_UNSUPPORTED, "DIERR_UNSUPPORTED")
+DXERRMSG(DIERR_NOTINITIALIZED, "This object has not been initialized")
+DXERRMSG(DIERR_ALREADYINITIALIZED, "This object is already initialized")
+DXERRMSG(DIERR_NOAGGREGATION, "DIERR_NOAGGREGATION")
+DXERRMSG(DIERR_OTHERAPPHASPRIO, "DIERR_OTHERAPPHASPRIO")
+DXERRMSG(DIERR_INPUTLOST, "Access to the device has been lost.  It must be re-acquired.")
+DXERRMSG(DIERR_ACQUIRED, "The operation cannot be performed while the device is acquired.")
+DXERRMSG(DIERR_NOTACQUIRED, "The operation cannot be performed unless the device is acquired.")
+//DXERRMSG(DIERR_READONLY, "DIERR_READONLY")
+//DXERRMSG(DIERR_HANDLEEXISTS, "DIERR_HANDLEEXISTS")
+DXERRMSG(DIERR_INSUFFICIENTPRIVS, "Unable to IDirectInputJoyConfig_Acquire because the user does not have sufficient privileges to change the joystick configuration. & An invalid media type was specified")
+DXERRMSG(DIERR_DEVICEFULL, "The device is full. & An invalid media subtype was specified.")
+DXERRMSG(DIERR_MOREDATA, "Not all the requested information fit into the buffer. & This object can only be created as an aggregated object.")
+DXERRMSG(DIERR_NOTDOWNLOADED, "The effect is not downloaded. & The enumerator has become invalid.")
+DXERRMSG(DIERR_HASEFFECTS, "The device cannot be reinitialized because there are still effects attached to it. & At least one of the pins involved in the operation is already connected.")
+DXERRMSG(DIERR_NOTEXCLUSIVEACQUIRED, "The operation cannot be performed unless the device is acquired in DISCL_EXCLUSIVE mode. & This operation cannot be performed because the filter is active.")
+DXERRMSG(DIERR_INCOMPLETEEFFECT, "The effect could not be downloaded because essential information is missing.  For example, no axes have been associated with the effect, or no type-specific information has been created. & One of the specified pins supports no media types.")
+DXERRMSG(DIERR_NOTBUFFERED, "Attempted to read buffered device data from a device that is not buffered. & There is no common media type between these pins.")
+DXERRMSG(DIERR_EFFECTPLAYING, "An attempt was made to modify parameters of an effect while it is playing.  Not all hardware devices support altering the parameters of an effect while it is playing. & Two pins of the same direction cannot be connected together.")
+DXERRMSG(DIERR_UNPLUGGED, "The operation could not be completed because the device is not plugged in. & The operation cannot be performed because the pins are not connected.")
+DXERRMSG(DIERR_REPORTFULL, "SendDeviceData failed because more information was requested to be sent than can be sent to the device.  Some devices have restrictions on how much data can be sent to them.  (For example, there might be a limit on the number of buttons that can be pressed at once.) & No sample buffer allocator is available.")
+DXERRMSG(DIERR_MAPFILEFAIL, "A mapper file function failed because reading or writing the user or IHV settings file failed. & A run-time error occurred.")
+#endif
+
+#if defined(__DINPUTD_INCLUDED__)
+// -------------------------------------------------------------
+// dinputd.h error codes
+// -------------------------------------------------------------
+DXERRMSG(DIERR_NOMOREITEMS, "No more items.")
+DXERRMSG(DIERR_DRIVERFIRST, "Device driver-specific codes. Unless the specific driver has been precisely identified, no meaning should be attributed to these values other than that the driver originated the error.")
+DXERRMSG(DIERR_DRIVERFIRST + 1, "DIERR_DRIVERFIRST+1")
+DXERRMSG(DIERR_DRIVERFIRST + 2, "DIERR_DRIVERFIRST+2")
+DXERRMSG(DIERR_DRIVERFIRST + 3, "DIERR_DRIVERFIRST+3")
+DXERRMSG(DIERR_DRIVERFIRST + 4, "DIERR_DRIVERFIRST+4")
+DXERRMSG(DIERR_DRIVERFIRST + 5, "DIERR_DRIVERFIRST+5")
+DXERRMSG(DIERR_DRIVERLAST, "Device installer errors.")
+DXERRMSG(DIERR_INVALIDCLASSINSTALLER, "Registry entry or DLL for class installer invalid or class installer not found.")
+DXERRMSG(DIERR_CANCELLED, "The user cancelled the install operation. & The stream already has allocated samples and the surface doesn't match the sample format.")
+DXERRMSG(DIERR_BADINF, "The INF file for the selected device could not be found or is invalid or is damaged. & The specified purpose ID can't be used for the call.")
+#endif
+
+#if defined(_D3D9_H_)
+// -------------------------------------------------------------
+// d3d9.h error codes
+// -------------------------------------------------------------
+//DXERRMSG(D3D_OK, "Ok")
+DXERRMSG(D3DERR_WRONGTEXTUREFORMAT, "Wrong texture format")
+DXERRMSG(D3DERR_UNSUPPORTEDCOLOROPERATION, "Unsupported color operation")
+DXERRMSG(D3DERR_UNSUPPORTEDCOLORARG, "Unsupported color arg")
+DXERRMSG(D3DERR_UNSUPPORTEDALPHAOPERATION, "Unsupported alpha operation")
+DXERRMSG(D3DERR_UNSUPPORTEDALPHAARG, "Unsupported alpha arg")
+DXERRMSG(D3DERR_TOOMANYOPERATIONS, "Too many operations")
+DXERRMSG(D3DERR_CONFLICTINGTEXTUREFILTER, "Conflicting texture filter")
+DXERRMSG(D3DERR_UNSUPPORTEDFACTORVALUE, "Unsupported factor value")
+DXERRMSG(D3DERR_CONFLICTINGRENDERSTATE, "Conflicting render state")
+DXERRMSG(D3DERR_UNSUPPORTEDTEXTUREFILTER, "Unsupported texture filter")
+DXERRMSG(D3DERR_CONFLICTINGTEXTUREPALETTE, "Conflicting texture palette")
+DXERRMSG(D3DERR_DRIVERINTERNALERROR, "Driver internal error")
+DXERRMSG(D3DERR_NOTFOUND, "Not found")
+DXERRMSG(D3DERR_MOREDATA, "More data")
+DXERRMSG(D3DERR_DEVICELOST, "Device lost")
+DXERRMSG(D3DERR_DEVICENOTRESET, "Device not reset")
+DXERRMSG(D3DERR_NOTAVAILABLE, "Not available")
+DXERRMSG(D3DERR_OUTOFVIDEOMEMORY, "Out of video memory")
+DXERRMSG(D3DERR_INVALIDDEVICE, "Invalid device")
+DXERRMSG(D3DERR_INVALIDCALL, "Invalid call")
+DXERRMSG(D3DERR_DRIVERINVALIDCALL, "Driver invalid call")
+DXERRMSG(D3DERR_WASSTILLDRAWING, "Was Still Drawing")
+DXERRMSG(D3DOK_NOAUTOGEN, "The call succeeded but there won't be any mipmaps generated")
+
+// Extended for Windows Vista
+DXERRMSG(D3DERR_DEVICEREMOVED, "Hardware device was removed")
+DXERRMSG(S_NOT_RESIDENT, "Resource not resident in memory")
+DXERRMSG(S_RESIDENT_IN_SHARED_MEMORY, "Resource resident in shared memory")
+DXERRMSG(S_PRESENT_MODE_CHANGED, "Desktop display mode has changed")
+DXERRMSG(S_PRESENT_OCCLUDED, "Client window is occluded (minimized or other fullscreen)")
+DXERRMSG(D3DERR_DEVICEHUNG, "Hardware adapter reset by OS")
+
+// Extended for Windows 7
+DXERRMSG(D3DERR_UNSUPPORTEDOVERLAY, "Overlay is not supported")
+DXERRMSG(D3DERR_UNSUPPORTEDOVERLAYFORMAT, "Overlay format is not supported")
+DXERRMSG(D3DERR_CANNOTPROTECTCONTENT, "Contect protection not available")
+DXERRMSG(D3DERR_UNSUPPORTEDCRYPTO, "Unsupported cryptographic system")
+DXERRMSG(D3DERR_PRESENT_STATISTICS_DISJOINT, "Presentation statistics are disjoint")
+#endif
+
+
+#if defined(__DSOUND_INCLUDED__)
+// -------------------------------------------------------------
+// dsound.h error codes
+// -------------------------------------------------------------
+//DXERRMSG(DS_OK, "")
+DXERRMSG(DS_NO_VIRTUALIZATION, "The call succeeded, but we had to substitute the 3D algorithm")
+DXERRMSG(DSERR_ALLOCATED, "The call failed because resources (such as a priority level) were already being used by another caller")
+DXERRMSG(DSERR_CONTROLUNAVAIL, "The control (vol, pan, etc.) requested by the caller is not available")
+//DXERRMSG(DSERR_INVALIDPARAM, "DSERR_INVALIDPARAM")
+DXERRMSG(DSERR_INVALIDCALL, "This call is not valid for the current state of this object")
+//DXERRMSG(DSERR_GENERIC, "DSERR_GENERIC")
+DXERRMSG(DSERR_PRIOLEVELNEEDED, "The caller does not have the priority level required for the function to succeed")
+//DXERRMSG(DSERR_OUTOFMEMORY, "Not enough free memory is available to complete the operation")
+DXERRMSG(DSERR_BADFORMAT, "The specified WAVE format is not supported")
+//DXERRMSG(DSERR_UNSUPPORTED, "DSERR_UNSUPPORTED")
+DXERRMSG(DSERR_NODRIVER, "No sound driver is available for use")
+DXERRMSG(DSERR_ALREADYINITIALIZED, "This object is already initialized")
+//DXERRMSG(DSERR_NOAGGREGATION, "DSERR_NOAGGREGATION")
+DXERRMSG(DSERR_BUFFERLOST, "The buffer memory has been lost, and must be restored")
+DXERRMSG(DSERR_OTHERAPPHASPRIO, "Another app has a higher priority level, preventing this call from succeeding")
+DXERRMSG(DSERR_UNINITIALIZED, "This object has not been initialized")
+//DXERRMSG(DSERR_NOINTERFACE, "DSERR_NOINTERFACE")
+//DXERRMSG(DSERR_ACCESSDENIED, "DSERR_ACCESSDENIED")
+DXERRMSG(DSERR_BUFFERTOOSMALL, "Tried to create a DSBCAPS_CTRLFX buffer shorter than DSBSIZE_FX_MIN milliseconds")
+DXERRMSG(DSERR_DS8_REQUIRED, "Attempt to use DirectSound 8 functionality on an older DirectSound object")
+DXERRMSG(DSERR_SENDLOOP, "A circular loop of send effects was detected")
+DXERRMSG(DSERR_BADSENDBUFFERGUID, "The GUID specified in an audiopath file does not match a valid MIXIN buffer")
+DXERRMSG(DSERR_OBJECTNOTFOUND, "The object requested was not found (numerically equal to DMUS_E_NOT_FOUND)")
+
+DXERRMSG(DSERR_FXUNAVAILABLE, "Requested effects are not available")
+#endif
+
+#if defined(__d3d10_h__)
+// -------------------------------------------------------------
+// d3d10.h error codes
+// -------------------------------------------------------------
+DXERRMSG(D3D10_ERROR_TOO_MANY_UNIQUE_STATE_OBJECTS, "There are too many unique state objects.")
+DXERRMSG(D3D10_ERROR_FILE_NOT_FOUND, "File not found")
+#endif
+
+#if defined(__dxgitype_h__)
+// -------------------------------------------------------------
+// dxgi.h error codes
+// -------------------------------------------------------------
+DXERRMSG(DXGI_STATUS_OCCLUDED, "The target window or output has been occluded. The application should suspend rendering operations if possible.")
+DXERRMSG(DXGI_STATUS_CLIPPED, "Target window is clipped.")
+DXERRMSG(DXGI_STATUS_NO_REDIRECTION, "")
+DXERRMSG(DXGI_STATUS_NO_DESKTOP_ACCESS, "No access to desktop.")
+DXERRMSG(DXGI_STATUS_GRAPHICS_VIDPN_SOURCE_IN_USE, "")
+DXERRMSG(DXGI_STATUS_MODE_CHANGED, "Display mode has changed")
+DXERRMSG(DXGI_STATUS_MODE_CHANGE_IN_PROGRESS, "Display mode is changing")
+DXERRMSG(DXGI_ERROR_INVALID_CALL, "The application has made an erroneous API call that it had enough information to avoid. This error is intended to denote that the application should be altered to avoid the error. Use of the debug version of the DXGI.DLL will provide run-time debug output with further information.")
+DXERRMSG(DXGI_ERROR_NOT_FOUND, "The item requested was not found. For GetPrivateData calls, this means that the specified GUID had not been previously associated with the object.")
+DXERRMSG(DXGI_ERROR_MORE_DATA, "The specified size of the destination buffer is too small to hold the requested data.")
+DXERRMSG(DXGI_ERROR_UNSUPPORTED, "Unsupported.")
+DXERRMSG(DXGI_ERROR_DEVICE_REMOVED, "Hardware device removed.")
+DXERRMSG(DXGI_ERROR_DEVICE_HUNG, "Device hung due to badly formed commands.")
+DXERRMSG(DXGI_ERROR_DEVICE_RESET, "Device reset due to a badly formed commant.")
+DXERRMSG(DXGI_ERROR_WAS_STILL_DRAWING, "Was still drawing.")
+DXERRMSG(DXGI_ERROR_FRAME_STATISTICS_DISJOINT, "The requested functionality is not supported by the device or the driver.")
+DXERRMSG(DXGI_ERROR_GRAPHICS_VIDPN_SOURCE_IN_USE, "The requested functionality is not supported by the device or the driver.")
+DXERRMSG(DXGI_ERROR_DRIVER_INTERNAL_ERROR, "An internal driver error occurred.")
+DXERRMSG(DXGI_ERROR_NONEXCLUSIVE, "The application attempted to perform an operation on an DXGI output that is only legal after the output has been claimed for exclusive owenership.")
+DXERRMSG(DXGI_ERROR_NOT_CURRENTLY_AVAILABLE, "The requested functionality is not supported by the device or the driver.")
+DXERRMSG(DXGI_ERROR_REMOTE_CLIENT_DISCONNECTED, "Remote desktop client disconnected.")
+DXERRMSG(DXGI_ERROR_REMOTE_OUTOFMEMORY, "Remote desktop client is out of memory.")
+#endif
+
+#if defined(__d3d11_h__)
+// -------------------------------------------------------------
+// d3d11.h error codes
+// -------------------------------------------------------------
+DXERRMSG(D3D11_ERROR_TOO_MANY_UNIQUE_STATE_OBJECTS, "There are too many unique state objects.")
+DXERRMSG(D3D11_ERROR_FILE_NOT_FOUND, "File not found")
+DXERRMSG(D3D11_ERROR_TOO_MANY_UNIQUE_VIEW_OBJECTS, "Therea are too many unique view objects.")
+DXERRMSG(D3D11_ERROR_DEFERRED_CONTEXT_MAP_WITHOUT_INITIAL_DISCARD, "Deferred context requires Map-Discard usage pattern")
+#endif

--- a/src/archutils/Win32/DirectXGuids.cpp
+++ b/src/archutils/Win32/DirectXGuids.cpp
@@ -1,0 +1,13 @@
+#include "global.h"
+
+// The purpose of this file is to define the various GUIDs we need, which
+// we used to get via dxguid.lib in the DirectX SDK. The DirectX SDK has
+// been discontinued and (mostly) rolled into the Windows SDK, but it is
+// missing a few features. One of which is dxguid.lib.
+
+// if you wind up running into other GUIDs you need, add them here
+
+#define INITGUID
+
+#define DIRECTINPUT_VERSION 0x0800
+#include <dinput.h>

--- a/src/archutils/Win32/DirectXHelpers.cpp
+++ b/src/archutils/Win32/DirectXHelpers.cpp
@@ -8,9 +8,22 @@ std::string hr_final(std::string const &msg, HRESULT hr)
 	return msg + fmt::sprintf(" (%s)", sError.c_str());
 }
 
+#define DIRECTINPUT_VERSION 0x0800
+#define DIRECTSOUND_VERSION 0x0700
+#include <dinput.h>
+#include <d3d9.h>
+#include <MMSystem.h> // dsound needs this
+#include <dsound.h>
+
+#define DXERRMSG(hrcode, dummy) case hrcode: return #hrcode;
+
 std::string GetErrorString(HRESULT hr)
 {
-	return "FIX ME";
+	switch (hr)
+	{
+#include "DirectXErrorList.h"
+	default: return fmt::sprintf("unknown HRESULT 0x%8.8X", hr);
+	}
 }
 
 /*

--- a/src/archutils/Win32/DirectXHelpers.cpp
+++ b/src/archutils/Win32/DirectXHelpers.cpp
@@ -1,25 +1,16 @@
 #include "global.h"
-#include "DirectXHelpers.h"
 #include "RageUtil.h"
+#include "DirectXHelpers.h"
 
-#include <windows.h>
-#if defined(USE_DXERR9)
-#include <dxerr9.h>
-#else
-#include <dxerr.h>
-#endif
-#if defined(_MSC_VER)
-#  pragma comment(lib, "dxerr.lib")
-#endif
-
-std::string hr_final(std::string const &msg, int hr)
+std::string hr_final(std::string const &msg, HRESULT hr)
 {
-#if defined(USE_DXERR9)
-	const char *szError = DXGetErrorString9(hr);
-#else
-	const char *szError = DXGetErrorString(hr);
-#endif
-	return msg + fmt::sprintf(" (%s)", szError);
+	const std::string sError = GetErrorString(hr);
+	return msg + fmt::sprintf(" (%s)", sError.c_str());
+}
+
+std::string GetErrorString(HRESULT hr)
+{
+	return "FIX ME";
 }
 
 /*

--- a/src/archutils/Win32/DirectXHelpers.h
+++ b/src/archutils/Win32/DirectXHelpers.h
@@ -4,11 +4,15 @@
 #include <string>
 #include "format.h"
 
+#include <Windows.h>
+
+std::string GetErrorString(HRESULT hr);
+
 // Meant to be private.
-std::string hr_final(std::string const &msg, int hr);
+std::string hr_final(std::string const &msg, HRESULT hr);
 
 template<typename... Args>
-std::string hr_format(int hr, std::string const &msg, Args const & ...args)
+std::string hr_format(HRESULT hr, std::string const &msg, Args const & ...args)
 {
 	std::string item = fmt::sprintf(msg, args...);
 	return hr_final(item, hr);

--- a/src/archutils/Win32/ErrorStrings.h
+++ b/src/archutils/Win32/ErrorStrings.h
@@ -10,7 +10,7 @@ template<typename... Args>
 std::string werr_format(int err, std::string const &msg, Args const & ...args)
 {
 	char buf[1024] = "";
-	FormatMessage(FORMAT_MESSAGE_FROM_SYSTEM,
+	FormatMessage(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
 		0, err, 0, buf, sizeof(buf), nullptr);
 
 	// Why is FormatMessage returning text ending with \r\n? (who? -aj)


### PR DESCRIPTION
Replaced most of the things missing from the Windows SDK version of the DirectX APIs so Stepmania can be built without needing the (old and deprecated) DirectX SDK.

One missing piece to still replace: d3d screenshot. The previous implementation used D3DX to copy/convert the backbuffer to RGBA. But D3DX was removed when DirectX was moved into the Windows SDK.