### PR TITLE
Sort input devices on Linux

### DIFF
--- a/src/arch/InputHandler/InputHandler_Linux_Event.cpp
+++ b/src/arch/InputHandler/InputHandler_Linux_Event.cpp
@@ -69,19 +69,6 @@ struct EventDevice
 
 static vector<EventDevice *> g_apEventDevices;
 
-/* Return true if the numbered event device exists.  sysfs may not always be
- * there; return false if we don't know. */
-static bool EventDeviceExists( int iNum )
-{
-	RString sDir = ssprintf( "/sys/class" );
-	struct stat st;
-	if( stat(sDir, &st) == -1 )
-		return true;
-
-	RString sFile = ssprintf( "/sys/class/input/event%i", iNum );
-	return stat(sFile, &st) == 0;
-}
-
 static bool BitIsSet( const uint8_t *pArray, uint32_t iBit )
 {
 	return !!(pArray[iBit/8] & (1<<(iBit%8)));

--- a/src/arch/InputHandler/LinuxInputManager.cpp
+++ b/src/arch/InputHandler/LinuxInputManager.cpp
@@ -33,6 +33,11 @@ RString getDevice(RString inputDir, RString type)
 	return result;
 }
 
+static bool cmpDevices(RString a, RString b)
+{
+	return a < b;
+}
+
 LinuxInputManager::LinuxInputManager()
 {
 	m_bEventEnabled = g_sInputDrivers.Get().find("LinuxEvent") != std::string::npos;
@@ -71,6 +76,10 @@ LinuxInputManager::LinuxInputManager()
 		if( !bEventPresent && !bJoystickPresent )
 			LOG->Info("LinuxInputManager: %s seems to have no eventNN or jsNN.", dName.c_str() );
 	}
+
+	// Sort devices for more consistent numbering.
+	std::sort(m_vsPendingEventDevices.begin(), m_vsPendingEventDevices.end(), cmpDevices);
+	std::sort(m_vsPendingJoystickDevices.begin(), m_vsPendingJoystickDevices.end(), cmpDevices);
 }
 
 void LinuxInputManager::InitDriver(InputHandler_Linux_Event* driver)


### PR DESCRIPTION
The readdir() function doesn't guarantee any specific ordering, so the numbers of joysticks might change when restarting StepMania. (Empirically this usually only happens after a reboot.)

Let's sort the input devices alphabetically before opening them to have more consistent numbering and avoid annoying remapping of controllers.
