### PR TITLE
Added NoteColorMode ProgressOnBeatAtEnd

### DIFF
--- a/src/NoteDisplay.cpp
+++ b/src/NoteDisplay.cpp
@@ -41,6 +41,7 @@ LuaXType( NotePart );
 static const char *NoteColorTypeNames[] = {
 	"Denominator",
 	"Progress",
+	"ProgressOnBeatAtEnd"
 };
 XToString( NoteColorType );
 StringToX( NoteColorType );
@@ -1331,6 +1332,13 @@ void NoteDisplay::DrawActor(const TapNote& tn, Actor* pActor, NotePart part,
 			color = float( BeatToNoteType( fBeat ) );
 			color = clamp( color, 0, (cache->m_iNoteColorCount[part]-1) );
 			break;
+		case NoteColorType_ProgressOnBeatAtEnd:
+			//if we're at the very beginning of the beat, it should be the last color.
+			if ( fBeat-int64_t(fBeat) == 0.0f ) {
+				color = float(cache->m_iNoteColorCount[part]-1);
+				break;
+			}
+			//otherwise, handle it the same as Progress.
 		case NoteColorType_Progress:
 			color = fmodf( ceilf( fBeat * cache->m_iNoteColorCount[part] ), (float)cache->m_iNoteColorCount[part] );
 			break;

--- a/src/NoteDisplay.h
+++ b/src/NoteDisplay.h
@@ -36,6 +36,7 @@ enum NoteColorType
 {
 	NoteColorType_Denominator, /**< Color by note type. */
 	NoteColorType_Progress, /**< Color by progress. */
+	NoteColorType_ProgressOnBeatAtEnd, /**< Color by progress, except 4th notes are considered to occur at the end of the beat. */
 	NUM_NoteColorType,
 	NoteColorType_Invalid
 };


### PR DESCRIPTION
Almost the same as Progress, but 4ths use the last frame rather than the first.
This lets rainbow and vivid from DDR be made properly.