### PR TITLE
Force Lua to be compiled as C++ code when using MSVC

### DIFF
--- a/extern/CMakeProject-lua.cmake
+++ b/extern/CMakeProject-lua.cmake
@@ -64,6 +64,7 @@ set_property(TARGET "lua-5.1" PROPERTY FOLDER "External Libraries")
 
 if(MSVC)
   sm_add_compile_definition("lua-5.1" _CRT_SECURE_NO_WARNINGS)
+  sm_add_compile_flag("lua-5.1" /TP)
 endif(MSVC)
 
 disable_project_warnings("lua-5.1")

--- a/src/EnumHelper.h
+++ b/src/EnumHelper.h
@@ -5,10 +5,14 @@
 #include "RageUtil.h"
 #include <memory>
 
+#ifndef _MSC_VER
 extern "C"
 {
+#endif
 #include "../extern/lua-5.1/src/lua.h"
+#ifndef _MSC_VER
 }
+#endif
 
 /** @brief A general foreach loop for enumerators, going up to a max value. */
 #define FOREACH_ENUM_N( e, max, var )	for( e var=(e)0; var<max; enum_add<e>( var, +1 ) )

--- a/src/LuaManager.h
+++ b/src/LuaManager.h
@@ -8,12 +8,16 @@ class RageMutex;
 class XNode;
 class LuaReference;
 
+#ifndef _MSC_VER
 extern "C"
 {
+#endif
 #include "../extern/lua-5.1/src/lua.h"
 #include "../extern/lua-5.1/src/lualib.h"
 #include "../extern/lua-5.1/src/lauxlib.h"
+#ifndef _MSC_VER
 }
+#endif
 
 // For Dialog::Result
 #include "arch/Dialog/Dialog.h"


### PR DESCRIPTION
The `setjmp`/`longjmp` error handling mechanism may fail with Microsoft C++ since they utilize the same stack-unwinding mechanism with C++ exception handling. Lua calling `longjmp` after `luaD_rawrunprotected` (which calls `setjmp`) returns leads to unpredictable behaviour. On Windows x64 build, this causes `lua_error` to crash the whole StepMania program.

Lua provides the same macros to utilize C++ `throw`/`catch`, which effectively solve the problem. Just specify Lua library as C++ code to enable them.

Reference: https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/longjmp