### PR TITLE
Make ScreenHowToPlay clear its personal song from globals when exiting

### DIFF
--- a/src/ScreenHowToPlay.cpp
+++ b/src/ScreenHowToPlay.cpp
@@ -206,6 +206,8 @@ void ScreenHowToPlay::Init()
 
 ScreenHowToPlay::~ScreenHowToPlay()
 {
+	SOUND->StopMusic();
+	GAMESTATE->set_curr_song(nullptr);
 	delete m_pLifeMeterBar;
 	delete m_pmCharacter;
 	delete m_pmDancePad;

--- a/src/TimingData.cpp
+++ b/src/TimingData.cpp
@@ -1183,6 +1183,7 @@ void TimingData::GetDetailedInfoForSecond(DetailedTimeInfo& args) const
 
 float TimingData::GetBeatFromElapsedTime(float second) const
 {
+	if(empty()) { return 0.f; }
 	float globoff= GAMESTATE->get_hasted_music_rate() * PREFSMAN->m_fGlobalOffsetSeconds;
 	if(!m_line_segments.empty())
 	{
@@ -1204,6 +1205,7 @@ float TimingData::GetBeatFromElapsedTime(float second) const
 
 float TimingData::GetBeatFromElapsedTimeNoOffset(float second) const
 {
+	if(empty()) { return 0.f; }
 	if(!m_line_segments.empty())
 	{
 		return GetLineBeatFromSecond(second);
@@ -1224,6 +1226,7 @@ float TimingData::GetBeatFromElapsedTimeNoOffset(float second) const
 
 void TimingData::GetDetailedInfoForSecondNoOffset(DetailedTimeInfo& args) const
 {
+	if(empty()) { return; }
 	LineSegment segment;
 	if(!m_line_segments.empty())
 	{
@@ -1265,6 +1268,7 @@ float TimingData::GetElapsedTimeFromBeat(float beat) const
 
 float TimingData::GetElapsedTimeFromBeatNoOffset(float beat) const
 {
+	if(empty()) { return 0.f; }
 	if(!m_line_segments.empty())
 	{
 		return GetLineSecondFromBeat(beat);


### PR DESCRIPTION
#1656 also occurs in master, with the default theme.
The underlying cause is probably the same on the 5_1-new branch, though TimingData has a different structure so the commit can't be applied directly.

If you want to make ScreenHowToPlay easy to reach for testing, edit this into a screen:

```
t[#t+1]= Def.Actor{
	OnCommand= function(self)
		SCREENMAN:GetTopScreen():AddInputCallback(
			function(event)
				if event.type == "InputEventType_FirstPress" and
				event.DeviceInput.button == "DeviceButton_n" then
					SCREENMAN:GetTopScreen():SetNextScreenName("ScreenHowToPlay")
						:StartTransitioningScreen("SM_GoToNextScreen")
				end
																					 end)
	end
}
```