### PR TITLE
Don't enforce line endings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,7 +4,6 @@ root = true
 [*]
 indent_style = tab
 indent_size = 4
-end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
@@ -18,6 +17,3 @@ indent_style = space
 
 [*.md]
 trim_trailing_whitespace = false
-
-[configure.ac]
-end_of_line = lf


### PR DESCRIPTION
Line endings are currently very inconsistent.
To be able to make concise commits easily without having every line's ending changed automatically, we should not enforce the line ending.
Another reason to unset the line endings setting is to be able to make use of git's autocrlf. See [editorconfig/editorconfig#226](https://github.com/editorconfig/editorconfig/issues/226#issuecomment-339153692)