### PR TITLE
Fix Xcode build; bump minimum version of macOS

### DIFF
--- a/CMake/SetupFfmpeg.cmake
+++ b/CMake/SetupFfmpeg.cmake
@@ -33,6 +33,14 @@ if(MACOSX)
     "--cc=clang -m64"
     "--enable-sse"
   )
+
+  find_program(
+    FFMPEG_YASM_EXECUTABLE
+    yasm
+    PATHS /usr/bin /usr/local/bin /opt/local/bin)
+  list(APPEND FFMPEG_CONFIGURE
+    "--yasmexe=${FFMPEG_YASM_EXECUTABLE}"
+  )
 endif()
 
 if(WITH_GPL_LIBS)

--- a/CMake/SetupOggVorbis.cmake
+++ b/CMake/SetupOggVorbis.cmake
@@ -23,7 +23,7 @@ if (NOT (IS_DIRECTORY "${SM_VORBIS_SRC_DIR}"))
 endif()
 
 externalproject_add("vorbis"
-  CMAKE_ARGS -DCMAKE_BUILD_TYPE:STRING=Release -DOGG_INCLUDE_DIRS:STRING=${SM_OGG_INCLUDE_DIR} -DOGG_LIBRARIES:STRING=${SM_OGG_ROOT}/libogg.a
+  CMAKE_ARGS -DCMAKE_BUILD_TYPE:STRING=Release -DOGG_INCLUDE_DIRS:STRING=${SM_OGG_INCLUDE_DIR} -DOGG_LIBRARIES:STRING=${SM_OGG_ROOT}/$<$<CONFIG:Release>:Release>$<$<CONFIG:Debug>:Debug>$<$<CONFIG:MinSizeRel>:MinSizeRel>$<$<CONFIG:RelWithDebInfo>:RelWithDebInfo>/libogg.a
   SOURCE_DIR "${SM_VORBIS_SRC_DIR}"
   UPDATE_COMMAND ""
   INSTALL_COMMAND ""
@@ -35,4 +35,3 @@ set(SM_VORBIS_ROOT ${BINARY_DIR})
 set(SM_VORBIS_INCLUDE_DIR "${SM_VORBIS_SRC_DIR}/include")
 
 add_dependencies("vorbis" "ogg")
-

--- a/CMake/SetupOggVorbis.cmake
+++ b/CMake/SetupOggVorbis.cmake
@@ -5,7 +5,7 @@ if (NOT (IS_DIRECTORY "${SM_OGG_SRC_DIR}"))
 endif()
 
 externalproject_add("ogg"
-  CMAKE_ARGS -DCMAKE_BUILD_TYPE:STRING=Release
+  CMAKE_ARGS -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
   SOURCE_DIR "${SM_OGG_SRC_DIR}"
   UPDATE_COMMAND ""
   INSTALL_COMMAND ""
@@ -16,6 +16,19 @@ externalproject_get_property("ogg" BINARY_DIR)
 set(SM_OGG_ROOT ${BINARY_DIR})
 set(SM_OGG_INCLUDE_DIR "${SM_OGG_SRC_DIR}/include")
 
+if(APPLE AND CMAKE_GENERATOR MATCHES "Unix Makefiles")
+  # Xcode does this and CMake is somehow aware, but with Unix Makefiles this is
+  # necessary for the time being.
+  externalproject_add_step("ogg"
+                           fix-path
+                           COMMAND ${CMAKE_COMMAND} -E make_directory ${SM_OGG_ROOT}/${CMAKE_BUILD_TYPE}
+                           DEPENDEES build)
+  externalproject_add_step("ogg"
+                           copy-libogg
+                           COMMAND ${CMAKE_COMMAND} -E copy ${SM_OGG_ROOT}/libogg.a ${SM_OGG_ROOT}/${CMAKE_BUILD_TYPE}/
+                           DEPENDEES fix-path)
+endif()
+
 set(SM_VORBIS_SRC_DIR "${SM_EXTERN_DIR}/libvorbis-git")
 
 if (NOT (IS_DIRECTORY "${SM_VORBIS_SRC_DIR}"))
@@ -23,7 +36,7 @@ if (NOT (IS_DIRECTORY "${SM_VORBIS_SRC_DIR}"))
 endif()
 
 externalproject_add("vorbis"
-  CMAKE_ARGS -DCMAKE_BUILD_TYPE:STRING=Release -DOGG_INCLUDE_DIRS:STRING=${SM_OGG_INCLUDE_DIR} -DOGG_LIBRARIES:STRING=${SM_OGG_ROOT}/$<$<CONFIG:Release>:Release>$<$<CONFIG:Debug>:Debug>$<$<CONFIG:MinSizeRel>:MinSizeRel>$<$<CONFIG:RelWithDebInfo>:RelWithDebInfo>/libogg.a
+  CMAKE_ARGS -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} -DOGG_INCLUDE_DIRS:STRING=${SM_OGG_INCLUDE_DIR} -DOGG_LIBRARIES:STRING=${SM_OGG_ROOT}/${CMAKE_BUILD_TYPE}/libogg.a
   SOURCE_DIR "${SM_VORBIS_SRC_DIR}"
   UPDATE_COMMAND ""
   INSTALL_COMMAND ""
@@ -33,5 +46,21 @@ externalproject_add("vorbis"
 externalproject_get_property("vorbis" BINARY_DIR)
 set(SM_VORBIS_ROOT ${BINARY_DIR})
 set(SM_VORBIS_INCLUDE_DIR "${SM_VORBIS_SRC_DIR}/include")
+
+if(APPLE AND CMAKE_GENERATOR MATCHES "Unix Makefiles")
+  # See note above
+  externalproject_add_step("vorbis"
+                           fix-path
+                           COMMAND ${CMAKE_COMMAND} -E make_directory ${SM_VORBIS_ROOT}/lib/${CMAKE_BUILD_TYPE}
+                           DEPENDEES build)
+  externalproject_add_step("vorbis"
+                           copy-libvorbis
+                           COMMAND ${CMAKE_COMMAND} -E copy ${SM_VORBIS_ROOT}/lib/libvorbis.a ${SM_VORBIS_ROOT}/lib/${CMAKE_BUILD_TYPE}/
+                           DEPENDEES fix-path)
+  externalproject_add_step("vorbis"
+                           copy-libvorbisfile
+                           COMMAND ${CMAKE_COMMAND} -E copy ${SM_VORBIS_ROOT}/lib/libvorbisfile.a ${SM_VORBIS_ROOT}/lib/${CMAKE_BUILD_TYPE}/
+                           DEPENDEES fix-path)
+endif()
 
 add_dependencies("vorbis" "ogg")

--- a/StepmaniaCore.cmake
+++ b/StepmaniaCore.cmake
@@ -224,7 +224,7 @@ endif()
 if(WITH_SDL)
 
     find_package(SDL2)
-    
+
     if(NOT SDL2_FOUND)
         message(FATAL_ERROR "SDL2 Library was not found. If you wish to compile without SDL2, set WITH_SDL to OFF when configuring.")
     else()
@@ -295,10 +295,8 @@ elseif(MACOSX)
 
   set(SYSTEM_PCRE_FOUND FALSE)
   set(WITH_CRASH_HANDLER TRUE)
-  # Apple Archs needs to be 32-bit for now.
-  # When SDL2 is introduced, this may change.
-  set(CMAKE_OSX_DEPLOYMENT_TARGET "10.7")
-  set(CMAKE_OSX_DEPLOYMENT_TARGET_FULL "10.7.0")
+  set(CMAKE_OSX_DEPLOYMENT_TARGET "10.9")
+  set(CMAKE_OSX_DEPLOYMENT_TARGET_FULL "10.9.0")
 
   find_library(MAC_FRAME_ACCELERATE Accelerate ${CMAKE_SYSTEM_FRAMEWORK_PATH})
   find_library(MAC_FRAME_APPKIT AppKit ${CMAKE_SYSTEM_FRAMEWORK_PATH})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -459,9 +459,9 @@ elseif(APPLE)
 
   if (HAS_OGG)
     list(APPEND SMDATA_LINK_LIB
-      "${SM_OGG_ROOT}/libogg.a"
-      "${SM_VORBIS_ROOT}/lib/libvorbis.a"
-      "${SM_VORBIS_ROOT}/lib/libvorbisfile.a"
+      "${SM_OGG_ROOT}/$<$<CONFIG:Release>:Release>$<$<CONFIG:Debug>:Debug>$<$<CONFIG:MinSizeRel>:MinSizeRel>$<$<CONFIG:RelWithDebInfo>:RelWithDebInfo>/libogg.a"
+      "${SM_VORBIS_ROOT}/lib/$<$<CONFIG:Release>:Release>$<$<CONFIG:Debug>:Debug>$<$<CONFIG:MinSizeRel>:MinSizeRel>$<$<CONFIG:RelWithDebInfo>:RelWithDebInfo>/libvorbis.a"
+      "${SM_VORBIS_ROOT}/lib/$<$<CONFIG:Release>:Release>$<$<CONFIG:Debug>:Debug>$<$<CONFIG:MinSizeRel>:MinSizeRel>$<$<CONFIG:RelWithDebInfo>:RelWithDebInfo>/libvorbisfile.a"
     )
   endif()
 

--- a/src/arch/InputHandler/InputHandler_MacOSX_HID.cpp
+++ b/src/arch/InputHandler/InputHandler_MacOSX_HID.cpp
@@ -461,9 +461,9 @@ wchar_t InputHandler_MacOSX_HID::DeviceButtonToChar( DeviceButton button, bool b
 	UInt8 iMacVirtualKey;
 	if( KeyboardDevice::DeviceButtonToMacVirtualKey( button, iMacVirtualKey ) )
 	{
-        CGEventRef event = CGEventCreate(NULL);
-        CGEventFlags mods = CGEventGetFlags(event);
-        UInt32 nModifiers = bUseCurrentKeyModifiers ? (UInt32)mods : 0;
+		CGEventRef event = CGEventCreate(NULL);
+		CGEventFlags mods = CGEventGetFlags(event);
+		UInt32 nModifiers = bUseCurrentKeyModifiers ? (UInt32)mods : 0;
 		wchar_t sCharCode = KeyCodeToChar( iMacVirtualKey, nModifiers );
 		if( sCharCode != 0 )
 		{

--- a/src/archutils/Darwin/Crash.cpp
+++ b/src/archutils/Darwin/Crash.cpp
@@ -98,7 +98,7 @@ bool CrashHandler::IsDebuggerPresent()
 
 void CrashHandler::DebugBreak()
 {
-	os_log(OS_LOG_DEFAULT, "\pDebugBreak()");
+	os_log(OS_LOG_DEFAULT, "DebugBreak()");
 }
 
 /*


### PR DESCRIPTION
This fixes the Xcode build and also makes the "Unix Makefile" generator work properly for the Ogg/Vorbis oddness. You can do these side-by-side:

```
cd Build
cmake -G Xcode ..
xcodebuild  # or `open StepMania.xcodeproj/` and click Build in Xcode UI
```

```
mkdir Build2
cd Build2
cmake -DCMAKE_BUILD_TYPE=Release ..
make -j9
```

This fixes detecting the yasm binary for ffmpeg. And I adjusted the tabs in `InputHandler_MacOSX_HID.cpp` since they went in as spaces in my last PR.

It is recommended that `-DCMAKE_BUILD_TYPE` always get passed in the Makefile case, but if left blank it will work too.

I will try and figure out Ninja support in the future. It has the same problem as Makefile but the target computation is not done earlier than how Make does it.