### PR TITLE
Delay writing image cache index while loading songs

### DIFF
--- a/src/ImageCache.cpp
+++ b/src/ImageCache.cpp
@@ -169,6 +169,7 @@ void ImageCache::UnloadAllImages()
 }
 
 ImageCache::ImageCache()
+	: delay_save_cache(false)
 {
 	ReadFromDisk();
 }
@@ -457,8 +458,15 @@ void ImageCache::CacheImageInternal( RString sImageDir, RString sImagePath )
 	ImageData.SetValue( sImagePath, "Width", iSourceWidth );
 	ImageData.SetValue( sImagePath, "Height", iSourceHeight );
 	ImageData.SetValue( sImagePath, "FullHash", GetHashForFile( sImagePath ) );
-	ImageData.WriteFile( IMAGE_CACHE_INDEX );
+	if (!delay_save_cache)
+		WriteToDisk();
 }
+
+void ImageCache::WriteToDisk()
+{
+	ImageData.WriteFile(IMAGE_CACHE_INDEX);
+}
+
 
 /*
  * (c) 2003 Glenn Maynard

--- a/src/ImageCache.h
+++ b/src/ImageCache.h
@@ -13,6 +13,7 @@ public:
 	ImageCache();
 	~ImageCache();
 	void ReadFromDisk();
+	void WriteToDisk();
 
 	RageTextureID LoadCachedImage( RString sImageDir, RString sImagePath );
 	void CacheImage( RString sImageDir, RString sImagePath );
@@ -22,6 +23,8 @@ public:
 	void Undemand( RString sImageDir );
 
 	void OutputStats() const;
+
+	bool delay_save_cache;
 
 private:
 	static RString GetImageCachePath( RString sImageDir, RString sImagePath );

--- a/src/SongManager.cpp
+++ b/src/SongManager.cpp
@@ -158,7 +158,8 @@ void SongManager::InitSongsFromDisk( LoadingWindow *ld )
 	RageTimer tm;
 	// Tell SONGINDEX to not write the cache index file every time a song adds
 	// an entry. -Kyz
-	SONGINDEX->delay_save_cache= true;
+	SONGINDEX->delay_save_cache = true;
+	IMAGECACHE->delay_save_cache = true;
 	LoadStepManiaSongDir( SpecialFiles::SONGS_DIR, ld );
 
 	const bool bOldVal = PREFSMAN->m_bFastLoad;
@@ -168,6 +169,8 @@ void SongManager::InitSongsFromDisk( LoadingWindow *ld )
 	LoadEnabledSongsFromPref();
 	SONGINDEX->SaveCacheIndex();
 	SONGINDEX->delay_save_cache= false;
+	IMAGECACHE->WriteToDisk();
+	IMAGECACHE->delay_save_cache = false;
 
 	LOG->Trace( "Found %d songs in %f seconds.", (int)m_pSongs.size(), tm.GetDeltaTime() );
 }


### PR DESCRIPTION
While building the song and banner cache, we were nearly constantly writing the image cache index file to disk. The song cache already had this feature, so I I just applied it to the image cache as well. Before this change, it was taking perhaps 45 minutes to cache everything from scratch. After, it could load in 15 minutes or so (IIRC).