### PR TITLE
Attract Watchdog during times of low memory due to leaks

### DIFF
--- a/src/ScreenManager.cpp
+++ b/src/ScreenManager.cpp
@@ -135,10 +135,12 @@ namespace ScreenManagerUtil
 			}
 			else if (m_stPrevScreenType == attract && ls.m_pScreen->GetScreenType() == attract)
 			{
+				unsigned long free_ram = ArchHooks::GetSystemAvailRam();
+
 				//If we are in attract, and RAM is below threshold, then start keeping an eye on the clock.
-				if(ArchHooks::GetSystemFreeRam() < g_iAttractWatchdogRAMThreshold)
+				if(free_ram < g_iAttractWatchdogRAMThreshold)
 				{
-					LOG->Warn("RAM is below set threshold: %dMB < %dMB", ArchHooks::GetSystemFreeRam(), g_iAttractWatchdogRAMThreshold.Get());
+					LOG->Warn("RAM is below set threshold: %dMB < %dMB", free_ram, g_iAttractWatchdogRAMThreshold.Get());
 
 					if(m_tAttractWatchdog.Ago() > g_fAttractWatchdogTimeout)
 					{

--- a/src/arch/ArchHooks/ArchHooks.h
+++ b/src/arch/ArchHooks/ArchHooks.h
@@ -126,7 +126,7 @@ public:
 	void RegisterWithLua();
 
 	// Check on system memory status
-	static unsigned long GetSystemFreeRam();
+	static unsigned long GetSystemAvailRam();
 
 private:
 	/* This are helpers for GetMicrosecondsSinceStart on systems with a timer

--- a/src/arch/ArchHooks/ArchHooks.h
+++ b/src/arch/ArchHooks/ArchHooks.h
@@ -125,6 +125,9 @@ public:
 	void PushSelf( lua_State *L );
 	void RegisterWithLua();
 
+	// Check on system memory status
+	static unsigned long GetSystemFreeRam();
+
 private:
 	/* This are helpers for GetMicrosecondsSinceStart on systems with a timer
 	 * that may loop or move backwards. */

--- a/src/arch/ArchHooks/ArchHooks_Unix.cpp
+++ b/src/arch/ArchHooks/ArchHooks_Unix.cpp
@@ -17,6 +17,7 @@
 #include <sys/time.h>
 #include <sys/types.h>
 #include <sys/wait.h>
+#include <sys/sysinfo.h>
 
 #if defined(CRASH_HANDLER)
 #include "archutils/Unix/CrashHandler.h"
@@ -417,6 +418,14 @@ void ArchHooks::MountUserFilesystems( const RString &sDirOfExecutable )
 	FILEMAN->Mount( "dir", sUserDataPath + "/Songs", "/Songs" );
 	FILEMAN->Mount( "dir", sUserDataPath + "/RandomMovies", "/RandomMovies" );
 	FILEMAN->Mount( "dir", sUserDataPath + "/Themes", "/Themes" );
+}
+
+unsigned long ArchHooks::GetSystemFreeRam()
+{
+	struct sysinfo si;
+	sysinfo (&si);
+
+	return si.freeram / (1024 * 1024);
 }
 
 /*

--- a/src/arch/ArchHooks/ArchHooks_Win32.cpp
+++ b/src/arch/ArchHooks/ArchHooks_Win32.cpp
@@ -238,6 +238,16 @@ RString ArchHooks_Win32::GetClipboard()
 	return ret;
 }
 
+unsigned long ArchHooks::GetSystemFreeRam()
+{
+	MEMORYSTATUSEX statex;
+	statex.dwLength = sizeof(statex);
+
+	GlobalMemoryStatusEx(&statex);
+
+	return statex.ullTotalPhys / (1024 * 1024);
+}
+
 /*
  * (c) 2003-2004 Glenn Maynard, Chris Danford
  * All rights reserved.

--- a/src/arch/ArchHooks/ArchHooks_Win32.cpp
+++ b/src/arch/ArchHooks/ArchHooks_Win32.cpp
@@ -238,14 +238,22 @@ RString ArchHooks_Win32::GetClipboard()
 	return ret;
 }
 
-unsigned long ArchHooks::GetSystemFreeRam()
+unsigned long ArchHooks::GetSystemAvailRam()
 {
 	MEMORYSTATUSEX statex;
 	statex.dwLength = sizeof(statex);
 
+	// grab system info.
 	GlobalMemoryStatusEx(&statex);
 
-	return statex.ullTotalPhys / (1024 * 1024);
+	// grab memory currently in use by the process
+	// taken from RyTak
+	PROCESS_MEMORY_COUNTERS pmc;
+    GetProcessMemoryInfo(GetCurrentProcess(), &pmc, sizeof(pmc));
+    SIZE_T MemUse = pmc.PagefileUsage / (1024 * 1024) - 32;
+
+	// return difference between total ram on the system and the memory currently in use.
+	return (statex.ullAvailPhys / (1024 * 1024)) - MemUse;
 }
 
 /*


### PR DESCRIPTION
As a fan of Stepmania and an owner of multiple cabinets, I am in the interest in maintaining uptimes on low end hardware...with the requisite "too many songs".

Recently I rolled out an installation of 5.1-new to a venue and got messages saying the machine would lock up after a certain period of time.

Going through my troubleshooting techniques I set up the same installation at home, and sure enough over the course of a couple hours the footprint of StepMania grows slowly and begins to approach the physical memory limit.

I contacted some of the people that I knew from the dev team and they are well aware of some of the memory issues plaguing the current code base and are on track to solve them in future revisions....

However this leaves me in a predicament. I can easily install more RAM into the system, but at some point, for example a venue with 24h operation, the game will still reach the limit and require manual intervention from arcade staff.

So to combat this I added a quick watchdog timer to the attract sequence. The idea is that if the game remains in attract long enough (IE not being interacted with by players), while the system is currently low on memory, the game will automatically exit. On exit, the system image is designed to restart the game.

The amount of RAM and time in attract before resetting are both specified via a preference for the specific machine and operator preference.

So instead of having an arcade operator walk over and manually reset the machine, at minimum the game will restart itself when it realizes it could be in danger of locking up, and starts with a fresh process. This may look odd to the passerby who sees StepMania starting up randomly, but at minimum the game will operate, be playable, and is a stopgap while the major memory leaks are addressed by developers.