### PR TITLE
Detect 8:3 as widescreen

### DIFF
--- a/Themes/_fallback/Scripts/02 Utilities.lua
+++ b/Themes/_fallback/Scripts/02 Utilities.lua
@@ -352,11 +352,7 @@ end
 
 function IsUsingWideScreen()
 	local curAspect = GetScreenAspectRatio()
-	if math.abs(curAspect-16/9) <= .044 or math.abs(curAspect - 16/10) <= .044 then
-		return true
-	else
-		return false
-	end
+	return curAspect > 16/10 - .044
 end
 
 -- Usage:  Pass in an ActorFrame and a string to put in front of every line.


### PR DESCRIPTION
While working on https://github.com/dguzek/Simply-Love-SM5/pull/167 I noticed that `IsUsingWideScreen()` doesn't detect 8:3 as widescreen.

The function previously only checked 16:10 and 16:9, the modified code just checks that the ratio is greater than 16:10. (Coincidentally that's also what the documentation states about this function.)