### PR TITLE
Remove custom functions from jsoncpp headers

### DIFF
--- a/extern/jsoncpp/include/json/value.h
+++ b/extern/jsoncpp/include/json/value.h
@@ -234,13 +234,6 @@ namespace Json {
       double asDouble() const;
       bool asBool() const;
 
-      bool TryGet( std::string &out ) const { if(!isString()) return false; out=asString(); return true; }
-      bool TryGet( int &out ) const { if(!isInt()) return false; out=asInt(); return true; }
-      bool TryGet( UInt &out ) const { if(!isUInt()) return false; out=asUInt(); return true; }
-      bool TryGet( double &out ) const { if(!isDouble()) return false; out=asDouble(); return true; }
-      bool TryGet( float &out ) const { if(!isDouble()) return false; out=(float)asDouble(); return true; }
-      bool TryGet( bool &out ) const { if(!isBool()) return false; out=asBool(); return true; }
-
       bool isNull() const;
       bool isBool() const;
       bool isInt() const;

--- a/extern/jsoncpp/src/lib_json/json_reader.cpp
+++ b/extern/jsoncpp/src/lib_json/json_reader.cpp
@@ -1,5 +1,5 @@
-#include "json/reader.h"
-#include "json/value.h"
+#include <json/reader.h>
+#include <json/value.h>
 #include <utility>
 #include <cstdio>
 #include <cassert>
@@ -877,8 +877,7 @@ std::istream& operator>>( std::istream &sin, Value &root )
     Json::Reader reader;
     bool ok = reader.parse(sin, root, true);
     //JSON_ASSERT( ok );
-//    if (!ok) throw std::runtime_error(reader.getFormatedErrorMessages());
-    assert(ok);
+    if (!ok) throw std::runtime_error(reader.getFormatedErrorMessages());
     return sin;
 }
 

--- a/extern/jsoncpp/src/lib_json/json_value.cpp
+++ b/extern/jsoncpp/src/lib_json/json_value.cpp
@@ -1,6 +1,6 @@
 #include <iostream>
-#include "json/value.h"
-#include "json/writer.h"
+#include <json/value.h>
+#include <json/writer.h>
 #include <utility>
 #include <stdexcept>
 #include <cstring>
@@ -15,7 +15,7 @@
 
 #define JSON_ASSERT_UNREACHABLE assert( false )
 #define JSON_ASSERT( condition ) assert( condition );  // @todo <= change this into an exception throw
