### PR TITLE
Course mode trail generation fixes

### DIFF
--- a/src/Course.cpp
+++ b/src/Course.cpp
@@ -479,9 +479,9 @@ bool Course::GetTrailUnsorted( StepsType st, CourseDifficulty cd, Trail &trail )
 	}
 	else
 	{
+		vector<SongAndSteps> vSongAndSteps;
 		for (auto e = entries.begin(); e != entries.end(); ++e)
 		{
-			vector<SongAndSteps> vSongAndSteps;
 			SongAndSteps resolved;	// fill this in
 			SongCriteria soc = e->songCriteria;
 
@@ -505,6 +505,7 @@ bool Course::GetTrailUnsorted( StepsType st, CourseDifficulty cd, Trail &trail )
 
 			if( pSong )
 			{
+				vSongAndSteps.clear();
 				StepsUtil::GetAllMatching( pSong, stc, vSongAndSteps );
 			}
 			else if( vSongAndSteps.empty() || !( bSameSongCriteria && bSameStepsCriteria ) )
@@ -732,27 +733,17 @@ void Course::GetTrailUnsortedEndless( const vector<CourseEntry> &entries, Trail 
 			// Make a backup of the steplist so we can revert if we overfilter
 			std::vector<SongAndSteps> revertList = vSongAndSteps;
 			// Filter candidate list via blacklist
-			vSongAndSteps.erase(std::remove_if(
-				vSongAndSteps.begin(),
-				vSongAndSteps.end(),
-				[&](const SongAndSteps& ss) {
-					return std::find(alreadySelected.begin(), alreadySelected.end(), ss.pSong) != alreadySelected.end();
-				}),
-				vSongAndSteps.end());
+			RemoveIf(vSongAndSteps, [&](const SongAndSteps& ss) {
+				return std::find(alreadySelected.begin(), alreadySelected.end(), ss.pSong) != alreadySelected.end();
+			});
 			// If every candidate is in the blacklist, pick random song that wasn't played last
 			// (Repeat songs may still occur if song after this is fixed; this algorithm doesn't look ahead)
 			if (vSongAndSteps.empty())
 			{
 				vSongAndSteps = revertList;
-				vSongAndSteps.erase(std::remove_if(
-					vSongAndSteps.begin(),
-					vSongAndSteps.end(),
-					[&](const SongAndSteps& ss) {
-						return ss.pSong == lastSongSelected;
-					}),
-					vSongAndSteps.end());
+				RemoveIf(vSongAndSteps, SongIsEqual(lastSongSelected));
 
-				// If the song that was played last was the only candidate, forget it
+				// If the song that was played last was the only candidate, give up pick randomly
 				if (vSongAndSteps.empty())
 				{
 					vSongAndSteps = revertList;
@@ -891,11 +882,6 @@ void Course::GetTrailUnsortedEndless( const vector<CourseEntry> &entries, Trail 
 		}
 
 		trail.m_vEntries.push_back( te );
-		//if( trail.m_vEntries.size() > 0 && te.dc != cd )
-		//{
-		//	trail.m_vEntries.reserve( trail.m_vEntries.size() - 1 );
-		//	trail.m_vEntries.resize( trail.m_vEntries.size() - 1 );
-		//}
 		// LOG->Trace( "Chose: %s, %d", te.pSong->GetSongDir().c_str(), te.pSteps->GetMeter() );
 
 		if( IsAnEdit() && MAX_SONGS_IN_EDIT_COURSE > 0 &&

--- a/src/Course.cpp
+++ b/src/Course.cpp
@@ -680,13 +680,10 @@ bool Course::GetTrailUnsorted( StepsType st, CourseDifficulty cd, Trail &trail )
 void Course::GetTrailUnsortedEndless( const vector<CourseEntry> &entries, Trail &trail, StepsType &st, 
 	CourseDifficulty &cd, RandomGen &rnd, bool &bCourseDifficultyIsSignificant ) const
 {
-	vector<Song*> vpAllPossibleSongs;
-	vector<SongAndSteps> vSongAndSteps;
-	vector<Song*> vpSongs;
 	typedef vector<Steps*> StepsVector;
-	std::map<Song*, StepsVector> mapSongToSteps;
-	int songIndex = 0;
-	bool vpSongsSorted = false;
+	std::set<Song*> alreadySelected;
+	Song* lastSongSelected;
+	vector<SongAndSteps> vSongAndSteps;
 	for (auto e = entries.begin(); e != entries.end(); ++e)
 	{
 
@@ -712,8 +709,11 @@ void Course::GetTrailUnsortedEndless( const vector<CourseEntry> &entries, Trail 
 		const bool bSameSongCriteria = e != entries.begin() && ( e - 1 )->songCriteria == soc;
 		const bool bSameStepsCriteria = e != entries.begin() && ( e - 1 )->stepsCriteria == stc;
 
+		// If we're doing the same wildcard search as last entry,
+		// we can just reuse the vSongAndSteps vector.
 		if( pSong )
 		{
+			vSongAndSteps.clear();
 			StepsUtil::GetAllMatchingEndless( pSong, stc, vSongAndSteps );
 		}
 		else if( vSongAndSteps.empty() || !( bSameSongCriteria && bSameStepsCriteria ) )
@@ -726,37 +726,70 @@ void Course::GetTrailUnsortedEndless( const vector<CourseEntry> &entries, Trail 
 		if( vSongAndSteps.empty() )
 			continue;
 
-		if( !vpSongsSorted && !vSongAndSteps.empty() ) {
-			for (auto const &sas: vSongAndSteps)
+		// if we're doing a RANDOM wildcard search, try to avoid repetition
+		if (vSongAndSteps.size() > 1 && e->songSort == SongSort::SongSort_Randomize)
+		{
+			// Make a backup of the steplist so we can revert if we overfilter
+			std::vector<SongAndSteps> revertList = vSongAndSteps;
+			// Filter candidate list via blacklist
+			vSongAndSteps.erase(std::remove_if(
+				vSongAndSteps.begin(),
+				vSongAndSteps.end(),
+				[&](const SongAndSteps& ss) {
+					return std::find(alreadySelected.begin(), alreadySelected.end(), ss.pSong) != alreadySelected.end();
+				}),
+				vSongAndSteps.end());
+			// If every candidate is in the blacklist, pick random song that wasn't played last
+			// (Repeat songs may still occur if song after this is fixed; this algorithm doesn't look ahead)
+			if (vSongAndSteps.empty())
 			{
-				StepsVector &v = mapSongToSteps[sas.pSong];
-				
-				v.push_back( sas.pSteps );
-				if( v.size() == 1 )
+				vSongAndSteps = revertList;
+				vSongAndSteps.erase(std::remove_if(
+					vSongAndSteps.begin(),
+					vSongAndSteps.end(),
+					[&](const SongAndSteps& ss) {
+						return ss.pSong == lastSongSelected;
+					}),
+					vSongAndSteps.end());
+
+				// If the song that was played last was the only candidate, forget it
+				if (vSongAndSteps.empty())
 				{
-					vpSongs.push_back( sas.pSong );
+					vSongAndSteps = revertList;
 				}
 			}
-			vpSongsSorted = true;
-			CourseSortSongs( e->songSort, vpSongs, rnd );
-			songIndex = 0;
 		}
 
-		ASSERT( e->iChooseIndex >= 0 );
-		if( e->iChooseIndex < int( vSongAndSteps.size() ) )
+		std::vector<Song*> vpSongs;
+		std::map<Song*, StepsVector> songStepMap;
+		// Build list of songs for sorting, and mapping of songs to steps simultaneously
+		for (auto& ss : vSongAndSteps)
 		{
-			if( songIndex >= vpSongs.size() ) {
-				songIndex = 0;
+			StepsVector& stepsForSong = songStepMap[ss.pSong];
+			// If we haven't noted this song yet, add it to the song list
+			if (stepsForSong.size() == 0)
+			{
+				vpSongs.push_back(ss.pSong);
 			}
-			resolved.pSong = vpSongs[ songIndex ];
-			const vector<Steps*> &mappedSongs = mapSongToSteps[ resolved.pSong ];
-			songIndex++;
-			resolved.pSteps = mappedSongs[ RandomInt( mappedSongs.size() ) ];
+
+			stepsForSong.push_back(ss.pSteps);
 		}
-		else
-		{
+
+		ASSERT(e->iChooseIndex >= 0);
+		// If we're trying to pick BEST100 when only 99 songs exist,
+		// we have a problem, so bail out
+		if (e->iChooseIndex >= vpSongs.size()) {
 			continue;
 		}
+
+		// Otherwise, pick random steps corresponding to the selected song
+		CourseSortSongs(e->songSort, vpSongs, rnd);
+		resolved.pSong = vpSongs[e->iChooseIndex];
+		const vector<Steps*>& songSteps = songStepMap[resolved.pSong];
+		resolved.pSteps = songSteps[random_up_to(rnd, songSteps.size())];
+
+		lastSongSelected = resolved.pSong;
+		alreadySelected.emplace(resolved.pSong);
 
 		/* If we're not COURSE_DIFFICULTY_REGULAR, then we should be choosing steps that are
 		 * either easier or harder than the base difficulty.  If no such steps exist, then
@@ -858,11 +891,11 @@ void Course::GetTrailUnsortedEndless( const vector<CourseEntry> &entries, Trail 
 		}
 
 		trail.m_vEntries.push_back( te );
-		if( trail.m_vEntries.size() > 0 && te.dc != cd )
-		{
-			trail.m_vEntries.reserve( trail.m_vEntries.size() - 1 );
-			trail.m_vEntries.resize( trail.m_vEntries.size() - 1 );
-		}
+		//if( trail.m_vEntries.size() > 0 && te.dc != cd )
+		//{
+		//	trail.m_vEntries.reserve( trail.m_vEntries.size() - 1 );
+		//	trail.m_vEntries.resize( trail.m_vEntries.size() - 1 );
+		//}
 		// LOG->Trace( "Chose: %s, %d", te.pSong->GetSongDir().c_str(), te.pSteps->GetMeter() );
 
 		if( IsAnEdit() && MAX_SONGS_IN_EDIT_COURSE > 0 &&

--- a/src/Course.cpp
+++ b/src/Course.cpp
@@ -479,9 +479,9 @@ bool Course::GetTrailUnsorted( StepsType st, CourseDifficulty cd, Trail &trail )
 	}
 	else
 	{
-		vector<SongAndSteps> vSongAndSteps;
 		for (auto e = entries.begin(); e != entries.end(); ++e)
 		{
+			vector<SongAndSteps> vSongAndSteps;
 			SongAndSteps resolved;	// fill this in
 			SongCriteria soc = e->songCriteria;
 

--- a/src/StepsUtil.cpp
+++ b/src/StepsUtil.cpp
@@ -80,7 +80,7 @@ void StepsUtil::GetAllMatchingEndless( Song *pSong, const StepsCriteria &stc, ve
 		successful = true;
 	}
 
-	if( !successful )
+	if( !successful && vSteps.size() > 0 )
 	{
 		Difficulty difficulty = ( *( vSteps.begin() ) )->GetDifficulty();
 		Difficulty previousDifficulty = difficulty;


### PR DESCRIPTION
Fix #1828 

This implements fixes for trail generation bugs noted in that issue, both in nonstop/oni and endless mode. In particular:

- Wildcards and group wildcards now work properly and don't infect the following course entries
- Endless course generation would crash in `GetAllMatchingEndless` when no steps existed for a song in a certain gamemode (attempting to obtain `begin()` of size-0 vector)
- Endless course generation algorithm was screwed up, so I tore it out and stuck a new one in
- Endless courses were not allowed to have individual tracks differing in difficulty from the course itself, for some reason (so Easy courses could only have Easy charts selected, etc.) I don't know if there's a good rationale for this (EDIT: PR #1022 partially explains it) but I noticed nonstop courses do not have this behavior so I removed it from the endless coursegen

(At this point I'm not sure _why_ it is that endless and nonstop use different course generation functions; they appear to be 90% similar, and I have a feeling most of the above bugs are because one codepath got fixes and the other didn't. I'm pretty new to the codebase though so I left it as is.)

I decided to remove the previous algorithm used by `GetTrailUnsortedEndless` to pick songs and steps from course entries because it wasn't clear what it was supposed to be doing outside of some comments left way back at the time of commit (PR #1002), and more importantly, didn't _work_. (Not sure how long this has been in a broken state.) I'm not sure my implementation here works 100% the way the original author intended, but it's basically this:

For each course entry:
1. Get all songs/steps according to song/step criteria (as normal)
2. If generating from a * (random sort):
2a. Filter out any song/step pairs with songs that have already been selected during trail generation; if no candidates left, go to 2b., else 3.
2b. Filter out the last played song; if no candidates left, give up trying to filter (should only happen if a wildcard has only one possible matching song)
3. Sort songs by course entry sort setting, then choose the appropriate song and random matching chart
4. Update already-selected list and last-played

This (fairly naive) algorithm acts as a pseudo-shuffle in that the only time repeats are possible is when all songs that can be generated from a given course entry are in the pool. However, the algorithm falls back to randomness (though it doesn't allow for selecting the same song twice) at that point, since there's no point at which the already-selected vector is cleared. If every course entry were identical it would be a different story, but since every entry has a different pool of allowed songs it isn't clear where would be the correct time to reset the shuffle. (Maybe could do a loop over course entries to get the superset of all possible songs and use the size of that to determine when to reset the already-selected pool?)

This implementation doesn't forbid repeat songs in cases such as:

```
#SONG:*:HEAVY;
#SONG:Springtime:HEAVY;
```

Could use one-song lookahead with wildcards to get around this, but I opted to leave it alone for now.

My implementation is pretty brute-force in terms of time complexity, so there's definitely room for improvement (and I'd be happy to hear any feedback as to how to improve this). I did some profiling of a release build in VS and it seems like the majority of CPU time spent is in `GetAllMatchingEndless`, so I didn't put much into optimizing the algorithm itself. It may be a different story on lower-spec hardware;  I don't have any on-hand. I used a stress-test course with a couple hundred wildcard-selected songs chosen from a pretty sizeable song pool and it loaded quickly enough on my laptop.

Tried to more-or-less match existing code style, dunno how well I succeeded.

**EDIT:** If anyone has repro information for #1020, I'd appreciate it. I'd like to make sure this isn't introducing a regression. Did some testing (removed a Medium chart and used it at the start of an Endless course, etc.) and I don't see any problems but a specific known problematic case might make that a bit easier to tell.