### PR TITLE
Fix disqualification for C-mods and rate mods

### DIFF
--- a/src/GameState.cpp
+++ b/src/GameState.cpp
@@ -1915,6 +1915,12 @@ bool GameState::CurrentOptionsDisqualifyPlayer( PlayerNumber pn )
 		return false;
 
 	const PlayerOptions &po = m_pPlayerState[pn]->m_PlayerOptions.GetPreferred();
+	const SongOptions &so = m_SongOptions.GetPreferred();
+
+	// Playing a song/course at a slower music rate should disqualify score. -x0rbl
+	if (so.m_fMusicRate < 1.0) {
+		return true;
+	}
 
 	// Check the stored player options for disqualify.  Don't disqualify because
 	// of mods that were forced.

--- a/src/Steps.cpp
+++ b/src/Steps.cpp
@@ -595,7 +595,9 @@ bool Steps::HasSignificantTimingChanges() const
 	if( timing->HasBpmChanges() )
 	{
 		// check to see if these changes are significant.
-		if( (GetMaxBPM() - GetMinBPM()) > 3.000f )
+		DisplayBpms bpms;
+		m_pSong->GetDisplayBpms(bpms);
+		if (bpms.GetMax() - bpms.GetMin() > 3.000f)
 			return true;
 	}
 


### PR DESCRIPTION
This commit makes two changes to the way that disqualification works:

### 1. C-mods now disqualify the player based on the range of BPMs shown on the screen

The functions `GetMaxBPM()` and `GetMinBPM()` return the *specified* BPM maximum/minimum; i.e. the range set in a `#DISPLAYBPM` tag.  If `#DISPLAYBPM` is not set, these values will not be set either.  Most charts don't set `#DISPLAYBPM`, so the result is that most non-C-moddable songs will *not* DQ you for a C-mod.

This can be fixed by using `Song::GetDisplayBpms`, which will return the range in `#DISPLAYBPM` if it exists, otherwise it will return the range from `#BPMS`.  Then songs without `#DISPLAYBPM` will DQ C-mods correctly.  Note that setting `#DISPLAYBPM` to a fixed value can still override a range in `#BPMS`, as in ITG.

### 2. Selecting a rate mod below 1.0 will DQ the player.

I think it should be agreeable that lower rate mods should DQ.

I considered making rate mods above 1.0 also DQ.  One reason is that rolls may require fewer steps at a faster rate.  The other is that, for steps that are slightly offsync, faster rates reduce the time delta between the step and the correct beat, making it theoretically easier to get a proper timing judgment.  Both of these seem like edge cases, but I'm mentioning them in here in case any of the devs would prefer to change the `<` to a `!=`.