### PR TITLE
Fix accessing pointer from temporary object.

### DIFF
--- a/src/SongUtil.cpp
+++ b/src/SongUtil.cpp
@@ -265,10 +265,10 @@ void SongUtil::AdjustDuplicateSteps( Song *pSong )
 			 * bug in an earlier version. */
 			DeleteDuplicateSteps( pSong, vSteps );
 
-			char const *songTitle = pSong->GetDisplayFullTitle().c_str();
-			CHECKPOINT_M(ssprintf("Duplicate steps from %s removed.", songTitle));
+			const RString &songTitle = pSong->GetDisplayFullTitle();
+			CHECKPOINT_M(ssprintf("Duplicate steps from %s removed.", songTitle.c_str()));
 			StepsUtil::SortNotesArrayByDifficulty( vSteps );
-			CHECKPOINT_M(ssprintf("Charts from %s sorted.", songTitle));
+			CHECKPOINT_M(ssprintf("Charts from %s sorted.", songTitle.c_str()));
 			for( unsigned k=1; k<vSteps.size(); k++ )
 			{
 				vSteps[k]->SetDifficulty( Difficulty_Edit );


### PR DESCRIPTION
The destructor of the object returned by `GetDisplayFullTitle()` is called immediately after the call to `c_str()`, resulting in `songTitle` pointing to invalid memory. This would occasionally cause crashes when running a debug build with Visual Studio 2017.