### PR TITLE
Broader Dancing Character Control for themers

### DIFF
--- a/Themes/_fallback/metrics.ini
+++ b/Themes/_fallback/metrics.ini
@@ -4847,3 +4847,57 @@ NullCountString=""
 2DCharacterYP1=SCREEN_HEIGHT*0.5
 2DCharacterXP2=SCREEN_WIDTH*0.75
 2DCharacterYP2=SCREEN_HEIGHT*0.5
+
+# Allows you to change the position of the X model relative to SCREEN_CENTER_X
+# Keep in mind, the camera and models are placed in a YRot of 180, so the X value here
+# will act in reverse.
+OnePlayerModelX=0
+
+# TODO
+# Distance between both models during versus or battle modes.
+TwoPlayersModelX=8
+
+# Controls the Dancing characters camera.
+[DancingCamera]
+# Distance relative to Z to the position of the characters.
+RestDistance=32.0
+# Distance relative to Y to the position of the characters.
+RestHeight=-11.0
+# Distance relative to Z to the position of the characters
+# At the moment of the sweep animation to begin.
+SweepDistance=28.0
+# Variable ammount in which the Z position will change
+# during said tween.
+SweepDistanceVariable=4.0
+# Variable ammount in which the Y position will change
+# during said tween.
+SweepHeightVariable=7.0
+# Variable range in which the Y position will tween
+# to become the new variable to start from.
+SweepPanYRangeDegrees=45.0
+SweepPanYVarianceDegrees=60.0
+SweepHeight=-11.0
+StillDistance=26.0
+StillDistanceVariance=3.0
+StillPanYRangeDegrees=120.0
+StillHeightVariance=5.0
+StillHeight=-10.0
+
+# As the name implies, this sets the ammount of beats that the camera will
+# stay in its current state until transitioning to the next camera tween.
+BeatsUntilNextCamPos=8
+CameraFOV=45
+
+# Control the lighting position here.
+LightX=-3
+LightY=-7.5
+LightZ=9
+
+# Control the lighting color here.
+AmbientColor=color(".4,.4,.4,1")
+AmbientDangerColor=color(".4,.1,.1,1")
+AmbientFailedColor=color(".2,.1,.1,1")
+# Diffuse color of the scene.
+DiffuseColor=color("1,.95,.95,1")
+DiffuseDangerColor=color(".8,.1,.1,1")
+DiffuseFailedColor=color(".4,.1,.1,1")

--- a/Themes/_fallback/metrics.ini
+++ b/Themes/_fallback/metrics.ini
@@ -4853,18 +4853,26 @@ NullCountString=""
 # will act in reverse.
 OnePlayerModelX=0
 
-# TODO
-# Distance between both models during versus or battle modes.
-TwoPlayersModelX=8
-
 # Controls the Dancing characters camera.
 [DancingCamera]
+# Camera Explanation
+# StepMania's Dancing Characters Camera is divided into 3 sections
+
+# Rest - Begins as soon as Gameplay is started. It won't change until the
+# First note has been hit/passed.
+
+# Sweep - Part of the camera where it begins to move, and does linear tweens
+# Across the area, in a matrix-like style.
+
+# Still - Happens in a Rand ammount, in which if true, goes into a static position
+# in a random spot of the area where the characters can (mostly) be visible.
+
 # Distance relative to Z to the position of the characters.
 RestDistance=32.0
 # Distance relative to Y to the position of the characters.
 RestHeight=-11.0
-# Distance relative to Z to the position of the characters
-# At the moment of the sweep animation to begin.
+
+# Here's the moment the sweep animation will begin.
 SweepDistance=28.0
 # Variable ammount in which the Z position will change
 # during said tween.
@@ -4876,7 +4884,9 @@ SweepHeightVariable=7.0
 # to become the new variable to start from.
 SweepPanYRangeDegrees=45.0
 SweepPanYVarianceDegrees=60.0
+# Height where the Sweep will begin from.
 SweepHeight=-11.0
+
 StillDistance=26.0
 StillDistanceVariance=3.0
 StillPanYRangeDegrees=120.0
@@ -4886,6 +4896,8 @@ StillHeight=-10.0
 # As the name implies, this sets the ammount of beats that the camera will
 # stay in its current state until transitioning to the next camera tween.
 BeatsUntilNextCamPos=8
+
+# Set the Camera's Field Of View.
 CameraFOV=45
 
 # Control the lighting position here.

--- a/src/DancingCharacters.cpp
+++ b/src/DancingCharacters.cpp
@@ -25,24 +25,50 @@ int Neg1OrPos1();
  *
  * -- Colby
  */
-const float CAMERA_REST_DISTANCE = 32.f;
-const float CAMERA_REST_LOOK_AT_HEIGHT = -11.f;
 
