### PR TITLE
Don't force libc++ with clang/Linux

### DIFF
--- a/extern/CMakeProject-cppformat.cmake
+++ b/extern/CMakeProject-cppformat.cmake
@@ -32,7 +32,4 @@ elseif(APPLE)
   sm_add_compile_flag("cppformat" "-stdlib=libc++")
 else() # Unix
   sm_add_compile_flag("cppformat" "-std=${SM_CPP_STANDARD}")
-  if(CMAKE_CXX_COMPILER MATCHES "clang")
-    sm_add_compile_flag("cppformat" "-stdlib=libc++")
-  endif()
 endif()

--- a/extern/CMakeProject-json.cmake
+++ b/extern/CMakeProject-json.cmake
@@ -40,8 +40,5 @@ else()
     sm_add_compile_flag("jsoncpp" "-stdlib=libc++")
   else() # Unix/Linux
     sm_add_compile_flag("jsoncpp" "-std=gnu++11")
-    if(CMAKE_CXX_COMPILER MATCHES "clang")
-      sm_add_compile_flag("jsoncpp" "-stdlib=libc++")
-    endif()
   endif()
 endif()

--- a/src/CMakeData-gtk.cmake
+++ b/src/CMakeData-gtk.cmake
@@ -8,10 +8,6 @@ add_library("GtkModule"
             "arch/LoadingWindow/LoadingWindow_GtkModule.h")
 
 sm_add_compile_flag("GtkModule" "-std=${SM_CPP_STANDARD}")
-if(CMAKE_CXX_COMPILER MATCHES "clang")
-  sm_add_compile_flag("GtkModule" "-stdlib=libc++")
-  set_target_properties("GtkModule" PROPERTIES LINK_FLAGS "-stdlib=libc++")
-endif()
 
 # It is normally not appropriate to set the prefix to the empty string. This is
 # to maintain compatibility with the current source. At some point, it may be

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -390,12 +390,6 @@ else() # Linux
   endif()
 
   sm_add_compile_flag("${SM_EXE_NAME}" "-std=${SM_CPP_STANDARD}")
-  if(CMAKE_CXX_COMPILER MATCHES "clang")
-    sm_add_compile_flag("${SM_EXE_NAME}" "-stdlib=libc++")
-    set_target_properties("${SM_EXE_NAME}"
-                          PROPERTIES LINK_FLAGS "-stdlib=libc++")
-    sm_add_compile_flag("jsoncpp" "-stdlib=libc++")
-  endif()
 endif()
 
 set_property(TARGET "${SM_EXE_NAME}" PROPERTY FOLDER "Internal Libraries")


### PR DESCRIPTION
Clang works with libstdc++ on Linux, there's no need to force libc++. Some distros don't make installing libc++ easy (e.g. Arch Linux).

-DCMAKE_CXX_FLAGS="-stdlib=libc++" should restore this functionality at CMake time.