### PR TITLE
5.1: Build with PulseAudio by default

### DIFF
--- a/CMake/DefineOptions.cmake
+++ b/CMake/DefineOptions.cmake
@@ -103,7 +103,7 @@ elseif(LINUX)
          "Build using libXinerama to query for monitor numbers (if available)."
          ON)
   option(WITH_ALSA "Build with ALSA support" ON)
-  option(WITH_PULSEAUDIO "Build with PulseAudio support" OFF)
+  option(WITH_PULSEAUDIO "Build with PulseAudio support" ON)
   option(WITH_JACK "Build with JACK support" OFF)
   option(WITH_XRANDR "Build with Xrandr support" ON)
   option(WITH_X11 "Build with X11 support" ON)


### PR DESCRIPTION
Fixes #1848.

As PulseAudio is widely adapted it might make sense to enable it by default for builds on Linux.