### PR TITLE
Fix LRC parsing crash for unrecognized values

### DIFF
--- a/src/LyricsLoader.cpp
+++ b/src/LyricsLoader.cpp
@@ -90,10 +90,11 @@ bool LyricsLoader::LoadFromLRCFile(const RString& sPath, Song& out)
 		// offsets each timestamp after the offset by that amount.
 		//float fLyricOffset = 0.0f;
 
+		// Enforce strict timestamp format to prevent crashing the program.
+		vector<RString> dummy;
+		static Regex timestamp("^([0-9]+:){0,2}[0-9]+(.[0-9]*)?$");
+		if (timestamp.Compare(sValueName, dummy))
 		{
-			/* If we've gotten this far, and no other statement caught this
-			 * value before this does, assume it's a time value. */
-
 			LyricSegment seg;
 			seg.m_Color = CurrentColor;
 			seg.m_fStartTime = HHMMSSToSeconds(sValueName);


### PR DESCRIPTION
I encountered this crash from a random .lrc file, which started like this. Rather than crash, this commit just skips any unrecognized lines.

```
[ti:Guren no Yumiya]
[ar:Linked Horizon]
[al:Shingeki no Kyojin OP]
[la:ja]
[by:Grc-009]
[COLOUR]0xFFFFFF
[00:00.55]Sie sind das Essen und wir sind die Jager!
[00:03.31]
[00:15.26]Fumareta hana no 
```