### PR TITLE
Improve DrawQuads batching in the font render.

### DIFF
--- a/src/BitmapText.cpp
+++ b/src/BitmapText.cpp
@@ -422,7 +422,7 @@ void BitmapText::DrawChars( bool bUseStrokeTexture )
 	for( int start = iStartGlyph; start < iEndGlyph; )
 	{
 		int end = start;
-		while( end < iEndGlyph  &&  m_vpFontPageTextures[end] == m_vpFontPageTextures[start] )
+		while( end < iEndGlyph  &&  *m_vpFontPageTextures[end] == *m_vpFontPageTextures[start] )
 			end++;
 
 		bool bHaveATexture = !bUseStrokeTexture  ||  (bUseStrokeTexture && m_vpFontPageTextures[start]->m_pTextureStroke);

--- a/src/Font.h
+++ b/src/Font.h
@@ -24,6 +24,15 @@ struct FontPageTextures
 
 	/** @brief Set up the initial textures. */
 	FontPageTextures(): m_pTextureMain(NULL), m_pTextureStroke(NULL) {}
+
+	bool operator == (const struct FontPageTextures& other) const {
+		return m_pTextureMain == other.m_pTextureMain &&
+			m_pTextureStroke == other.m_pTextureStroke;
+	}
+
+	bool operator != (const struct FontPageTextures& other) const {
+		return !operator==(other);
+	}
 };
 
 /** @brief The components of a glyph (not technically a character). */


### PR DESCRIPTION
Currently only identical glyphs are merged into one DrawQuads call.
This fixes the comparison so that all glyphs with the same texture can
be merged, which greatly improves the font rendering performance.