### PR TITLE
Fix crash with AllowMultipleHighScoreWithSameName

### DIFF
--- a/src/HighScore.cpp
+++ b/src/HighScore.cpp
@@ -405,7 +405,7 @@ void HighScoreList::LoadFromNode( const XNode* pHighScoreList )
 
 void HighScoreList::RemoveAllButOneOfEachName()
 {
-	for (vector<HighScore>::iterator i = vHighScores.begin(); i != vHighScores.end() - 1; ++i)
+	for (vector<HighScore>::iterator i = vHighScores.begin(); i != vHighScores.end(); ++i)
 	{
 		for( vector<HighScore>::iterator j = i+1; j != vHighScores.end(); j++ )
 		{


### PR DESCRIPTION
When the `AllowMultipleHighScoreWithSameName` preference set to `false`, we call `HighScoreList::RemoveAllButOneOfEachName()` on the high score lists to remove duplicate name entries.  This function is likely to crash for two reasons:

    void HighScoreList::RemoveAllButOneOfEachName() {
        for( vector<HighScore>::iterator i = vHighScores.begin(); i != vHighScores.end() - 1; ++i ) {
            for( vector<HighScore>::iterator j = i+1; j != vHighScores.end(); j++ ) {
                if( i->GetName() == j->GetName() ) {
                    j--;
                    vHighScores.erase( j+1 );
                }
            }
        }
    }

If `vHighScores` is empty, the function will immediately crash at `vHighScores.end() - 1`.

It also fails if the last two elements of the list have the same name because `i` misses the terminating condition.  To visualize this, imagine that the high score list contains only two scores and both have the same name:

    {90%, 80%}  // Start here; scores 90% and 80% have the same name.
      i    j
    
    {90%}       // So j is decremented and 80% is removed.  The inner loop is now terminated.
     i,j
    
    {90%}       // Now i is incremented, which puts it at end().  The loop doesn't stop because the terminating condition is for end() - 1.
      j    i
    
    Crash when i tries to dereference its name in i->GetName().

This can be fixed by simply changing the outer loop condition to `i != vHighScores.end()`, which is the functional equivalent of the original code when the `FOREACH` macro was used.

We can reason about its correctness by noting the following invariants:

* In the inner loop body, prior to removal, iterator `i` always points somewhere before `j`
* Both before and after removal, `i` and `j` point to real elements

These imply that the increments of `i` and `j` will never bring them past `end()` and that the decrement of `j` will never bring it before `begin()`.  To see that the invariants hold, first note that they hold trivially when there are no removals, then observe that the two steps involved in a removal can't violate the invariants.

Reference:
https://github.com/stepmania/stepmania/commit/7e3789b131bb5da143e2b069630440ea3e7043fb
https://github.com/stepmania/stepmania/commit/b4de5421b7fe1b15ef1d19e7e1d6d7f4f43d0157

