### PR TITLE
Preserve event timestamps in X11 input driver

### DIFF
--- a/src/arch/InputHandler/InputHandler_X11.cpp
+++ b/src/arch/InputHandler/InputHandler_X11.cpp
@@ -203,9 +203,9 @@ void InputHandler_X11::Update()
 				lastEvent.type = 0;
 				continue;
 			}
+
 			// This is a new event so the last release was not a repeat.
-			ButtonPressed( DeviceInput(DEVICE_KEYBOARD, lastDB, 0) );
-			lastEvent.type = 0;
+			RegisterKeyEvent( event.xkey.time, false, lastDB );
 		}
 
 		if( event.type == FocusOut )
@@ -221,7 +221,9 @@ void InputHandler_X11::Update()
 			continue;
 
 		if( bKeyPress )
-			ButtonPressed( DeviceInput(DEVICE_KEYBOARD, lastDB, 1) );
+		{
+			RegisterKeyEvent( event.xkey.time, true, lastDB );
+		}
 		/*
 		else if( bMousePress )
 			ButtonPressed( DeviceInput(DEVICE_MOUSE, lastDB, 1) );
@@ -234,7 +236,9 @@ void InputHandler_X11::Update()
 	if( lastEvent.type != 0 )
 	{
 		if( lastEvent.type == (KeyPress|KeyRelease) )
-			ButtonPressed( DeviceInput(DEVICE_KEYBOARD, lastDB, 0) );
+		{
+			RegisterKeyEvent( event.xkey.time, false, lastDB );
+		}
 		/*
 		if( lastEvent.type == (ButtonPress|ButtonRelease) )
 			ButtonPressed( DeviceInput(DEVICE_MOUSE, lastDB, 0) );
@@ -252,6 +256,25 @@ void InputHandler_X11::GetDevicesAndDescriptions( vector<InputDeviceInfo>& vDevi
 		vDevicesOut.push_back( InputDeviceInfo(DEVICE_KEYBOARD,"Keyboard") );
 		vDevicesOut.push_back( InputDeviceInfo(DEVICE_MOUSE,"Mouse") );
 	}
+}
+
+void InputHandler_X11::RegisterKeyEvent( unsigned long timestamp, bool keyDown, DeviceButton button )
+{
+	// https://linux.die.net/man/3/xkeyevent
+	// Event timestamp is in milliseconds
+
+	// seconds, microseconds
+	RageTimer timer(
+	  timestamp / 1000,
+	  (timestamp % 1000) * 1000 );
+
+	DeviceInput di(
+		DEVICE_KEYBOARD,
+		button,
+		keyDown ? 1.0f:0.0f,
+		timer);
+
+	ButtonPressed( di );
 }
 
 /*

--- a/src/arch/InputHandler/InputHandler_X11.h
+++ b/src/arch/InputHandler/InputHandler_X11.h
@@ -12,6 +12,9 @@ public:
 	~InputHandler_X11();
 	void Update();
 	void GetDevicesAndDescriptions( vector<InputDeviceInfo>& vDevicesOut );
+private:
+    // timestamp is unsigned long to match X11 Time type
+	void RegisterKeyEvent( unsigned long timestamp, bool keyDown, DeviceButton button );
 };
 
 #endif


### PR DESCRIPTION
The X11 XKeyEvent structure (and others) include a timestamp
field, with 1ms resolution.
This was previously ignored causing the input timestamps to be
set to the middle of each frame.
If the timestamps are passed through then the event timestamps are
not coupled to the framerate and the polling issues are resolved.

So far these changes have been tested on Linux Mint, for IPAC, JPAC, and keyboard. No issues have been identified (and several quads have been achieved without any of the previously noted polling issues)
