### PR TITLE
fix LuaDoc for SONGMAN:GetCoursesInGroup()

### DIFF
--- a/Docs/Luadoc/LuaDocumentation.xml
+++ b/Docs/Luadoc/LuaDocumentation.xml
@@ -5065,7 +5065,7 @@ save yourself some time, copy this for undocumented things:
 	<Function name='GetCourseGroupNames' return='{string}' arguments=''>
 		Returns a table containing all of the course group names.
 	</Function>
-	<Function name='GetCoursesInGroup' return='{Course}' arguments='string sGroup'>
+	<Function name='GetCoursesInGroup' return='{Course}' arguments='string sGroup, bool bIncludeAutogen'>
 		Returns a table with all of the courses in the specified group.
 	</Function>
 	<Function name='GetExtraStageInfo' return='various' arguments='bool bExtra2, Style s'>


### PR DESCRIPTION
SONGMAN:GetCoursesInGroup() actually takes two arguments, a string and a boolean, but the existing Lua Docs only mention the first.  This fixes that.