-#define JSON_ASSERT_MESSAGE( condition, message ) if (!( condition )) assert(false); /* throw std::runtime_error( message ); */
+#define JSON_ASSERT_MESSAGE( condition, message ) if (!( condition )) throw std::runtime_error( message );
 
 namespace Json {
 

--- a/extern/jsoncpp/src/lib_json/json_writer.cpp
+++ b/extern/jsoncpp/src/lib_json/json_writer.cpp
@@ -1,4 +1,4 @@
-#include "json/writer.h"
+#include <json/writer.h>
 #include <utility>
 #include <assert.h>
 #include <stdio.h>
@@ -111,7 +111,7 @@ std::string valueToString( bool value )
 std::string valueToQuotedString( const char *value )
 {
    // Not sure how to handle unicode...
-   if (strpbrk(value, "\"\\\b\f\n\r\t") == nullptr && !containsControlCharacter( value ))
+   if (strpbrk(value, "\"\\\b\f\n\r\t") == NULL && !containsControlCharacter( value ))
       return std::string("\"") + value + "\"";
    // We have to walk value and escape any special characters.
    // Appending to std::string is not efficient, but this should be rare.
@@ -542,7 +542,7 @@ StyledWriter::normalizeEOL( const std::string &text )
 // //////////////////////////////////////////////////////////////////
 
 StyledStreamWriter::StyledStreamWriter( std::string indentation )
-   : document_(nullptr)
+   : document_(NULL)
    , rightMargin_( 74 )
    , indentation_( indentation )
 {
@@ -559,7 +559,7 @@ StyledStreamWriter::write( std::ostream &out, const Value &root )
    writeValue( root );
    writeCommentAfterValueOnSameLine( root );
    *document_ << "\n";
-   document_ = nullptr; // Forget the stream, for safety.
+   document_ = NULL; // Forget the stream, for safety.
 }
 
 

--- a/src/JsonUtil.cpp
+++ b/src/JsonUtil.cpp
@@ -75,6 +75,19 @@ bool JsonUtil::WriteFile(const Json::Value &root, const RString &sFile, bool bMi
 	return true;
 }
 
+std::vector<RString> JsonUtil::DeserializeArrayStrings(const Json::Value &value)
+{
+	std::vector<RString> values;
+	for(auto &&inner_value : value)
+	{
+		if(inner_value.isConvertibleTo(Json::stringValue))
+		{
+			values.push_back(inner_value.asString());
+		}
+	}
+	return values;
+}
+
 /*
  * (c) 2001-2004 Chris Danford
  * All rights reserved.

--- a/src/JsonUtil.h
+++ b/src/JsonUtil.h
@@ -14,6 +14,8 @@ namespace JsonUtil
 
 	bool WriteFile(const Json::Value &root, const RString &sFile, bool bMinified);
 
+	std::vector<RString> DeserializeArrayStrings(const Json::Value &array);
+
 	template<class T>
 	static void SerializeVectorObjects(const vector<T> &v, void fn(const T &, Json::Value &), Json::Value &root)
 	{
@@ -195,57 +197,6 @@ namespace JsonUtil
 		}
 	}
 
-	template<class T>
-	static void DeserializeArrayValues(vector<T> &v, const Json::Value &root)
-	{
-		v.clear();
-		for( unsigned i=0; i<root.size(); i++ )
-		{
-			T t;
-			if( root[i].TryGet( t ) )
-				v.push_back( t );
-		}
-	}
-
-	// don't pull in the set header here
-	template<typename S, typename T>
-	static void DeserializeArrayValuesIntoSet(S &s, const Json::Value &root)
-	{
-		s.clear();
-		for( unsigned i=0; i<root.size(); i++ )
-		{
-			T t;
-			if( root[i].TryGet( t ) )
-				s.insert( t );
-		}
-	}
-
-	template<typename T>
-	static void DeserializeArrayValuesIntoVector(vector<T> &v, const Json::Value &root)
-	{
-		v.clear();
-		for( unsigned i=0; i<root.size(); i++ )
-		{
-			T t;
-			if( root[i].TryGet( t ) )
-				v.push_back( t );
-		}
-	}
-
-	template <typename M>
-	static void DeserializeValueToValueMap(M &m, const Json::Value &root)
-	{
-		for( Json::Value::const_iterator iter = root.begin(); iter != root.end(); iter++ )
-			(*iter).TryGet( m[ iter.memberName() ] );
-	}
-
-	template <typename M, typename E, typename F>
-	static void DeserializeStringToValueMap(M &m, F fnToValue(E e), const Json::Value &root)
-	{
-		for( Json::Value::const_iterator iter = root.begin(); iter != root.end(); iter++ )
-			(*iter).TryGet( m[ fnToValue(iter.memberName()) ] );
-	}
-
 	template <typename M, typename E, typename F>
 	static void DeserializeStringToObjectMap(M &m, F fnToValue(E e), const Json::Value &root)
 	{
@@ -267,22 +218,6 @@ namespace JsonUtil
 				continue;
 			V v;
 			if( !v.Deserialize( (*iter)[sValueName] ) )
-				continue;
-			m[k] = v;
-		}
-	}
-
-	template <typename K, typename V>
-	static void DeserializeObjectToValueMapAsArray(map<K,V> &m, const RString &sKeyName, const RString &sValueName, const Json::Value &root)
-	{
-		for( unsigned i=0; i<root.size(); i++ )
-		{
-			const Json::Value &root2 = root[i];
-			K k;
-			if( !k.Deserialize( root2[sKeyName] ) )
-				continue;
-			V v;
-			if( !root2[sValueName].TryGet(v) )
 				continue;
 			m[k] = v;
 		}

--- a/src/NotesLoaderJson.cpp
+++ b/src/NotesLoaderJson.cpp
@@ -214,7 +214,7 @@ static void Deserialize( Song &out, const Json::Value &root )
 		JsonUtil::DeserializeVectorObjects( vBgc, Deserialize, root["ForegroundChanges"] );
 	}
 
-	JsonUtil::DeserializeArrayValuesIntoVector( out.m_vsKeysoundFile, root["KeySounds"] );
+	out.m_vsKeysoundFile = JsonUtil::DeserializeArrayStrings(root["KeySounds"]);
 
 	{
 		vector<Steps*> vpSteps;


### PR DESCRIPTION
Resolves #1883.

Most functions where the custom ones were used could be deleted.
The one used instance has been specialized.