### PR TITLE
add 21:9 and 9:16 to ConfAspectRatio in _fallback

### DIFF
--- a/Themes/_fallback/Scripts/02 Utilities.lua
+++ b/Themes/_fallback/Scripts/02 Utilities.lua
@@ -329,13 +329,15 @@ end
 
 -- supported aspect ratios
 AspectRatios = {
-	ThreeFour   = 0.75,		-- (576x760 at 1024x768; meant for rotated monitors?)
-	OneOne      = 1.0,		-- 480x480  (uses Y value of specified resolution)
-	FiveFour    = 1.25,		-- 600x480 (1280x1024 is a real use case)
-	FourThree   = 1.33333,	-- 640x480 (common)
-	SixteenTen  = 1.6,		-- 720x480 (common)
-	SixteenNine = 1.77778,	-- 853x480 (common)
-	EightThree  = 2.66666	-- 1280x480 (two monitors)
+	ThreeFour    = 0.75,    -- (576x760 at 1024x768; meant for rotated monitors?)
+	OneOne       = 1.0,     -- 480x480  (uses Y value of specified resolution)
+	FiveFour     = 1.25,    -- 600x480 (1280x1024 is a real use case)
+	FourThree    = 1.33333, -- 640x480 (common)
+	SixteenTen   = 1.6,     -- 720x480 (common)
+	SixteenNine  = 1.77778, -- 853x480 (common)
+	EightThree   = 2.66666, -- 1280x480 (two monitors)
+	TwentyOneNine= 2.37,    -- 1138x480 (Ultrawide)
+	NineSixteen  = 0.5625,  -- 480x720  (16:9 widescreen as portrait display)
 }
 
 function WideScale(AR4_3, AR16_9)

--- a/Themes/_fallback/Scripts/03 DisplaySpecs.lua
+++ b/Themes/_fallback/Scripts/03 DisplaySpecs.lua
@@ -94,14 +94,17 @@ end
 
 -- TODO: here, I'm replicating the AspectRatios table from "02 Utilities.lua",
 -- but in a friendly format
+-- name can optionally be provided as a user-facing string for ConfAspectRatio
 local winFracs = {
-	{n=3, d=4},
-	{n=1, d=1},
-	{n=5, d=4},
-	{n=4, d=3},
+	{n=3,  d=4},
+	{n=1,  d=1},
+	{n=5,  d=4},
+	{n=4,  d=3},
 	{n=16, d=10},
 	{n=16, d=9},
-	{n=8, d=3}
+	{n=8,  d=3},
+	{n=64, d=27, name="21:9"},
+	{n=9,  d=16},
 }
 -- Maximum distance between aspect ratios to be considered equivalent
 -- (approximately half the distance between 16:9 and 16:10)
@@ -243,7 +246,7 @@ function ConfAspectRatio()
 			local vals = {}
 			foreach_ordered(ratios, function(v, f)
 						vals[#vals + 1] = f.n/f.d
-						choices[#choices + 1] = tostring(f.n) .. ':' .. tostring(f.d)
+						choices[#choices + 1] = (type(f.name)=="string" and f.name) or ("%d:%d"):format(f.n, f.d)
 			end)
 			self.Choices = choices
 			self.ChoiceVals = vals


### PR DESCRIPTION
# About

This adds choices for 21:9 (Ultrawide) and 9:16 (widescreen display in portrait mode) aspect ratios to the _fallback theme.  Previously, users would have to manually edit Preferences.ini to achieve either of these.

# Details

Since "21:9" seems to be the common marketing term for what is actually **64:27** (see: https://wikipedia.org/wiki/21:9_aspect_ratio), I've slightly extended `GenChoices()` in `ConfAspectRatio()` to use a "name" string from the `winFracs` table if one is provided.

If not, the original behavior of generating user-facing choices from the raw values is preserved.

I've updated the global `AspectRatios` table in _fallback/02 Utilities.lua to match.

![Screen Shot 2020-04-28 at 10 31 06 PM](https://user-images.githubusercontent.com/1253483/80557184-18af3980-89a4-11ea-80e4-072f2ac6807b.png)

## Support in existing themes

5.1's default theme and mainline Simply Love handle 21:9 okay already, so there's that.
Work is actively being done on other 9:16 themes.

I'll leave this open for 24 hours before merging, unless there is opposition, feedback, etc.