### PR TITLE
Allow theme pref lookup if chosen has no prefs

### DIFF
--- a/Themes/_fallback/Scripts/02 ThemePrefs.lua
+++ b/Themes/_fallback/Scripts/02 ThemePrefs.lua
@@ -35,22 +35,45 @@ local function GetThemeName()
 	return themeInfo and themeInfo.Name or THEME:GetThemeDisplayName()
 end
 
--- Given a preference name, returns the table it's in. Checks the current
--- theme first, then _fallback, then all other sections, in that order.
-local function ResolveTable( pref )
-	-- check the section for this theme
-	local name = GetThemeName()
-	local val
+local DetermineThemePath = function()
+	local theme = THEME:GetCurThemeName()
+	--lua.ReportScriptError(theme)
 
-	if PrefsTable[name] then
-		val = PrefsTable[name][pref]
-		if val ~= nil then
-			--Trace( ("ResolveTable(%s): found in %s"):format(pref,name) )
-			return PrefsTable[name]
+	local themePath = {theme}
+
+	while theme ~= "_fallback" and theme ~= nil do
+		local metrics = IniFile.ReadFile("Themes/" .. theme .. "/metrics.ini")
+		--lua.ReportScriptError(rec_print_table_to_str(metrics))
+		if metrics and metrics.Global then
+			theme = metrics.Global.FallbackTheme
+			if theme then
+				themePath[#themePath+1] = theme
+			end
+		else
+			theme = nil
 		end
 	end
 
-	-- not in the current theme; check the fallback if it exists
+	return themePath
+end
+
+-- Given a preference name, returns the table it's in. Checks the theme
+-- fallack path in order, then all other sections
+local function ResolveTable( pref )
+	local val
+	local themePath = DetermineThemePath()
+
+	for i,name in ipairs(themePath) do
+		if PrefsTable[name] then
+			val = PrefsTable[name][pref]
+			if val ~= nil then
+				--Trace( ("ResolveTable(%s): found in %s"):format(pref,name) )
+				return PrefsTable[name]
+			end
+		end
+	end
+
+	-- not in the theme path; check the fallback if it exists
 	if PrefsTable[FallbackTheme] then
 		val = PrefsTable[FallbackTheme][pref]
 		if val ~= nil then

--- a/Themes/_fallback/Scripts/02 ThemePrefs.lua
+++ b/Themes/_fallback/Scripts/02 ThemePrefs.lua
@@ -40,11 +40,14 @@ end
 local function ResolveTable( pref )
 	-- check the section for this theme
 	local name = GetThemeName()
-	local val = PrefsTable[name][pref]
+	local val
 
-	if val ~= nil then
-		--Trace( ("ResolveTable(%s): found in %s"):format(pref,name) )
-		return PrefsTable[name]
+	if PrefsTable[name] then
+		val = PrefsTable[name][pref]
+		if val ~= nil then
+			--Trace( ("ResolveTable(%s): found in %s"):format(pref,name) )
+			return PrefsTable[name]
+		end
 	end
 
 	-- not in the current theme; check the fallback if it exists


### PR DESCRIPTION
Change ThemePrefs to check for existance of chosen theme preference table before attempting to lookup values, allowing lookup to continue in other theme sections, such as when one theme falls back to another.

Re: #1628, alternate to #1629