### PR TITLE
Add more OptionsList functionality

### DIFF
--- a/Themes/_fallback/metrics.ini
+++ b/Themes/_fallback/metrics.ini
@@ -18,8 +18,6 @@ IsBaseTheme=1
 # How big the design of the theme is. for example, if a theme was designed for
 # 1080p, it would be shrunken for 640x480, as well as that, if it was designed
 # for 480p, it would be enlarged for bigger screens!
-# Note that doubleres graphics display with double the resolution, so a 640x480
-# doubleres theme will have an effective resolution of 1280x960
 ScreenWidth=1
 ScreenHeight=480
 
@@ -1844,7 +1842,7 @@ PrevScreen="ScreenInit"
 NextScreen=Branch.AfterInit()
 StartScreen=Branch.TitleMenu()
 #
-ForceTimer=false
+ForceTimer=true
 TimerSeconds=5
 #
 PlayMusic=false
@@ -2874,6 +2872,59 @@ ExplanationTogetherOffCommand=stoptweening
 
 [ScreenOptionsServiceExtendedChild]
 Fallback="ScreenOptionsServiceChild"
+[OptionsList]
+Fallback="ScreenWithMenuElements"
+
+#If true, holding left and pressing right will go to the next menu, and holding right and pressing left will go to the previous menu.
+LeftAndRightSwitchesMenu=true
+CodeNames=""
+
+#It takes from ScreenOptionsMaster.
+#This is the equivalent to LineNames
+TopMenus=""
+TopMenu=""
+
+DirectLines=""
+ItemsSpacingY=
+MaxItemsBeforeSplit=
+ItemsSplitWidth=
+
+TextOnCommand=
+TextOffCommand=
+TextTweenOffCommand=
+TextTweenOnCommand=
+TextResetCommand=
+
+UnderlineOnCommand=
+UnderlineOffCommand=
+UnderlineSetTwoRowsCommand=
+UnderlineSetOneRowCommand=
+UnderlineShowCommand=
+UnderlineHideCommand=
+UnderlineTweenOnCommand=
+UnderlineTweenOffCommand=
+UnderlineResetCommand=
+
+CursorOnCommand=
+CursorPositionTwoRowsCommand=
+CursorPositionOneRowCommand=
+CursorTweenOnCommand=
+CursorTweenOffCommand=
+CursorResetCommand=
+
+OptionsListOnCommand=
+OptionsListOffCommand=
+OptionsListTweenOffCommand=
+OptionsListTweenOnCommand=
+OptionsListResetCommand=
+
+OptionsListTweenOutForwardCommand=
+OptionsListTweenOutBackwardCommand=
+OptionsListTweenInForwardCommand=
+OptionsListTweenInBackwardCommand=
+
+OptionsListFadeOffCommand=
+OptionsListFadeOnCommand=
 
 [ScreenMiniMenu]
 Class="ScreenMiniMenu"

--- a/src/OptionRowHandler.cpp
+++ b/src/OptionRowHandler.cpp
@@ -1326,7 +1326,7 @@ public:
 		LUA->Release(L);
 		return changed;
 	}
-	virtual bool GoToFirstOnStart()
+	virtual bool GoToFirstOnStart() const
 	{
 		return m_GoToFirstOnStart;
 	}

--- a/src/OptionRowHandler.h
+++ b/src/OptionRowHandler.h
@@ -186,7 +186,7 @@ public:
 	virtual RString GetScreen( int /* iChoice */ ) const { return RString(); }
 	// Exists so that a lua function can act on the selection.  Returns true if the choices should be reloaded.
 	virtual bool NotifyOfSelection(PlayerNumber pn, int choice) { return false; }
-	virtual bool GoToFirstOnStart() { return true; }
+	virtual bool GoToFirstOnStart() const { return true; }
 };
 
 /** @brief Utilities for the OptionRowHandlers. */

--- a/src/OptionsList.h
+++ b/src/OptionsList.h
@@ -70,7 +70,7 @@ private:
 	void SelectionsChanged( const RString &sRowName );
 	void UpdateMenuFromSelections();
 	RString GetCurrentRow() const;
-	const OptionRowHandler *GetCurrentHandler();
+	OptionRowHandler *GetCurrentHandler();
 	int GetOneSelection( RString sRow, bool bAllowFail=false ) const;
 	void SwitchToCurrentRow();
 	void TweenOnCurrentRow( bool bForward );
@@ -101,6 +101,8 @@ private:
 
 	vector<RString> m_asMenuStack;
 	int m_iMenuStackSelection;
+protected:
+	bool m_bLeftAndRightSwitchesMenu;
 };
 
 


### PR DESCRIPTION
This fixes up the OptionsList a bit.

- Include a "Size" parameter in OptionsMenuChanged so themers know the size of the newly set OptionsList. From what I see in the source, the OptionRow actor is never available to themers because it's not actually used as an actor in OptionsList, so the size can't be obtained the normal way.
- Do not jump to the exit button if the OptionRow is SELECT_MULTIPLE, because it's an annoyance.
- Support NotifyOfSelection in OptionRow so selections and text can be changed on the fly.
- Add a metric "LeftAndRightSwitchesMenu" to disable the holding left+pressing right or holding right+pressing left functionality that switches to the next menu in the OptionsList, because many people seem to think it's a glitch, and many people seem to be annoyed by it.
- Add OptionsList parameters in metrics.ini so people know what to edit.