### PR TITLE
5.1: GtkModule: Add harfbuzz include path

### DIFF
--- a/src/CMakeData-gtk.cmake
+++ b/src/CMakeData-gtk.cmake
@@ -34,11 +34,13 @@ set_target_properties("GtkModule"
                                  "${SM_ROOT_DIR}")
 target_link_libraries("GtkModule" ${GTK2_LIBRARIES})
 set_property(TARGET "GtkModule" PROPERTY FOLDER "Internal Libraries")
+pkg_check_modules(HB REQUIRED harfbuzz)
 list(APPEND SM_GTK_INCLUDE_DIRS
             "${SM_SRC_DIR}"
             "${SM_SRC_DIR}/generated"
             "${SM_SRC_DIR}/arch/LoadingWindow"
-            "${GTK2_INCLUDE_DIRS}")
+            "${GTK2_INCLUDE_DIRS}"
+	          "${HB_INCLUDE_DIRS}")
 
 sm_add_compile_definition("GtkModule" CMAKE_POWERED)
 


### PR DESCRIPTION
Fixes #1850

Clone of #1851 targeting `5_1-new`.

I can confirm the bug being fixed by this on this branch as well.