### PR TITLE
A fix to song movies not playing in game

### DIFF
--- a/src/ScreenSelectMusic.cpp
+++ b/src/ScreenSelectMusic.cpp
@@ -1183,6 +1183,15 @@ void ScreenSelectMusic::HandleScreenMessage( const ScreenMessage SM )
 	}
 	else if( SM == SM_GoToNextScreen )
 	{
+		// Reload the currently selected song. This fixes the song bg movies (with symbols in filename)
+		// from not playing in game - sillybear
+		Song* to_reload = m_MusicWheel.GetSelectedSong();
+		if( to_reload )
+		{
+			to_reload->ReloadFromSongDir();
+			AfterMusicChange();
+		}
+		
 		if( !m_bGoToOptions )
 			SOUND->StopMusic();
 	}


### PR DESCRIPTION
This fixes song movies with symbols in filename (e.g. comma) from not playing in game by reloading the sm/ssc file when going to next screen.
Example movies being tested:
- Help me, ERINNNNNN!! (from DDR A)
- Hello, planet (from DDR A)