### PR TITLE
Add exception handling around std::stof in RageUtil.cpp

### DIFF
--- a/src/RageUtil.cpp
+++ b/src/RageUtil.cpp
@@ -1883,7 +1883,14 @@ float StringToFloat( const RString &sString )
 	{
 		return 0;
 	}
-	return std::stof(toTrim);
+	try
+	{
+		return std::stof(toTrim);
+	}
+	catch( std::logic_error& )
+	{
+		return 0;
+	}
 }
 
 bool StringToFloat( const RString &sString, float &fOut )
@@ -2331,8 +2338,15 @@ namespace StringConversion
 		if( sValue.size() == 0 )
 			return false;
 
-		out = (std::stoi(sValue) != 0);
-		return true;
+		try
+		{
+			out = (std::stoi(sValue) != 0);
+			return true;
+		}
+		catch( std::logic_error& )
+		{
+			return false;
+		}
 	}
 
 	template<> RString ToString<int>( const int &value )


### PR DESCRIPTION
It seems I've got a messed up song somewhere in my library that throws non-numerical data into this method. Handlers added to gracefully deal with the situation.

Only tested on Linux so far, but it's standard C++(11), could possibly have a missing header on windows but can't think of anything else to check.
