### PR TITLE
Avoid crash in ~LightsDriver_SystemMessage

### DIFF
--- a/src/LightsManager.cpp
+++ b/src/LightsManager.cpp
@@ -512,6 +512,12 @@ bool LightsManager::IsEnabled() const
 	return m_vpDrivers.size() >= 1 || PREFSMAN->m_bDebugLights;
 }
 
+void LightsManager::TurnOffAllLights()
+{
+	FOREACH( LightsDriver*, m_vpDrivers, iter )
+		(*iter)->Reset();
+}
+
 /*
  * (c) 2003-2004 Chris Danford
  * All rights reserved.

--- a/src/LightsManager.h
+++ b/src/LightsManager.h
@@ -67,6 +67,7 @@ public:
 	void BlinkCabinetLight( CabinetLight cl );
 	void BlinkGameButton( GameInput gi );
 	void BlinkActorLight( CabinetLight cl );
+	void TurnOffAllLights();
 	void PulseCoinCounter() { ++m_iQueuedCoinCounterPulses; }
 	float GetActorLightLatencySeconds() const;
 

--- a/src/StepMania.cpp
+++ b/src/StepMania.cpp
@@ -286,6 +286,14 @@ void ShutdownGame()
 	if( SOUNDMAN )
 		SOUNDMAN->Shutdown();
 
+	/* Reset all lights to off.
+	 * This is done before ~LightsManager as some drivers use SCREENMAN
+	 * and similar when setting lights. */
+	if( LIGHTSMAN )
+	{
+		LIGHTSMAN->TurnOffAllLights();
+	}
+
 	SAFE_DELETE( SCREENMAN );
 	SAFE_DELETE( STATSMAN );
 	SAFE_DELETE( MESSAGEMAN );

--- a/src/arch/Lights/LightsDriver.cpp
+++ b/src/arch/Lights/LightsDriver.cpp
@@ -30,7 +30,7 @@ void LightsDriver::Create( const RString &sDrivers, vector<LightsDriver *> &Add 
 	}
 }
 
-void LightsDriver::reset()
+void LightsDriver::Reset()
 {
 	LightsState state;
 	ZERO( state.m_bCabinetLights );

--- a/src/arch/Lights/LightsDriver.h
+++ b/src/arch/Lights/LightsDriver.h
@@ -17,8 +17,8 @@ public:
 
 	virtual void Set( const LightsState *ls ) = 0;
 
-        // Reset all lights to off
-        void reset();
+	// Reset all lights to off
+	void Reset();
 };
 
 #define REGISTER_LIGHTS_DRIVER_CLASS2( name, x ) \

--- a/src/arch/Lights/LightsDriver_Export.cpp
+++ b/src/arch/Lights/LightsDriver_Export.cpp
@@ -13,7 +13,6 @@ LightsDriver_Export::LightsDriver_Export()
 
 LightsDriver_Export::~LightsDriver_Export()
 {
-	LightsDriver::reset();
 }
 
 void LightsDriver_Export::Set( const LightsState *ls )

--- a/src/arch/Lights/LightsDriver_LinuxParallel.cpp
+++ b/src/arch/Lights/LightsDriver_LinuxParallel.cpp
@@ -24,7 +24,6 @@ LightsDriver_LinuxParallel::LightsDriver_LinuxParallel()
 
 LightsDriver_LinuxParallel::~LightsDriver_LinuxParallel()
 {
-	LightsDriver::reset();
 	// Reset all bits to zero and free the port's permissions
 	outb( 0, PORT_ADDRESS );
 	ioperm( PORT_ADDRESS, 1, 0 );

--- a/src/arch/Lights/LightsDriver_Linux_PIUIO.cpp
+++ b/src/arch/Lights/LightsDriver_Linux_PIUIO.cpp
@@ -32,7 +32,6 @@ LightsDriver_Linux_PIUIO::LightsDriver_Linux_PIUIO()
 
 LightsDriver_Linux_PIUIO::~LightsDriver_Linux_PIUIO()
 {
-	LightsDriver::reset();
 	if( fd >= 0 )
 		close(fd);
 }

--- a/src/arch/Lights/LightsDriver_SextetStream.cpp
+++ b/src/arch/Lights/LightsDriver_SextetStream.cpp
@@ -210,7 +210,6 @@ LightsDriver_SextetStream::LightsDriver_SextetStream()
 
 LightsDriver_SextetStream::~LightsDriver_SextetStream()
 {
-	LightsDriver::reset();
 	if(IMPL != NULL)
 	{
 		delete IMPL;

--- a/src/arch/Lights/LightsDriver_SystemMessage.cpp
+++ b/src/arch/Lights/LightsDriver_SystemMessage.cpp
@@ -12,7 +12,6 @@ LightsDriver_SystemMessage::LightsDriver_SystemMessage()
 
 LightsDriver_SystemMessage::~LightsDriver_SystemMessage()
 {
-	LightsDriver::reset();
 }
 
 void LightsDriver_SystemMessage::Set( const LightsState *ls )

--- a/src/arch/Lights/LightsDriver_SystemMessage.cpp
+++ b/src/arch/Lights/LightsDriver_SystemMessage.cpp
@@ -17,6 +17,11 @@ LightsDriver_SystemMessage::~LightsDriver_SystemMessage()
 
 void LightsDriver_SystemMessage::Set( const LightsState *ls )
 {
+	if (!PREFSMAN || !LIGHTSMAN || !SCREENMAN)
+	{
+		return;
+	}
+
 	if( !PREFSMAN->m_bDebugLights )
 		return;
 

--- a/src/arch/Lights/LightsDriver_Win32Parallel.cpp
+++ b/src/arch/Lights/LightsDriver_Win32Parallel.cpp
@@ -57,7 +57,6 @@ LightsDriver_Win32Parallel::LightsDriver_Win32Parallel()
 
 LightsDriver_Win32Parallel::~LightsDriver_Win32Parallel()
 {
-	LightsDriver::reset();
 	FreeLibrary( hDLL );
 }
 


### PR DESCRIPTION
This will avoid a crash caused by the fact LIGHTSMAN is destroyed
after the other MAN objects

As mentioned in #1661 the order of destruction could be changed to allow reset to work, but I don't think it's a big enough problem to warrant what (I assume) would be a fairly complex change