### PR TITLE
 Linux: Use GLVND if available

### DIFF
--- a/StepmaniaCore.cmake
+++ b/StepmaniaCore.cmake
@@ -450,6 +450,7 @@ elseif(LINUX)
     set(HAS_FFMPEG FALSE)
   endif()
 
+  set(OpenGL_GL_PREFERENCE GLVND)
   find_package(OpenGL REQUIRED)
   find_package(GLEW REQUIRED)
 endif(WIN32) # LINUX, APPLE


### PR DESCRIPTION
Fixes #1859.
Uses CMake's FindModule for OpenGL.

This depends on #1851 (on my system I can't build without it) and is thus marked as draft.

Should this target `5_1-new` as well?