### PR TITLE
change a few global Lua variables to be local

### DIFF
--- a/Themes/_fallback/Scripts/03 CustomSpeedMods.lua
+++ b/Themes/_fallback/Scripts/03 CustomSpeedMods.lua
@@ -70,7 +70,7 @@ end
 -- Parses a speed mod and returns the pair (type, number) or nil if parsing
 -- failed.
 local function CanonicalizeMod(mod)
-	num = tonumber(mod:match("^(%d+.?%d*)[xX]$"))
+	local num = tonumber(mod:match("^(%d+.?%d*)[xX]$"))
 	if num ~= nil then
 		return "x", num
 	end

--- a/Themes/default/Scripts/03 Gameplay.lua
+++ b/Themes/default/Scripts/03 Gameplay.lua
@@ -12,11 +12,11 @@ local tNotePositions = {
 }
 
 function GetTapPosition( sType )
-	bCategory = (sType == 'Standard') and 1 or 2
+	local  bCategory = (sType == 'Standard') and 1 or 2
 	-- true: Normal
 	-- false: Lower
-	bPreference = ThemePrefs.Get("NotePosition") and "Normal" or "Lower"
-	tNotePos = tNotePositions[bPreference]
+	local bPreference = ThemePrefs.Get("NotePosition") and "Normal" or "Lower"
+	local tNotePos = tNotePositions[bPreference]
 	return tNotePos[bCategory]
 end
 
@@ -74,13 +74,13 @@ end
 function ScreenSelectStylePositions(count)
 	local poses= {}
 	local choice_size = 192
-	
+
 	for i= 1, count do
 		local start_x = _screen.cx + ( (choice_size / 1.5) * ( i - math.ceil(count/2) ) )
 		-- The Y position depends on if the icon's index is even or odd.
 		local start_y = i % 2 == 0 and _screen.cy / 0.8 or (_screen.cy / 0.8) - (choice_size / 1.5)
 		poses[#poses+1] = {start_x, start_y}
 	end
-	
+
 	return poses
 end

--- a/Themes/legacy/Scripts/03 Gameplay.lua
+++ b/Themes/legacy/Scripts/03 Gameplay.lua
@@ -12,11 +12,11 @@ local tNotePositions = {
 }
 
 function GetTapPosition( sType )
-	bCategory = (sType == 'Standard') and 1 or 2
+	local bCategory = (sType == 'Standard') and 1 or 2
 	-- true: Normal
 	-- false: Lower
-	bPreference = ThemePrefs.Get("NotePosition") and "Normal" or "Lower"
-	tNotePos = tNotePositions[bPreference]
+	local bPreference = ThemePrefs.Get("NotePosition") and "Normal" or "Lower"
+	local tNotePos = tNotePositions[bPreference]
 	return tNotePos[bCategory]
 end
 


### PR DESCRIPTION
Running StepMania with the command line argument of `--ExportLuaInformation` while the current 5.1's default theme (Lambda) was selected added some seemingly stray Lua variables to the Constants table in ./Docs/Luadoc/Lua.xml.

I spotted them here: http://dguzek.github.io/Lua-For-SM5/LuaAPI#Constants

I'm assuming `num`, `bPreference`, and `bCategory` don't need global scope, so I added the `local` keyword where appropriate.