-const float CAMERA_SWEEP_DISTANCE = 28.f;
-const float CAMERA_SWEEP_DISTANCE_VARIANCE = 4.f;
-const float CAMERA_SWEEP_HEIGHT_VARIANCE = 7.f;
-const float CAMERA_SWEEP_PAN_Y_RANGE_DEGREES = 45.f;
-const float CAMERA_SWEEP_PAN_Y_VARIANCE_DEGREES = 60.f;
-const float CAMERA_SWEEP_LOOK_AT_HEIGHT = -11.f;
+#define CAMERA_REST_DISTANCE				THEME->GetMetricF("DancingCamera","RestDistance")
+#define CAMERA_REST_LOOK_AT_HEIGHT			THEME->GetMetricF("DancingCamera","RestHeight")
+#define CAMERA_SWEEP_DISTANCE				THEME->GetMetricF("DancingCamera","SweepDistance")
+#define CAMERA_SWEEP_DISTANCE_VARIANCE			THEME->GetMetricF("DancingCamera","SweepDistanceVariable")
+#define CAMERA_SWEEP_HEIGHT_VARIANCE			THEME->GetMetricF("DancingCamera","SweepHeightVariable")
+#define CAMERA_SWEEP_PAN_Y_RANGE_DEGREES		THEME->GetMetricF("DancingCamera","SweepPanYRangeDegrees")
+#define CAMERA_SWEEP_PAN_Y_VARIANCE_DEGREES		THEME->GetMetricF("DancingCamera","SweepPanYVarianceDegrees")
+#define CAMERA_SWEEP_LOOK_AT_HEIGHT			THEME->GetMetricF("DancingCamera","SweepHeight")
+#define CAMERA_STILL_DISTANCE				THEME->GetMetricF("DancingCamera","StillDistance")
+#define CAMERA_STILL_DISTANCE_VARIANCE			THEME->GetMetricF("DancingCamera","StillDistanceVariance")
+#define CAMERA_STILL_PAN_Y_RANGE_DEGREES		THEME->GetMetricF("DancingCamera","StillPanYRangeDegrees")
+#define CAMERA_STILL_HEIGHT_VARIANCE			THEME->GetMetricF("DancingCamera","StillHeightVariance")
+#define CAMERA_STILL_LOOK_AT_HEIGHT			THEME->GetMetricF("DancingCamera","StillHeight")
 
-const float CAMERA_STILL_DISTANCE = 26.f;
-const float CAMERA_STILL_DISTANCE_VARIANCE = 3.f;
-const float CAMERA_STILL_PAN_Y_RANGE_DEGREES = 120.f;
-const float CAMERA_STILL_HEIGHT_VARIANCE = 5.f;
-const float CAMERA_STILL_LOOK_AT_HEIGHT = -10.f;
+// This is to setup the lighting color.
+const ThemeMetric<RageColor>	LIGHT_AMBIENT_COLOR	( "DancingCamera", "AmbientColor" );
+const ThemeMetric<RageColor>	LIGHT_DIFFUSE_COLOR	( "DancingCamera", "DiffuseColor" );
 
-const float MODEL_X_ONE_PLAYER = 0;
-const float MODEL_X_TWO_PLAYERS[NUM_PLAYERS] = { +8, -8 };
+// This is for Danger and Failed colors.
+const ThemeMetric<RageColor>	LIGHT_ADANGER_COLOR	( "DancingCamera", "AmbientDangerColor" );
+const ThemeMetric<RageColor>	LIGHT_AFAILED_COLOR	( "DancingCamera", "AmbientFailedColor" );
+const ThemeMetric<RageColor>	LIGHT_DDANGER_COLOR	( "DancingCamera", "DiffuseDangerColor" );
+const ThemeMetric<RageColor>	LIGHT_DFAILED_COLOR	( "DancingCamera", "DiffuseFailedColor" );
+
+// This is to make positioning of said light.
+#define LIGHTING_X					THEME->GetMetricF("DancingCamera","LightX")
+#define LIGHTING_Y					THEME->GetMetricF("DancingCamera","LightY")
+#define LIGHTING_Z					THEME->GetMetricF("DancingCamera","LightZ")
+
+// Position of the model in X (one player)
+#define MODEL_X_ONE_PLAYER				THEME->GetMetricF("DancingCharacters","OnePlayerModelX")
+// Model spacing during Versus or Battle modes.
+#define MODEL_X_VERSUS					THEME->GetMetricF("DancingCharacters","TwoPlayersModelX")
+
+// As the name implies, this sets the ammount of beats that the camera will
+// stay in its current state until transitioning to the next camera tween.
+#define	AMM_BEATS_TIL_NEXTCAMERA			THEME->GetMetricF("DancingCamera","BeatsUntilNextCamPos")
+#define CAM_FOV						THEME->GetMetricF("DancingCamera","CameraFOV")
+
+// Since we only have two players, set those without changing the table too much.
+int VersusSpacing = (int)MODEL_X_VERSUS;
+const float MODEL_X_TWO_PLAYERS[NUM_PLAYERS] = { VersusSpacing, -VersusSpacing };
+
 const float MODEL_ROTATIONY_TWO_PLAYERS[NUM_PLAYERS] = { -90, 90 };
 
 DancingCharacters::DancingCharacters(): m_bDrawDangerLight(false),
