### PR TITLE
Improve DrawQuads batching in the font render.

### DIFF
--- a/src/BitmapText.cpp
+++ b/src/BitmapText.cpp
@@ -455,7 +455,7 @@ void BitmapText::DrawChars( bool bUseStrokeTexture )
 	for( int start = iStartGlyph; start < iEndGlyph; )
 	{
 		int end = start;
-		while( end < iEndGlyph  &&  m_vpFontPageTextures[end] == m_vpFontPageTextures[start] )
+		while( end < iEndGlyph  &&  *m_vpFontPageTextures[end] == *m_vpFontPageTextures[start] )
 			end++;
 
 		bool bHaveATexture = !bUseStrokeTexture  || m_vpFontPageTextures[start]->m_pTextureStroke;

--- a/src/Font.h
+++ b/src/Font.h
@@ -26,6 +26,15 @@ struct FontPageTextures
 
 	/** @brief Set up the initial textures. */
 	FontPageTextures(): m_pTextureMain(nullptr), m_pTextureStroke(nullptr) {}
+
+	bool operator == (const struct FontPageTextures& other) const {
+		return m_pTextureMain == other.m_pTextureMain &&
+			m_pTextureStroke == other.m_pTextureStroke;
+	}
+
+	bool operator != (const struct FontPageTextures& other) const {
+		return !operator==(other);
+	}
 };
 
 /** @brief The components of a glyph (not technically a character). */

--- a/src/arch/Threads/Threads_Pthreads.h
+++ b/src/arch/Threads/Threads_Pthreads.h
@@ -27,6 +27,10 @@ public:
 	void Resume();
 	uint64_t GetThreadId() const;
 	int Wait();
+
+	// pthread_setname_np name length can be at most 16 characters
+	// (including the terminating NUL character).
+	mutable char name[16];
 };
 
 class MutexImpl_Pthreads: public MutexImpl


### PR DESCRIPTION
Currently only identical glyphs are merged into one DrawQuads call.
This fixes the comparison so that all glyphs with the same texture can
be merged, which greatly improves the font rendering performance.