### PR TITLE
Fix Texture Font Generator for Windows x64 build

### DIFF
--- a/src/CMakeProject-texture.cmake
+++ b/src/CMakeProject-texture.cmake
@@ -41,6 +41,8 @@ if(NOT WITH_STATIC_LINKING)
   sm_add_compile_definition("TextureFontGenerator" _AFXDLL)
 endif()
 
+sm_add_compile_definition("TextureFontGenerator" CMAKE_POWERED)
+
 list(APPEND TEXTURE_LINK_LIB "zlib" "png")
 
 target_link_libraries("TextureFontGenerator" ${TEXTURE_LINK_LIB})
@@ -49,7 +51,8 @@ list(APPEND TEXTURE_INCLUDE_DIRS
             "${TEXTURE_DIR}"
             "${TEXTURE_DIR}/res"
             "${SM_EXTERN_DIR}/zlib"
-            "${SM_EXTERN_DIR}/libpng/include")
+            "${SM_EXTERN_DIR}/libpng/include"
+            "${SM_SRC_DIR}/generated")
 
 target_include_directories("TextureFontGenerator"
                            PUBLIC ${TEXTURE_INCLUDE_DIRS})

--- a/src/Texture Font Generator/TextureFont.cpp
+++ b/src/Texture Font Generator/TextureFont.cpp
@@ -335,7 +335,7 @@ void TextureFont::FormatFontPage( int iPage, HDC hDC )
 		}
 
 		++iCol;
-		if( iCol == pPage->m_iNumFramesY )
+		if( iCol == pPage->m_iNumFramesX )
 		{
 			iCol = 0;
 			++iRow;

--- a/src/Texture Font Generator/Utils.h
+++ b/src/Texture Font Generator/Utils.h
@@ -1,9 +1,22 @@
 #ifndef UTILS_H
 #define UTILS_H
 
-inline float truncf( float f )	{ return float(int(f)); };
-inline float roundf( float f )	{ if(f < 0) return truncf(f-0.5f); return truncf(f+0.5f); };
+#if defined(CMAKE_POWERED)
+#include "config.hpp"
+#elif defined(HAVE_CONFIG_H)
+#include "config.h"
+#endif
 
+#if !defined(HAVE_TRUNCF)
+inline float truncf( float f )	{ return float(int(f)); };
+#endif
+
+#if !defined(HAVE_ROUNDF)
+inline float roundf( float f )	{ if(f < 0) return truncf(f-0.5f); return truncf(f+0.5f); };
+#endif
+
+#if !defined(HAVE_LRINTF)
+#if defined(_MSC_VER) && defined(_X86_)
 inline long int lrintf( float f )
 {
 	int retval;
@@ -13,6 +26,10 @@ inline long int lrintf( float f )
 
 	return retval;
 }
+#else
+#define lrintf(x) ((int)rint(x))
+#endif
+#endif
 
 struct Surface
 {


### PR DESCRIPTION
I know Texture Font Generator is old and no longer being maintained, but I am making new bitmap fonts and have to do a fix. Changes include:

* Utilize CMake macros to fix linking.
* Fixed a bug that caused dimension error upon generating non-square-shaped font bitmap.