### PR TITLE
Reenable CMake USE_FOLDERS

### DIFF
--- a/StepmaniaCore.cmake
+++ b/StepmaniaCore.cmake
@@ -49,6 +49,9 @@ include("${SM_CMAKE_DIR}/DefineOptions.cmake")
 
 include("${SM_CMAKE_DIR}/SMDefs.cmake")
 
+# Put the predefined targets in separate groups.
+set_property(GLOBAL PROPERTY USE_FOLDERS ON)
+
 # Set up the linker flags for MSVC builds.
 configure_msvc_runtime()
 


### PR DESCRIPTION
This option was disabled in #1790 for unknown reason. I suggest enabling it unless we encounter problems.