### PR TITLE
restore autogen lights

### DIFF
--- a/src/PrefsManager.cpp
+++ b/src/PrefsManager.cpp
@@ -275,7 +275,7 @@ PrefsManager::PrefsManager() :
 	m_iSoundDevice			( "SoundDevice",			"" ),
 	m_iRageSoundSampleCountClamp	("RageSoundSampleCountClamp", 0), //some sound drivers mask the sample location number, the most popular number for this is 2^27, this causes lockup after ~50 minutes at 44.1khz sample rate
 	m_iSoundPreferredSampleRate	( "SoundPreferredSampleRate",		0 ),
-	m_sLightsStepsDifficulty	( "LightsStepsDifficulty",		"medium" ),
+	m_sLightsStepsDifficulty	( "LightsStepsDifficulty",		"hard,medium" ),
 	m_bAllowUnacceleratedRenderer	( "AllowUnacceleratedRenderer",		false ), 
 	m_bThreadedInput		( "ThreadedInput",			true ),
 	m_bThreadedMovieDecode		( "ThreadedMovieDecode",		true ),

--- a/src/ScreenGameplay.cpp
+++ b/src/ScreenGameplay.cpp
@@ -1452,6 +1452,27 @@ void ScreenGameplay::LoadLights()
 	NoteData TapNoteData1;
 	pSteps->GetNoteData( TapNoteData1 );
 
+	//taken from oitg, restores arrow -> marquee/bass light mapping.
+	if( asDifficulties.size() > 1 )
+	{
+		Difficulty d2 = StringToDifficulty( asDifficulties[1] );
+
+		Steps *pSteps2;
+
+		pSteps2 = SongUtil::GetClosestNotes( GAMESTATE->m_pCurSong, st, d2 );
+
+		if(pSteps2 != nullptr)
+		{
+			NoteData TapNoteData2;
+			pSteps2->GetNoteData( TapNoteData2 );
+
+			NoteDataUtil::LoadTransformedLightsFromTwo( TapNoteData1, TapNoteData2, m_CabinetLightsNoteData );
+			return;
+		}
+
+		/* fall through */
+	}
+
 	NoteDataUtil::LoadTransformedLights( TapNoteData1, m_CabinetLightsNoteData, GAMEMAN->GetStepsTypeInfo(StepsType_lights_cabinet).iNumTracks );
 }
 


### PR DESCRIPTION
One of the things that bugged me about SM5 was the fact that the default lights were seizures that just flashed to the BPM of the song. Compared to oitg, where each marquee light was mapped to an arrow.

This restores the functionality of oitg, giving each marquee light an arrow and bass neons generated correctly.

The result is a much better lighting experience for those of us with proper cabinets or home made lighting setups.