### PR TITLE
Moved display zbuffer clear to after notefields are drawn

### DIFF
--- a/src/NoteField.cpp
+++ b/src/NoteField.cpp
@@ -761,10 +761,6 @@ void NoteField::DrawPrimitives()
 			m_FieldRenderArgs.draw_pixels_before_targets);
 		return;
 	}
-
-	// Clear the z buffer so 3D notes aren't hidden by anything in the underlay using masking. -Kyz
-	DISPLAY->ClearZBuffer();
-
 	// Some might prefer an else block, instead of returning from the if, but I
 	// don't want to bump the indent on the entire remaining section. -Kyz
 	ArrowEffects::SetCurrentOptions(&m_pPlayerState->m_PlayerOptions.GetCurrent());

--- a/src/ScreenGameplay.cpp
+++ b/src/ScreenGameplay.cpp
@@ -61,6 +61,7 @@
 #include "Song.h"
 #include "XmlFileUtil.h"
 #include "Profile.h" // for replay data stuff
+#include "RageDisplay.h"
 
 // Defines
 #define SHOW_LIFE_METER_FOR_DISABLED_PLAYERS	THEME->GetMetricB(m_sName,"ShowLifeMeterForDisabledPlayers")
@@ -2046,6 +2047,8 @@ void ScreenGameplay::DrawPrimitives()
 	{
 		pi->m_pPlayer->DrawNoteFieldBoard();
 	}
+	// Clear the z buffer so 3D notes aren't hidden by anything in the underlay using masking. -Kyz
+	DISPLAY->ClearZBuffer();
 	ScreenWithMenuElements::DrawPrimitives();
 }
 


### PR DESCRIPTION
This should take care of issue #1678 in the way that kyzentun mentioned.