### PR TITLE
Propagate thread name to Linux pthread name.

### DIFF
--- a/src/arch/Threads/Threads_Pthreads.h
+++ b/src/arch/Threads/Threads_Pthreads.h
@@ -27,6 +27,10 @@ public:
 	void Resume();
 	uint64_t GetThreadId() const;
 	int Wait();
+
+	// pthread_setname_np name length can be at most 16 characters
+	// (including the terminating NUL character).
+	mutable char name[16];
 };
 
 class MutexImpl_Pthreads: public MutexImpl


### PR DESCRIPTION
Use pthread_setname_np to set the thread name.
This is useful to see the threads in top and other tools, e.g. 'top -H -p $(pidof stepmania)'.
    
Since At most 16 characters are allowed and some stepmania threads have longer names, there are two fallbacks to truncated the name:
If the name is of the form "Worker thread (name)", then "(name)" is used.
Otherwise long names are truncated by combining the first 6 and last 7 characters of the name with ".." as an ellipsis indicator in the middle.