### PR TITLE
Disable Minimaid by default

### DIFF
--- a/CMake/DefineOptions.cmake
+++ b/CMake/DefineOptions.cmake
@@ -54,14 +54,14 @@ else()
 endif()
 
 if(WIN32)
-  option(WITH_MINIMAID "Build with Minimaid Lights Support." ON)
+  option(WITH_MINIMAID "Build with Minimaid Lights Support." OFF)
   # Developer only option: connect to IRC to report the result. Only use with build servers.
   option(WITH_IRC_POST_HOOK "Report via IRC of the success afterwards." OFF)
 elseif(LINUX)
     # Builder beware: later versions of ffmpeg may break!
     option(WITH_SYSTEM_FFMPEG "Build with the system's FFMPEG, disabled build with bundled's FFMPEG" OFF)
     option(WITH_CRYSTALHD_DISABLED "Build FFMPEG without Crystal HD support." OFF)
-    option(WITH_MINIMAID "Build with Minimaid Lights Support." ON)
+    option(WITH_MINIMAID "Build with Minimaid Lights Support." OFF)
     option(WITH_TTY "Build with Linux TTY Input Support." OFF)
     option(WITH_PROFILING "Build with Profiling Support." OFF)
     option(WITH_GLES2 "Build with OpenGL ES 2.0 Support." ON)


### PR DESCRIPTION
We want to fix Travis and most users wont use this, will add a proper fix in the future, even if I have to write my own version of libmmmagic myself