### PR TITLE
Added ability to target specific CPUs and FPUs when compiling.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -128,6 +128,14 @@ sm_add_compile_definition("${SM_EXE_NAME}" $<$<CONFIG:RelWithDebInfo>:RELWITHDEB
 
 set(SM_COMPILE_FLAGS "")
 
+if(CPU_TARGET)
+  set(SM_COMPILE_FLAGS "${SM_COMPILE_FLAGS} -mcpu=${CPU_TARGET} -mtune=${CPU_TARGET}")
+endif()
+
+if(FPU_TARGET)
+  set(SM_COMPILE_FLAGS "${SM_COMPILE_FLAGS} -mfloat-abi=hard -mfpu=${FPU_TARGET}")
+endif()
+
 if(WITH_SSE2)
   if(MSVC)
     set(SM_COMPILE_FLAGS "${SM_COMPILE_FLAGS} /arch:SSE2")


### PR DESCRIPTION
This will

1. facilitate cross-compiling with just CLI options
2. enable optimized compilation for target platforms with small resources

It's a generic form of my patch over here: https://github.com/SpottyMatt/raspian-3b-stepmania-arcade/blob/master/stepmania-build/raspi-3b-arm.patch which I used to enable compiling a usable build on the ARM-based Raspberry Pi platform.

If merged, the adding the following CMake flags to your cmake invocation would enable compiling StepMania on a Raspberry Pi 3B/3B+ (for example):

```
-DWITH_SSE2=0 \
-DTARGET_CPU=cortex-a53 \
-DTARGET_FPU=neon-fp-armv8
```

Since all of the CMake flag-changing is inside `if(...)` statements, it should have no effect on existing builds that don't provide those options.