### PR TITLE
Update metrics.ini (DamageThreshold)

### DIFF
--- a/Themes/_fallback/metrics.ini
+++ b/Themes/_fallback/metrics.ini
@@ -583,7 +583,7 @@ ItemUseRateSeconds=0.0
 # The default life bar you see in gameplay
 
 # Percentage in which the game starts yelling at you to stop sucking
-DangerThreshold=0.2
+DangerThreshold=0.25
 # And how much it starts up at.
 InitialValue=0.5
 # And how much it takes to get ravin'


### PR DESCRIPTION
now it doubles, danger warning is now at .25 rather than 2, this way its half default, idk this just feel more right imp