### PR TITLE
ThemePrefs use chosen theme

### DIFF
--- a/src/ThemeManager.cpp
+++ b/src/ThemeManager.cpp
@@ -1446,6 +1446,18 @@ public:
 		return 0;
 	}
 
+	static int get_theme_fallback_list(T* p, lua_State* L)
+	{
+		lua_createtable(L, g_vThemes.size(), 0);
+		int ret= lua_gettop(L);
+		for(size_t tid= 0; tid < g_vThemes.size(); ++tid)
+		{
+			lua_pushstring(L, g_vThemes[tid].sThemeName.c_str());
+			lua_rawseti(L, ret, tid+1);
+		}
+		return 1;
+	}
+
 	LunaThemeManager()
 	{
 		ADD_METHOD( ReloadMetrics );
@@ -1473,6 +1485,7 @@ public:
 		ADD_METHOD( GetMetricNamesInGroup );
 		ADD_METHOD( GetStringNamesInGroup );
 		ADD_METHOD( SetTheme );
+		ADD_METHOD(get_theme_fallback_list);
 	}
 };
 


### PR DESCRIPTION
#1628 
ThemePrefs doesn't work right when a theme falls back on a theme that uses ThemePrefs.

02 ThemePrefs.lua has a detailed description of how the problem occurs.

Two ways to resolve this:
1. Require every theme that falls back on another theme to call ThemePrefs.Init at the end of its scripts.

Problem: A theme can't finish setting up the prefs it creates.

2. Make ThemePrefs use the actual theme the player chose.

Problem: Prefs are now saved under a different section name, so they have to be migrated.  This can be eased by making a screen or menu that uses ThemePrefs.CopyPrefsFrom, and have the player to pick a theme to copy prefs from.
