### PR TITLE
Fixed keyboard ghosting bug (stepmania/stepmania#1736)

### DIFF
--- a/src/arch/InputHandler/InputHandler_X11.cpp
+++ b/src/arch/InputHandler/InputHandler_X11.cpp
@@ -205,6 +205,7 @@ void InputHandler_X11::Update()
 			}
 
 			// This is a new event so the last release was not a repeat.
+			lastEvent.type = 0;
 			RegisterKeyEvent( event.xkey.time, false, lastDB );
 		}
 


### PR DESCRIPTION
Keyboard ghosting occurred when a key is pressed while a key is released within the same moment.  This fixes that issue.