### PR TITLE
Make TwoPartSelect remappable

### DIFF
--- a/Themes/_fallback/metrics.ini
+++ b/Themes/_fallback/metrics.ini
@@ -2164,6 +2164,7 @@ PreviousSongButton="MenuLeft"
 NextSongButton="MenuRight"
 #
 ChangeStepsWithGameButtons=false
+#Prev/NextDifficultyButton Also applies to TwoPartSelect.
 PreviousDifficultyButton="MenuUp"
 NextDifficultyButton="MenuDown"
 #
@@ -2174,6 +2175,8 @@ NextGroupButton="MenuDown"
 TwoPartSelection=TwoPartSelection()
 TwoPartConfirmsOnly=false
 TwoPartTimerSeconds=30
+CancelTwoPartSelectButton1="MenuUp"
+CancelTwoPartSelectButton2="MenuDown"
 #
 SampleMusicDelay=0.25
 SampleMusicDelayInit=0

--- a/src/GrooveRadar.cpp
+++ b/src/GrooveRadar.cpp
@@ -107,7 +107,7 @@ void GrooveRadar::GrooveRadarValueMap::SetFromSteps( const RadarValues &rv )
 	{
 		const float fValueCurrent = m_fValuesOld[c] * (1-m_PercentTowardNew) + m_fValuesNew[c] * m_PercentTowardNew;
 		m_fValuesOld[c] = fValueCurrent;
-		m_fValuesNew[c] = (int)clamp(rv[c], 0.0, 1.0);
+		m_fValuesNew[c] = clamp(rv[c], 0.0, 1.0);
 	}
 
 	if( !m_bValuesVisible ) // the values WERE invisible

--- a/src/ScreenSelectMusic.cpp
+++ b/src/ScreenSelectMusic.cpp
@@ -111,10 +111,16 @@ void ScreenSelectMusic::Init()
 	m_GameButtonNextSong = INPUTMAPPER->GetInputScheme()->ButtonNameToIndex( THEME->GetMetric(m_sName,"NextSongButton") );
 
 	// Ask for those only if changing steps with gamebuttons is allowed -DaisuMaster
-	if( CHANGE_STEPS_WITH_GAME_BUTTONS )
+	// Use for TwoPartSelection too.
+	if( CHANGE_STEPS_WITH_GAME_BUTTONS || TWO_PART_SELECTION )
 	{
 		m_GameButtonPreviousDifficulty = INPUTMAPPER->GetInputScheme()->ButtonNameToIndex( THEME->GetMetric(m_sName,"PreviousDifficultyButton") );
 		m_GameButtonNextDifficulty = INPUTMAPPER->GetInputScheme()->ButtonNameToIndex( THEME->GetMetric(m_sName,"NextDifficultyButton") );
+	}
+	if( TWO_PART_SELECTION )
+	{
+		m_GameButtonCancelTwoPart1 = INPUTMAPPER->GetInputScheme()->ButtonNameToIndex( THEME->GetMetric(m_sName,"CancelTwoPartSelectButton1") );
+		m_GameButtonCancelTwoPart2 = INPUTMAPPER->GetInputScheme()->ButtonNameToIndex( THEME->GetMetric(m_sName,"CancelTwoPartSelectButton2") );
 	}
 	// same here but for groups -DaisuMaster
 	if( CHANGE_GROUPS_WITH_GAME_BUTTONS )
@@ -852,16 +858,16 @@ bool ScreenSelectMusic::Input( const InputEventPlus &input )
 	{
 		if( m_SelectionState == SelectionState_SelectingSteps && input.type == IET_FIRST_PRESS && !m_bStepsChosen[input.pn] )
 		{
-			if( input.MenuI == m_GameButtonNextSong || input.MenuI == m_GameButtonPreviousSong )
+			if( input.MenuI == m_GameButtonPreviousDifficulty || input.MenuI == m_GameButtonNextDifficulty )
 			{
-				if( input.MenuI == m_GameButtonPreviousSong )
+				if( input.MenuI == m_GameButtonPreviousDifficulty )
 				{
 					if( GAMESTATE->IsAnExtraStageAndSelectionLocked() )
 						m_soundLocked.Play(true);
 					else
 						ChangeSteps( input.pn, -1 );
 				}
-				else if( input.MenuI == m_GameButtonNextSong )
+				else if( input.MenuI == m_GameButtonNextDifficulty )
 				{
 					if( GAMESTATE->IsAnExtraStageAndSelectionLocked() )
 						m_soundLocked.Play(true);
@@ -869,7 +875,8 @@ bool ScreenSelectMusic::Input( const InputEventPlus &input )
 						ChangeSteps( input.pn, +1 );
 				}
 			}
-			else if( input.MenuI == GAME_BUTTON_MENUUP || input.MenuI == GAME_BUTTON_MENUDOWN ) // && TWO_PART_DESELECTS_WITH_MENUUPDOWN
+			//This should not be MENUP or MENUDOWN, different games use different buttons to cancel.
+			else if( input.MenuI == m_GameButtonCancelTwoPart1 || input.MenuI == m_GameButtonCancelTwoPart2 ) // && TWO_PART_DESELECTS_WITH_MENUUPDOWN
 			{
 				if( GAMESTATE->IsAnExtraStageAndSelectionLocked() )
 					m_soundLocked.Play(true);

--- a/src/ScreenSelectMusic.h
+++ b/src/ScreenSelectMusic.h
@@ -123,6 +123,8 @@ protected:
 	GameButton m_GameButtonNextDifficulty;
 	GameButton m_GameButtonPreviousGroup;
 	GameButton m_GameButtonNextGroup;
+	GameButton m_GameButtonCancelTwoPart1;
+	GameButton m_GameButtonCancelTwoPart2;
 
 	RString m_sSectionMusicPath;
 	RString m_sSortMusicPath;


### PR DESCRIPTION
DDR uses Up/Down to select difficulty.
PIU uses Left/Right to select difficulty.
Thus these should be remappable for themers.
Because the Up/Down to cancel mapping would conflict with the Up/Down to change difficulty mapping, these also need to be remappable. 

P.S. I tested this and it works