### PR TITLE
Add menu input mode choices to default theme config.

### DIFF
--- a/Themes/_fallback/Scripts/04 menu.lua
+++ b/Themes/_fallback/Scripts/04 menu.lua
@@ -1096,22 +1096,23 @@ menu_controller_mt= {
 					self:update_cursor()
 					return sound_ret(sound)
 				end,
-				two_dir_adjust= function(dir, adj_sound, curs_sound)
-					if self.in_adjust_mode then
-						return sub_handlers.adjust(dir, adj_sound)
-					else
-						return sub_handlers.cursor_move(dir, curs_sound)
-					end
-				end,
 				two_dir_interact= function()
 					if item.info.func then
 						return self:handle_menu_action(item:interact(big))
 					elseif item.info.adjust then
-						self.in_adjust_mode= true
-						if self.cursor then
-							self.cursor:playcommand("AdjustMode")
+						if self.in_adjust_mode then
+							self.in_adjust_mode= false
+							if self.cursor then
+								self.cursor:playcommand("NormalMode")
+							end
+							return sound_ret("adjust_mode_off")
+						else
+							self.in_adjust_mode= true
+							if self.cursor then
+								self.cursor:playcommand("AdjustMode")
+							end
+							return sound_ret("adjust_mode_on")
 						end
-						return sound_ret("adjust_mode_on")
 					end
 				end,
 				select_jump= function()
@@ -1126,6 +1127,13 @@ menu_controller_mt= {
 					end
 				end,
 			}
+			sub_handlers.two_dir_adjust= function(dir, adj_sound, curs_sound)
+					if self.in_adjust_mode then
+						return sub_handlers.adjust(dir, adj_sound)
+					else
+						return sub_handlers.cursor_move(dir, curs_sound)
+					end
+			end
 			local button_to_sub= {
 				two_direction= {
 					left= {"two_dir_adjust", -1, "adjust_down", "cursor_up"},

--- a/Themes/default/BGAnimations/ScreenNestyPlayerOptions overlay.lua
+++ b/Themes/default/BGAnimations/ScreenNestyPlayerOptions overlay.lua
@@ -168,8 +168,7 @@ end
 local menu_layer, menu_controllers= nesty_menus.make_menu_actors{
 	actors= menu_actors,
 	data= menu_data,
-	-- TODO: config or something for input_mode
-	input_mode= "four_direction",
+	input_mode= theme_config:get_data().menu_mode,
 	item_change_callback= update_explanation,
 	exit_callback= back_to_ssm,
 	translation_section= "notefield_options",

--- a/Themes/default/BGAnimations/ScreenOptionsTheme overlay.lua
+++ b/Themes/default/BGAnimations/ScreenOptionsTheme overlay.lua
@@ -10,6 +10,7 @@ local options= {
 	{"item", theme_config, "TimingDisplay", "bool"},
 	{"item", theme_config, "GameplayFooter", "bool"},
 	{"item", theme_config, "Use12HourClock", "bool"},
+	{"item", theme_config, "menu_mode", "choice", {choices= {"two_direction", "two_direction_with_select", "four_direction"}}},
 }
 
 local menu_controller= setmetatable({}, menu_controller_mt)
@@ -45,7 +46,7 @@ return Def.ActorFrame{
 	OnCommand= function(self)
 		menu_sounds= nesty_menus.make_menu_sound_lookup(self)
 		menu_controller:init{
-			actor= self:GetChild("menu"), input_mode= "four_direction",
+			actor= self:GetChild("menu"), input_mode= theme_config:get_data().menu_mode,
 			repeats_to_big= 10, select_goes_to_top= true, data= options,
 			translation_section= "OptionTitles",
 		}

--- a/Themes/default/Scripts/02 theme_config.lua
+++ b/Themes/default/Scripts/02 theme_config.lua
@@ -6,6 +6,7 @@ local theme_config_default= {
 	TimingDisplay= false,
 	GameplayFooter= true,
 	Use12HourClock= false,
+	menu_mode= "four_direction",
 }
 
 theme_config= create_lua_config{


### PR DESCRIPTION
This fixed the two_direction menu input mode, and adds a config option to the default theme.


two_direction_with_select feels weird in use.

Left and right interact or adjust.
Start is up, not interact.  Select is down.

I don't know what the best behavior is for two_direction_with_select.