### PR TITLE
Turn lights out on exit

### DIFF
--- a/src/arch/Lights/LightsDriver.cpp
+++ b/src/arch/Lights/LightsDriver.cpp
@@ -30,6 +30,15 @@ void LightsDriver::Create( const RString &sDrivers, vector<LightsDriver *> &Add 
 	}
 }
 
+void LightsDriver::reset()
+{
+	LightsState state;
+	ZERO( state.m_bCabinetLights );
+	ZERO( state.m_bGameButtonLights );
+	ZERO( state.m_bCoinCounter );
+	Set( &state );
+}
+
 /*
  * (c) 2002-2005 Glenn Maynard
  * All rights reserved.

--- a/src/arch/Lights/LightsDriver.h
+++ b/src/arch/Lights/LightsDriver.h
@@ -16,6 +16,9 @@ public:
 	virtual ~LightsDriver() {};
 
 	virtual void Set( const LightsState *ls ) = 0;
+
+        // Reset all lights to off
+        void reset();
 };
 
 #define REGISTER_LIGHTS_DRIVER_CLASS2( name, x ) \

--- a/src/arch/Lights/LightsDriver_Export.cpp
+++ b/src/arch/Lights/LightsDriver_Export.cpp
@@ -11,6 +11,11 @@ LightsDriver_Export::LightsDriver_Export()
 	memset( &m_State, 0, sizeof(m_State) );
 }
 
+LightsDriver_Export::~LightsDriver_Export()
+{
+	LightsDriver::reset();
+}
+
 void LightsDriver_Export::Set( const LightsState *ls )
 {
 	m_Lock.Lock();

--- a/src/arch/Lights/LightsDriver_Export.h
+++ b/src/arch/Lights/LightsDriver_Export.h
@@ -10,6 +10,7 @@ class LightsDriver_Export: public LightsDriver
 {
 public:
 	LightsDriver_Export();
+	virtual ~LightsDriver_Export();
 	virtual void Set( const LightsState *ls );
 
 	// Get the current lights state. This can be called from a thread.

--- a/src/arch/Lights/LightsDriver_LinuxParallel.cpp
+++ b/src/arch/Lights/LightsDriver_LinuxParallel.cpp
@@ -24,6 +24,7 @@ LightsDriver_LinuxParallel::LightsDriver_LinuxParallel()
 
 LightsDriver_LinuxParallel::~LightsDriver_LinuxParallel()
 {
+	LightsDriver::reset();
 	// Reset all bits to zero and free the port's permissions
 	outb( 0, PORT_ADDRESS );
 	ioperm( PORT_ADDRESS, 1, 0 );

--- a/src/arch/Lights/LightsDriver_Linux_PIUIO.cpp
+++ b/src/arch/Lights/LightsDriver_Linux_PIUIO.cpp
@@ -32,6 +32,7 @@ LightsDriver_Linux_PIUIO::LightsDriver_Linux_PIUIO()
 
 LightsDriver_Linux_PIUIO::~LightsDriver_Linux_PIUIO()
 {
+	LightsDriver::reset();
 	if( fd >= 0 )
 		close(fd);
 }

--- a/src/arch/Lights/LightsDriver_SextetStream.cpp
+++ b/src/arch/Lights/LightsDriver_SextetStream.cpp
@@ -210,6 +210,7 @@ LightsDriver_SextetStream::LightsDriver_SextetStream()
 
 LightsDriver_SextetStream::~LightsDriver_SextetStream()
 {
+	LightsDriver::reset();
 	if(IMPL != NULL)
 	{
 		delete IMPL;

--- a/src/arch/Lights/LightsDriver_SystemMessage.cpp
+++ b/src/arch/Lights/LightsDriver_SystemMessage.cpp
@@ -12,6 +12,7 @@ LightsDriver_SystemMessage::LightsDriver_SystemMessage()
 
 LightsDriver_SystemMessage::~LightsDriver_SystemMessage()
 {
+	LightsDriver::reset();
 }
 
 void LightsDriver_SystemMessage::Set( const LightsState *ls )

--- a/src/arch/Lights/LightsDriver_Win32Parallel.cpp
+++ b/src/arch/Lights/LightsDriver_Win32Parallel.cpp
@@ -57,6 +57,7 @@ LightsDriver_Win32Parallel::LightsDriver_Win32Parallel()
 
 LightsDriver_Win32Parallel::~LightsDriver_Win32Parallel()
 {
+	LightsDriver::reset();
 	FreeLibrary( hDLL );
 }
 


### PR DESCRIPTION
To address #1645 

Should be fairly self-explanatory
- LightsDriver::reset added as a generally helpful function
- All drivers that don't explicitly reset the state updated to call reset during destruction
- Drivers like minimaid/others that reset are unmodified

Works as expected on my setup (new ParIO driver from my no-root-parallel-lights branch)

I haven't tested the other drivers due to limited hardware access