### PR TITLE
Remove outlier steps when adjusting sync.

### DIFF
--- a/src/AdjustSync.cpp
+++ b/src/AdjustSync.cpp
@@ -190,8 +190,14 @@ void AdjustSync::HandleSongEnd()
 
 void AdjustSync::AutosyncOffset()
 {
-	const float mean = calc_mean( s_fAutosyncOffset, s_fAutosyncOffset+OFFSET_SAMPLE_COUNT );
-	const float stddev = calc_stddev( s_fAutosyncOffset, s_fAutosyncOffset+OFFSET_SAMPLE_COUNT );
+    // Sort the steps by offset, so that outliers can be discarded.
+    std::sort( s_fAutosyncOffset, s_fAutosyncOffset+OFFSET_SAMPLE_COUNT );
+	const float mean = calc_mean( 
+	    s_fAutosyncOffset+OFFSET_OUTLIER_COUNT, 
+	    s_fAutosyncOffset+OFFSET_SAMPLE_COUNT-OFFSET_OUTLIER_COUNT);
+	const float stddev = calc_stddev(
+	    s_fAutosyncOffset+OFFSET_OUTLIER_COUNT, 
+	    s_fAutosyncOffset+OFFSET_SAMPLE_COUNT-OFFSET_OUTLIER_COUNT);
 
 	AutosyncType type = GAMESTATE->m_SongOptions.GetCurrent().m_AutosyncType;
 

--- a/src/AdjustSync.h
+++ b/src/AdjustSync.h
@@ -12,6 +12,16 @@
  */
 #define OFFSET_SAMPLE_COUNT 24
 
+/**
+ * @brief Removes outliers when adjusting sync of a song or machine.
+ *
+ * Of the OFFSET_SAMPLE_COUNT steps used to adjust the machine offset, the
+ * OFFSET_OUTLIER_COUNT earliest and OFFSET_OUTLIER_COUNT latest steps will
+ * be discarded prior to calculating mean / standard deviation. This makes
+ * adjustments more robust to the occassional misstep by the player.
+ */
+#define OFFSET_OUTLIER_COUNT 2
+
 class TimingData;
 /**
  * @brief Allows for adjusting the sync of a song.


### PR DESCRIPTION
I found that adjusting the sync is quite noisy due to outlier steps (such as a bad misstep on the pad, or poor timing when hitting the first step after a pause).

Figured that if the two earliest and two latest steps are removed before calculating mean / std, it'll give a better estimate of what the offset should be (and will reduce the standard deviation, decreasing the changes of the adjustment being discarded due to high standard deviation).