### PR TITLE
Fix XInput library linkage for compatibility down to Windows Vista

### DIFF
--- a/src/arch/InputHandler/InputHandler_DirectInput.cpp
+++ b/src/arch/InputHandler/InputHandler_DirectInput.cpp
@@ -14,7 +14,11 @@
 
 #include "InputHandler_DirectInputHelper.h"
 
+#ifdef NTDDI_WIN8 // Link to Xinput9_1_0.lib on Windows 8 SDK and above to ensure linkage to Xinput9_1_0.dll
+#pragma comment(lib, "Xinput9_1_0.lib")
+#else
 #pragma comment(lib, "xinput.lib")
+#endif
 
 #include <XInput.h>
 #include <WbemIdl.h>


### PR DESCRIPTION
As a side effect of DirectX SDK dependency removal, linkage to `xinput.lib` points to `XInput1_4.dll` (available since Windows 8) on Windows 8 SDK and above or `XInput9_1_0.dll` (available since Windows Vista) on Windows SDK 7.1. For required minimum compatibility with Windows 7, an SDK version check is added to ensure linkage to `XInput9_1_0.dll`.
<del>This change will drop compatibility with Windows XP effectively.</del>
On Windows XP, DirectX End-User Runtimes (October 2005) or above is required for `XInput9_1_0.dll`.

Reference: https://docs.microsoft.com/en-us/windows/win32/xinput/xinput-versions

Fixes #1948