@@ -223,19 +249,19 @@ void DancingCharacters::Update( float fDelta )
 	fLastBeat = fThisBeat;
 
 	// time for a new sweep?
-	if( GAMESTATE->m_Position.m_fSongBeat > m_fThisCameraEndBeat )
+	if (GAMESTATE->m_Position.m_fSongBeat > m_fThisCameraEndBeat)
 	{
-		if( RandomInt(6) >= 4 )
+		if (RandomInt(6) >= 4)
 		{
 			// sweeping camera
-			m_CameraDistance = CAMERA_SWEEP_DISTANCE + RandomInt(-1,1) * CAMERA_SWEEP_DISTANCE_VARIANCE;
-			m_CameraPanYStart = m_CameraPanYEnd = RandomInt(-1,1) * CAMERA_SWEEP_PAN_Y_RANGE_DEGREES;
+			m_CameraDistance = CAMERA_SWEEP_DISTANCE + RandomInt(-1, 1) * CAMERA_SWEEP_DISTANCE_VARIANCE;
+			m_CameraPanYStart = m_CameraPanYEnd = RandomInt(-1, 1) * CAMERA_SWEEP_PAN_Y_RANGE_DEGREES;
 			m_fCameraHeightStart = m_fCameraHeightEnd = CAMERA_STILL_LOOK_AT_HEIGHT;
 
-			m_CameraPanYEnd += RandomInt(-1,1) * CAMERA_SWEEP_PAN_Y_VARIANCE_DEGREES;
-			m_fCameraHeightStart = m_fCameraHeightEnd = m_fCameraHeightStart + RandomInt(-1,1) * CAMERA_SWEEP_HEIGHT_VARIANCE;
+			m_CameraPanYEnd += RandomInt(-1, 1) * CAMERA_SWEEP_PAN_Y_VARIANCE_DEGREES;
+			m_fCameraHeightStart = m_fCameraHeightEnd = m_fCameraHeightStart + RandomInt(-1, 1) * CAMERA_SWEEP_HEIGHT_VARIANCE;
 
-			float fCameraHeightVariance = RandomInt(-1,1) * CAMERA_SWEEP_HEIGHT_VARIANCE;
+			float fCameraHeightVariance = RandomInt(-1, 1) * CAMERA_SWEEP_HEIGHT_VARIANCE;
 			m_fCameraHeightStart -= fCameraHeightVariance;
 			m_fCameraHeightEnd += fCameraHeightVariance;
 
@@ -244,7 +270,7 @@ void DancingCharacters::Update( float fDelta )
 		else
 		{
 			// still camera
-			m_CameraDistance = CAMERA_STILL_DISTANCE + RandomInt(-1,1) * CAMERA_STILL_DISTANCE_VARIANCE;
+			m_CameraDistance = CAMERA_STILL_DISTANCE + RandomInt(-1, 1) * CAMERA_STILL_DISTANCE_VARIANCE;
 			m_CameraPanYStart = m_CameraPanYEnd = Neg1OrPos1() * CAMERA_STILL_PAN_Y_RANGE_DEGREES;
 			m_fCameraHeightStart = m_fCameraHeightEnd = CAMERA_SWEEP_LOOK_AT_HEIGHT + Neg1OrPos1() * CAMERA_STILL_HEIGHT_VARIANCE;
 
@@ -252,10 +278,12 @@ void DancingCharacters::Update( float fDelta )
 		}
 
 		int iCurBeat = (int)GAMESTATE->m_Position.m_fSongBeat;
-		iCurBeat -= iCurBeat%8;
+		// Need to convert it to a int, otherwise it complains.
+		int NewBeatToSet = (int)AMM_BEATS_TIL_NEXTCAMERA;
+		iCurBeat -= iCurBeat % NewBeatToSet;
 
-		m_fThisCameraStartBeat = (float) iCurBeat;
-		m_fThisCameraEndBeat = float(iCurBeat + 8);
+		m_fThisCameraStartBeat = (float)iCurBeat;
+		m_fThisCameraEndBeat = float(iCurBeat + AMM_BEATS_TIL_NEXTCAMERA);
 	}
 	/*
 	// is there any of this still around? This block of code is _ugly_. -Colby
@@ -327,7 +355,7 @@ void DancingCharacters::DrawPrimitives()
 
 	RageVector3 m_LookAt( 0, m_fLookAtHeight, 0 );
 
-	DISPLAY->LoadLookAt( 45,
+	DISPLAY->LoadLookAt( CAM_FOV,
 		m_CameraPoint,
 		m_LookAt,
 		RageVector3(0,1,0) );
@@ -339,15 +367,15 @@ void DancingCharacters::DrawPrimitives()
 
 		DISPLAY->SetLighting( true );
 
-		RageColor ambient  = bFailed ? RageColor(0.2f,0.1f,0.1f,1) : (bDanger ? RageColor(0.4f,0.1f,0.1f,1) : RageColor(0.4f,0.4f,0.4f,1));
-		RageColor diffuse  = bFailed ? RageColor(0.4f,0.1f,0.1f,1) : (bDanger ? RageColor(0.8f,0.1f,0.1f,1) : RageColor(1,0.95f,0.925f,1));
-		RageColor specular = RageColor(0.8f,0.8f,0.8f,1);
+		RageColor ambient  = bFailed ? (RageColor)LIGHT_ADANGER_COLOR : (bDanger ? (RageColor)LIGHT_ADANGER_COLOR : (RageColor)LIGHT_AMBIENT_COLOR);
+		RageColor diffuse  = bFailed ? (RageColor)LIGHT_DDANGER_COLOR : (bDanger ? (RageColor)LIGHT_DDANGER_COLOR : (RageColor)LIGHT_DIFFUSE_COLOR);
+		RageColor specular = (RageColor)LIGHT_AMBIENT_COLOR;
 		DISPLAY->SetLightDirectional( 
 			0,
 			ambient, 
 			diffuse,
 			specular,
-			RageVector3(-3, -7.5f, +9) );
+			RageVector3(LIGHTING_X, LIGHTING_Y, LIGHTING_Z) );
 
 		if( PREFSMAN->m_bCelShadeModels )
 		{

--- a/src/DancingCharacters.cpp
+++ b/src/DancingCharacters.cpp
@@ -57,18 +57,13 @@ const ThemeMetric<RageColor>	LIGHT_DFAILED_COLOR	( "DancingCamera", "DiffuseFail
 
 // Position of the model in X (one player)
 #define MODEL_X_ONE_PLAYER				THEME->GetMetricF("DancingCharacters","OnePlayerModelX")
-// Model spacing during Versus or Battle modes.
-#define MODEL_X_VERSUS					THEME->GetMetricF("DancingCharacters","TwoPlayersModelX")
 
 // As the name implies, this sets the ammount of beats that the camera will
 // stay in its current state until transitioning to the next camera tween.
 #define	AMM_BEATS_TIL_NEXTCAMERA			THEME->GetMetricF("DancingCamera","BeatsUntilNextCamPos")
 #define CAM_FOV						THEME->GetMetricF("DancingCamera","CameraFOV")
 
-// Since we only have two players, set those without changing the table too much.
-int VersusSpacing = (int)MODEL_X_VERSUS;
-const float MODEL_X_TWO_PLAYERS[NUM_PLAYERS] = { VersusSpacing, -VersusSpacing };
-
+const float MODEL_X_TWO_PLAYERS[NUM_PLAYERS] = { +8, -8 };
 const float MODEL_ROTATIONY_TWO_PLAYERS[NUM_PLAYERS] = { -90, 90 };
 
 DancingCharacters::DancingCharacters(): m_bDrawDangerLight(false),
@@ -419,7 +414,7 @@ void DancingCharacters::DrawPrimitives()
 	 */
 }
 
-/*
+/*	2018 Jose Varela
  * (c) 2003-2004 Chris Danford
  * All rights reserved.
  * 


### PR DESCRIPTION
The Dancing Characters in SM is quite limited in terms of settings, so I thought of making it more open for people to customize for their themes.

These changes allow for more things to control in terms of the camera and lighting. All being stored in [DancingCamera] located at the bottom of the fallback.ini file.

Here's some images showing the stuff can do with these changes.
![2018-07-29_162701](https://user-images.githubusercontent.com/23246027/43370851-4f70b750-934c-11e8-935f-25abc88a2f77.jpg)
![2018-07-29_135206](https://user-images.githubusercontent.com/23246027/43370858-638a3ca2-934c-11e8-9d64-ef8541221576.jpg)
![2018-07-29_134643](https://user-images.githubusercontent.com/23246027/43370862-69bae874-934c-11e8-96ed-d51c0b2d1f80.jpg)
