### PR TITLE
Update vertex count stats when drawing smooth lines (OGL)

### DIFF
--- a/src/RageDisplay_OGL.cpp
+++ b/src/RageDisplay_OGL.cpp
@@ -1617,6 +1617,7 @@ void RageDisplay_Legacy::DrawLineStripInternal( const RageSpriteVertex v[], int 
 	/* Draw the line loop: */
 	SetupVertices( v, iNumVerts );
 	glDrawArrays( GL_LINE_STRIP, 0, iNumVerts );
+	StatsAddVerts(iNumVerts);
 
 	glDisable( GL_LINE_SMOOTH );
 
@@ -1642,6 +1643,7 @@ void RageDisplay_Legacy::DrawLineStripInternal( const RageSpriteVertex v[], int 
 
 	SetupVertices( v, iNumVerts );
 	glDrawArrays( GL_POINTS, 0, iNumVerts );
+	StatsAddVerts(iNumVerts);
 
 	glDisable( GL_POINT_SMOOTH );
 }


### PR DESCRIPTION
While working on a change for the density graph in the Simply Love theme I [noticed that the vertex count is off](https://github.com/dguzek/Simply-Love-SM5/pull/167#issuecomment-552563273) when rendering smooth lines

The statistics are updated in the generic codepath, which is not used by RageDisplay_Legacy::DrawLineStripInternal() when rendering smooth lines.

Note, that the output vertex count can differ a lot between smooth lines (2) and non-smooth lines (~38 output vertices per input vertex), so updating the statistics can not be done in RageDisplay::DrawLineStrip() like it is done for the other draw functions.