### PR TITLE
Fix float parsing errors

### DIFF
--- a/src/RageUtil.cpp
+++ b/src/RageUtil.cpp
@@ -1877,27 +1877,38 @@ void MakeLower( wchar_t *p, size_t iLen )
 
 float StringToFloat( const RString &sString )
 {
-	RString toTrim = sString;
-	Trim(toTrim);
-	if (toTrim.size() == 0)
+	try
 	{
-		return 0;
+		float fOut = std::stof(sString);
+		if (!isfinite(fOut))
+		{
+			fOut = 0.0f;
+		}
+		return fOut;
 	}
-	return std::stof(toTrim);
+	catch(...)
+	{
+		return 0.0f;
+	}	
 }
 
 bool StringToFloat( const RString &sString, float &fOut )
 {
-	RString toTrim = sString;
-	Trim(toTrim);
-	if (toTrim.size() == 0)
+	try
 	{
-		return false;
+		fOut = std::stof(sString);
+		if (!isfinite(fOut))
+		{
+			fOut = 0.0f;
+			return false;
+		}
+		return true;
 	}
-	char *endPtr;
-
-	fOut = strtof( toTrim, &endPtr );
-	return *endPtr == '\0' && isfinite( fOut );
+	catch(...)
+	{
+		fOut = 0.0f;
+		return false;
+	}	
 }
 
 RString FloatToString( const float &num )

--- a/src/RageUtil.cpp
+++ b/src/RageUtil.cpp
@@ -1877,38 +1877,20 @@ void MakeLower( wchar_t *p, size_t iLen )
 
 float StringToFloat( const RString &sString )
 {
-	try
+	float fOut = std::strtof(sString, nullptr);
+	if (!isfinite(fOut))
 	{
-		float fOut = std::stof(sString);
-		if (!isfinite(fOut))
-		{
-			fOut = 0.0f;
-		}
-		return fOut;
+		fOut = 0.0f;
 	}
-	catch(...)
-	{
-		return 0.0f;
-	}	
+	return fOut;
 }
 
 bool StringToFloat( const RString &sString, float &fOut )
 {
-	try
-	{
-		fOut = std::stof(sString);
-		if (!isfinite(fOut))
-		{
-			fOut = 0.0f;
-			return false;
-		}
-		return true;
-	}
-	catch(...)
-	{
-		fOut = 0.0f;
-		return false;
-	}	
+	char *endPtr = nullptr;
+
+	fOut = std::strtof(sString, &endPtr);
+	return sString.size() && *endPtr == '\0' && isfinite(fOut);
 }
 
 RString FloatToString( const float &num )


### PR DESCRIPTION
My C++11 commit [1] introduced a bug that would crash SM5 upon loading songs that had non-float parsable values.

An example is Beach Blast from Mute Sims. The SM file has the following line:

#DISPLAYBPM:?;

The '?' would not be parsed as a float. This change catches failed conversions and returns 0.0f for them (which was the prior behavior, and current to the master branch as well).

TESTED (on Win x64): Booted SM5 without changes, with Beach Blast in my Songs directory -> Crashes on boot
Booted SM5 with my changes, -> Game boots and Beach Blast is playable.
The changes made are OS agnostic (essentially just wraps the stof call with a try catch block).

[1] https://github.com/stepmania/stepmania/commit/7e3789b131bb5da143e2b069630440ea3e7043fb