### PR TITLE
Timed note explosions

### DIFF
--- a/NoteSkins/default/explosions.lua
+++ b/NoteSkins/default/explosions.lua
@@ -113,6 +113,10 @@ return function(button_list, stepstype, skin_params)
 			WidthSetCommand= function(self, param)
 				param.column:set_layer_fade_type(self, "FieldLayerFadeType_Explosion")
 			end,
+			ColumnJudgmentCommand= function(self, param)
+				param.column:set_layer_second_offset(self, -param.second_offset);
+				param.column:set_layer_beat_offset(self, -param.beat_offset);
+			end,
 			Def.Sprite{
 				Texture= "_glow", InitCommand= function(self)
 					self:visible(false)

--- a/src/NoteField.h
+++ b/src/NoteField.h
@@ -53,10 +53,16 @@ struct FieldChild : ActorFrame
 		double explosion_alpha, double explosion_glow,
 		double beat, double second,
 		ModifiableValue& note_alpha, ModifiableValue& note_glow);
+	void set_beat_offset(double value);
+	void set_second_offset(double value);
+	void update_is_offset();
 	Actor* m_child;
 	FieldLayerFadeType m_fade_type;
 	FieldLayerTransformType m_transform_type;
+	double m_second_offset;
+	double m_beat_offset;
 	size_t m_from_noteskin;
+	bool m_is_offset;
 };
 
 enum field_draw_entry_meaning
@@ -197,7 +203,7 @@ struct NoteFieldColumn : ActorFrame
 	Rage::transform const& get_head_trans() { return head_transform; }
 
 	void pass_message_to_heads(Message& msg);
-	void did_tap_note(TapNoteScore tns, bool bright);
+	void did_tap_note(TapNoteScore tns, bool bright, float second_offset);
 	void did_hold_note(HoldNoteScore hns, bool bright);
 	void set_hold_status(TapNote const* tap, bool start, bool end);
 	void set_pressed(bool on);
@@ -228,6 +234,8 @@ struct NoteFieldColumn : ActorFrame
 	FieldLayerFadeType get_layer_fade_type(Actor* child);
 	void set_layer_transform_type(Actor* child, FieldLayerTransformType type);
 	FieldLayerTransformType get_layer_transform_type(Actor* child);
+	void set_layer_beat_offset(Actor* child, double offset);
+	void set_layer_second_offset(Actor* child, double offset);
 
 	bool m_use_game_music_beat;
 	bool m_show_unjudgable_notes;
@@ -294,7 +302,7 @@ private:
 		Rage::Vector3& forward, Rage::Vector3& left,
 		NoteFieldColumn::render_note& note);
 
-	void did_tap_note_internal(TapNoteScore tns, bool bright);
+	void did_tap_note_internal(TapNoteScore tns, bool bright, float second_offset);
 	void did_hold_note_internal(HoldNoteScore hns, bool bright);
 	void draw_thing_internal();
 	void add_renderable_to_lists(render_note& renderable);
@@ -483,7 +491,7 @@ struct NoteField : ActorFrame
 	void set_displayed_second(double second);
 	bool timing_is_safe() { return m_timing_data != nullptr; }
 
-	void did_tap_note(size_t column, TapNoteScore tns, bool bright);
+	void did_tap_note(size_t column, TapNoteScore tns, bool bright, float second_offset);
 	void did_hold_note(size_t column, HoldNoteScore hns, bool bright);
 	void set_pressed(size_t column, bool on);
 

--- a/src/Player.cpp
+++ b/src/Player.cpp
@@ -2326,7 +2326,7 @@ void Player::Step( int col, int row, const RageTimer &tm, bool bHeld, bool bRele
 				const bool bBright = ( m_pPlayerStageStats && m_pPlayerStageStats->m_iCurCombo > (unsigned int)BRIGHT_GHOST_COMBO_THRESHOLD ) || bBlind;
 				if(m_note_field)
 				{
-					m_note_field->did_tap_note(col, bBlind? TNS_W1:score, bBright);
+					m_note_field->did_tap_note(col, bBlind? TNS_W1:score, bBright, iterNote.result.fTapNoteOffset);
 				}
 				if( score >= m_pPlayerState->m_PlayerOptions.GetCurrent().m_MinTNSToHideNotes || bBlind )
 					HideNote( col, iRowOfOverlappingNoteOrRow );
@@ -2425,7 +2425,7 @@ void Player::UpdateTapNotesMissedOlderThan( float fMissIfOlderThanSeconds )
 			tn.result.tns = TNS_AvoidMine;
 			if(m_note_field != nullptr)
 			{
-				m_note_field->did_tap_note(iter.Track(), tn.result.tns, false);
+				m_note_field->did_tap_note(iter.Track(), tn.result.tns, false, 0.f);
 			}
 			/* The only real way to tell if a mine has been scored is if it has disappeared
 			 * but this only works for hit mines so update the scores for avoided mines here. */
@@ -2443,7 +2443,7 @@ void Player::UpdateTapNotesMissedOlderThan( float fMissIfOlderThanSeconds )
 			// message.  Delaying until I have time to rearchitect Player. -Kyz
 			if(m_note_field != nullptr)
 			{
-				m_note_field->did_tap_note(iter.Track(), tn.result.tns, false);
+				m_note_field->did_tap_note(iter.Track(), tn.result.tns, false, 0.f);
 			}
 		}
 	}
@@ -2551,7 +2551,7 @@ void Player::UpdateJudgedRows()
 			}
 			if(m_note_field != nullptr)
 			{
-				m_note_field->did_tap_note(iter.Track(), tn.result.tns, false);
+				m_note_field->did_tap_note(iter.Track(), tn.result.tns, false, tn.result.fTapNoteOffset);
 			}
 
 			if( tn.iKeysoundIndex >= 0 && tn.iKeysoundIndex < (int) m_vKeysounds.size() )
@@ -2622,7 +2622,7 @@ void Player::FlashGhostRow( int iRow )
 		}
 		if(m_note_field != nullptr)
 		{
-			m_note_field->did_tap_note(iTrack, lastTNS, bBright);
+			m_note_field->did_tap_note(iTrack, lastTNS, bBright, tn.result.fTapNoteOffset);
 		}
 		if( lastTNS >= m_pPlayerState->m_PlayerOptions.GetCurrent().m_MinTNSToHideNotes || bBlind )
 		{


### PR DESCRIPTION
2018-02-28 3 14:34:23 -0700 Feb Wed 059 1519853663 < lirodon> Kyzentun, 5.2 noteskin idea (blatantly ripped from SMX but still), the ability to have the explosion correspond to where it was on screen when you actually tapped it
2018-02-28 3 14:34:54 -0700 Feb Wed 059 1519853694 < lirodon> i.e. if you hit it early, the explosion would, on certain judgements, render a little under the receptor rather than right over it all the time

Done in the default noteskin to show how.