### PR TITLE
update Classes and Enums in bundled Lua.xml

### DIFF
--- a/Docs/Luadoc/Lua.xml
+++ b/Docs/Luadoc/Lua.xml
@@ -414,6 +414,7 @@
 			<Function name='rotationy'/>
 			<Function name='rotationz'/>
 			<Function name='scale_or_crop_background'/>
+			<Function name='scale_or_crop_background_no_move'/>
 			<Function name='scaletocover'/>
 			<Function name='scaletofit'/>
 			<Function name='setsize'/>
@@ -571,6 +572,7 @@
 			<Function name='SetTransformFromFunction'/>
 			<Function name='SetTransformFromHeight'/>
 			<Function name='SetTransformFromWidth'/>
+			<Function name='SetWrap'/>
 			<Function name='getsecondtodestination'/>
 			<Function name='scrollthroughallitems'/>
 			<Function name='scrollwithpadding'/>
@@ -580,10 +582,12 @@
 		</Class>
 		<Class base='Actor' name='ActorSound'>
 			<Function name='get'/>
+			<Function name='get_is_action'/>
 			<Function name='load'/>
 			<Function name='pause'/>
 			<Function name='play'/>
 			<Function name='playforplayer'/>
+			<Function name='set_is_action'/>
 			<Function name='stop'/>
 		</Class>
 		<Class name='AnnouncerManager'>
@@ -604,7 +608,6 @@
 			<Function name='SetFromSteps'/>
 		</Class>
 		<Class base='Sprite' name='Banner'>
-			<Function name='GetDecodeMovie'/>
 			<Function name='GetPercentScrolling'/>
 			<Function name='GetScrolling'/>
 			<Function name='LoadBackgroundFromUnlockEntry'/>
@@ -617,7 +620,6 @@
 			<Function name='LoadFromSortOrder'/>
 			<Function name='LoadIconFromCharacter'/>
 			<Function name='ScaleToClipped'/>
-			<Function name='SetDecodeMovie'/>
 			<Function name='SetScrolling'/>
 			<Function name='scaletoclipped'/>
 		</Class>
@@ -631,6 +633,7 @@
 			<Function name='Stroke'/>
 			<Function name='distort'/>
 			<Function name='get_mult_attrs_with_diffuse'/>
+			<Function name='getstrokecolor'/>
 			<Function name='jitter'/>
 			<Function name='max_dimension_use_zoom'/>
 			<Function name='maxheight'/>
@@ -669,6 +672,10 @@
 			<Function name='Load'/>
 			<Function name='Set'/>
 		</Class>
+		<Class base='ActorFrame' name='ControllerStateDisplay'>
+			<Function name='LoadGameController'/>
+			<Function name='LoadMultiPlayer'/>
+		</Class>
 		<Class name='Course'>
 			<Function name='AllSongsAreFixed'/>
 			<Function name='GetAllTrails'/>
@@ -683,6 +690,7 @@
 			<Function name='GetEstimatedNumStages'/>
 			<Function name='GetGoalSeconds'/>
 			<Function name='GetGroupName'/>
+			<Function name='GetNumCourseEntries'/>
 			<Function name='GetPlayMode'/>
 			<Function name='GetScripter'/>
 			<Function name='GetTotalSeconds'/>
@@ -842,6 +850,7 @@
 			<Function name='Dopefish'/>
 			<Function name='EnoughCreditsToJoin'/>
 			<Function name='Env'/>
+			<Function name='GetAutoGenFarg'/>
 			<Function name='GetCharacter'/>
 			<Function name='GetCoinMode'/>
 			<Function name='GetCoins'/>
@@ -870,6 +879,7 @@
 			<Function name='GetGameplayLeadIn'/>
 			<Function name='GetHardestStepsDifficulty'/>
 			<Function name='GetHumanPlayers'/>
+			<Function name='GetLastGameplayDuration'/>
 			<Function name='GetLoadingCourseSongIndex'/>
 			<Function name='GetMasterPlayerNumber'/>
 			<Function name='GetMultiPlayerState'/>
@@ -931,6 +941,7 @@
 			<Function name='ResetPlayerOptions'/>
 			<Function name='SaveLocalData'/>
 			<Function name='SaveProfiles'/>
+			<Function name='SetAutoGenFarg'/>
 			<Function name='SetCharacter'/>
 			<Function name='SetCurrentCourse'/>
 			<Function name='SetCurrentPlayMode'/>
@@ -946,10 +957,12 @@
 			<Function name='SetPreferredSong'/>
 			<Function name='SetPreferredSongGroup'/>
 			<Function name='SetSongOptions'/>
+			<Function name='SetStepsForEditMode'/>
 			<Function name='SetTemporaryEventMode'/>
 			<Function name='ShowW1'/>
 			<Function name='StoreRankingName'/>
 			<Function name='UnjoinPlayer'/>
+			<Function name='prepare_song_for_gameplay'/>
 		</Class>
 		<Class base='ActorFrame' name='GradeDisplay'>
 			<Function name='Load'/>
@@ -1049,6 +1062,7 @@
 			<Function name='ChangeSort'/>
 			<Function name='GetSelectedSection'/>
 			<Function name='IsRouletting'/>
+			<Function name='Move'/>
 			<Function name='SelectCourse'/>
 			<Function name='SelectSong'/>
 		</Class>
@@ -1120,6 +1134,8 @@
 			<Function name='GetPlayerTimingData'/>
 			<Function name='SetActorWithComboPosition'/>
 			<Function name='SetActorWithJudgmentPosition'/>
+			<Function name='get_oitg_zoom_mode'/>
+			<Function name='set_oitg_zoom_mode'/>
 		</Class>
 		<Class name='PlayerInfo'>
 			<Function name='GetLifeMeter'/>
@@ -1209,6 +1225,7 @@
 			<Function name='FailSetting'/>
 			<Function name='Flip'/>
 			<Function name='Floored'/>
+			<Function name='FromString'/>
 			<Function name='GetReversePercentForColumn'/>
 			<Function name='GetStepAttacks'/>
 			<Function name='IsEasierForSongAndSteps'/>
@@ -1458,6 +1475,7 @@
 			<Function name='SetLastUsedHighScoreName'/>
 			<Function name='SetWeightPounds'/>
 			<Function name='SetVoomax'/>
+			<Function name='get_songs'/>
 		</Class>
 		<Class name='ProfileManager'>
 			<Function name='GetLocalProfile'/>
@@ -1556,6 +1574,7 @@
 			<Function name='GetImageHeight'/>
 			<Function name='GetPath'/>
 			<Function name='GetTextureCoordRect'/>
+			<Function name='GetNumFrames'/>
 			<Function name='loop'/>
 			<Function name='position'/>
 			<Function name='rate'/>
@@ -1568,6 +1587,9 @@
 		<Class base='BitmapText' name='RollingNumbers'>
 			<Function name='Load'/>
 			<Function name='targetnumber'/>
+		</Class>
+		<Class base='WheelBase' name='RoomWheel'>
+			<Function name='Move'/>
 		</Class>
 		<Class base='BitmapText' name='ScoreDisplayAliveTime'/>
 		<Class base='BitmapText' name='ScoreDisplayCalories'/>
@@ -1638,6 +1660,28 @@
 		</Class>
 		<Class base='ScreenEvaluation' name='ScreenNetEvaluation'>
 			<Function name='GetNumActivePlayers'/>
+		</Class>
+		<Class base='ScreenNetSelectBase' name='ScreenNetRoom'>
+			<Function name='GetMusicWheel'/>
+			<Function name='SelectCurrent'/>
+		</Class>
+		<Class base='ScreenWithMenuElements' name='ScreenNetSelectBase'>
+			<Function name='ChatboxInput'/>
+			<Function name='ChatboxVisible'/>
+			<Function name='GetChatLines'/>
+			<Function name='GetChatScroll'/>
+			<Function name='GetUser'/>
+			<Function name='GetUserQty'/>
+			<Function name='GetUserState'/>
+			<Function name='ScrollChatDown'/>
+			<Function name='ScrollChatUp'/>
+			<Function name='ShowNextMsg'/>
+			<Function name='ShowPreviousMsg'/>
+			<Function name='UsersVisible'/>
+		</Class>
+		<Class base='ScreenNetSelectBase' name='ScreenNetSelectMusic'>
+			<Function name='GetMusicWheel'/>
+			<Function name='SelectCurrent'/>
 		</Class>
 		<Class base='ScreenWithMenuElements' name='ScreenOptions'>
 			<Function name='AllAreOnLastRow'/>
@@ -1738,6 +1782,7 @@
 			<Function name='HasSignificantBPMChangesOrStops'/>
 			<Function name='HasStepsType'/>
 			<Function name='HasStepsTypeAndDifficulty'/>
+			<Function name='IsCustomSong'/>
 			<Function name='IsDisplayBpmConstant'/>
 			<Function name='IsDisplayBpmRandom'/>
 			<Function name='IsDisplayBpmSecret'/>
@@ -1749,6 +1794,7 @@
 			<Function name='IsTutorial'/>
 			<Function name='MusicLengthSeconds'/>
 			<Function name='NormallyDisplayed'/>
+			<Function name='ReloadFromSongDir'/>
 			<Function name='ShowInDemonstrationAndRanking'/>
 		</Class>
 		<Class name='SongManager'>
@@ -1818,6 +1864,7 @@
 		<Class base='Actor' name='Sprite'>
 			<Function name='CropTo'/>
 			<Function name='GetAnimationLengthSeconds'/>
+			<Function name='GetDecodeMovie'/>
 			<Function name='GetNumStates'/>
 			<Function name='GetState'/>
 			<Function name='GetTexture'/>
@@ -1832,6 +1879,7 @@
 			<Function name='SetAllStateDelays'/>
 			<Function name='SetCustomImageRect'/>
 			<Function name='SetCustomPosCoords'/>
+			<Function name='SetDecodeMovie'/>
 			<Function name='SetEffectMode'/>
 			<Function name='SetSecondsIntoAnimation'/>
 			<Function name='SetStateProperties'/>
@@ -1979,6 +2027,7 @@
 			<Function name='ReloadMetrics'/>
 			<Function name='RunLuaScripts'/>
 			<Function name='SetTheme'/>
+			<Function name='get_theme_fallback_list'/>
 		</Class>
 		<Class name='TimingData'>
 			<Function name='GetActualBPM'/>
@@ -2193,11 +2242,12 @@
 			<EnumValue name='&apos;AutosyncType_Machine&apos;' value='2'/>
 			<EnumValue name='&apos;AutosyncType_Tempo&apos;' value='3'/>
 		</Enum>
-		<Enum name='BannerCacheMode'>
-			<EnumValue name='&apos;BannerCacheMode_Off&apos;' value='0'/>
-			<EnumValue name='&apos;BannerCacheMode_LowResPreload&apos;' value='1'/>
-			<EnumValue name='&apos;BannerCacheMode_LowResLoadOnDemand&apos;' value='2'/>
-			<EnumValue name='&apos;BannerCacheMode_Full&apos;' value='3'/>
+		<Enum name='BackgroundFitMode'>
+			<EnumValue name='&apos;BackgroundFitMode_CoverDistort&apos;' value='0'/>
+			<EnumValue name='&apos;BackgroundFitMode_CoverPreserve&apos;' value='1'/>
+			<EnumValue name='&apos;BackgroundFitMode_FitInside&apos;' value='2'/>
+			<EnumValue name='&apos;BackgroundFitMode_FitInsideAvoidLetter&apos;' value='3'/>
+			<EnumValue name='&apos;BackgroundFitMode_FitInsideAvoidPillar&apos;' value='4'/>
 		</Enum>
 		<Enum name='BlendMode'>
 			<EnumValue name='&apos;BlendMode_Normal&apos;' value='0'/>
@@ -2294,6 +2344,7 @@
 			<EnumValue name='&apos;FileType_Xml&apos;' value='5'/>
 			<EnumValue name='&apos;FileType_Model&apos;' value='6'/>
 			<EnumValue name='&apos;FileType_Lua&apos;' value='7'/>
+			<EnumValue name='&apos;FileType_Ini&apos;' value='8'/>
 		</Enum>
 		<Enum name='GameController'>
 			<EnumValue name='&apos;GameController_1&apos;' value='0'/>
@@ -2361,6 +2412,12 @@
 			<EnumValue name='&apos;HorizAlign_Center&apos;' value='1'/>
 			<EnumValue name='&apos;HorizAlign_Right&apos;' value='2'/>
 		</Enum>
+		<Enum name='ImageCacheMode'>
+			<EnumValue name='&apos;ImageCacheMode_Off&apos;' value='0'/>
+			<EnumValue name='&apos;ImageCacheMode_LowResPreload&apos;' value='1'/>
+			<EnumValue name='&apos;ImageCacheMode_LowResLoadOnDemand&apos;' value='2'/>
+			<EnumValue name='&apos;ImageCacheMode_Full&apos;' value='3'/>
+		</Enum>
 		<Enum name='InputEventType'>
 			<EnumValue name='&apos;InputEventType_FirstPress&apos;' value= '0'/>
 			<EnumValue name='&apos;InputEventType_Repeat&apos;' value= '1'/>
@@ -2401,6 +2458,10 @@
 			<EnumValue name='&apos;Maybe_Ask&apos;' value='0'/>
 			<EnumValue name='&apos;Maybe_No&apos;' value='1'/>
 			<EnumValue name='&apos;Maybe_Yes&apos;' value='2'/>
+		</Enum>
+		<Enum name='MemoryCardDriverType'>
+			<EnumValue name='&apos;MemoryCardDriverType_USB&apos;' value='0'/>
+			<EnumValue name='&apos;MemoryCardDriverType_Directory&apos;' value='1'/>
 		</Enum>
 		<Enum name='MemoryCardState'>
 			<EnumValue name='&apos;MemoryCardState_ready&apos;' value='0'/>
@@ -2474,6 +2535,11 @@
 			<EnumValue name='&apos;MusicWheelUsesSections_Never&apos;' value='0'/>
 			<EnumValue name='&apos;MusicWheelUsesSections_Always&apos;' value='1'/>
 			<EnumValue name='&apos;MusicWheelUsesSections_ABCOnly&apos;' value='2'/>
+		</Enum>
+		<Enum name='NoteColorType'>
+			<EnumValue name='&apos;NoteColorType_Denominator&apos;' value='0'/>
+			<EnumValue name='&apos;NoteColorType_Progress&apos;' value='1'/>
+			<EnumValue name='&apos;NoteColorType_ProgressAlternate&apos;' value='2'/>
 		</Enum>
 		<Enum name='NoteColumnSplineMode'>
 			<EnumValue name='&apos;NoteColumnSplineMode_Disabled&apos;' value='0'/>
@@ -2574,14 +2640,15 @@
 			<EnumValue name='&apos;RadarCategory_Air&apos;' value='2'/>
 			<EnumValue name='&apos;RadarCategory_Freeze&apos;' value='3'/>
 			<EnumValue name='&apos;RadarCategory_Chaos&apos;' value='4'/>
-			<EnumValue name='&apos;RadarCategory_TapsAndHolds&apos;' value='5'/>
-			<EnumValue name='&apos;RadarCategory_Jumps&apos;' value='6'/>
-			<EnumValue name='&apos;RadarCategory_Holds&apos;' value='7'/>
-			<EnumValue name='&apos;RadarCategory_Mines&apos;' value='8'/>
-			<EnumValue name='&apos;RadarCategory_Hands&apos;' value='9'/>
-			<EnumValue name='&apos;RadarCategory_Rolls&apos;' value='10'/>
-			<EnumValue name='&apos;RadarCategory_Lifts&apos;' value='11'/>
-			<EnumValue name='&apos;RadarCategory_Fakes&apos;' value='12'/>
+			<EnumValue name='&apos;RadarCategory_Notes&apos;' value='5'/>
+			<EnumValue name='&apos;RadarCategory_TapsAndHolds&apos;' value='6'/>
+			<EnumValue name='&apos;RadarCategory_Jumps&apos;' value='7'/>
+			<EnumValue name='&apos;RadarCategory_Holds&apos;' value='8'/>
+			<EnumValue name='&apos;RadarCategory_Mines&apos;' value='9'/>
+			<EnumValue name='&apos;RadarCategory_Hands&apos;' value='10'/>
+			<EnumValue name='&apos;RadarCategory_Rolls&apos;' value='11'/>
+			<EnumValue name='&apos;RadarCategory_Lifts&apos;' value='12'/>
+			<EnumValue name='&apos;RadarCategory_Fakes&apos;' value='13'/>
 		</Enum>
 		<Enum name='RandomBackgroundMode'>
 			<EnumValue name='&apos;RandomBackgroundMode_Off&apos;' value='0'/>
@@ -2726,6 +2793,10 @@
 			<EnumValue name='&apos;StepsType_Pnm_Five&apos;' value='31'/>
 			<EnumValue name='&apos;StepsType_Pnm_Nine&apos;' value='32'/>
 			<EnumValue name='&apos;StepsType_Lights_Cabinet&apos;' value='33'/>
+			<EnumValue name='&apos;StepsType_Kickbox_Human&apos;' value='34'/>
+			<EnumValue name='&apos;StepsType_Kickbox_Quadarm&apos;' value='35'/>
+			<EnumValue name='&apos;StepsType_Kickbox_Insect&apos;' value='36'/>
+			<EnumValue name='&apos;StepsType_Kickbox_Arachnid&apos;' value='37'/>
 		</Enum>
 		<Enum name='StyleType'>
 			<EnumValue name='&apos;StyleType_OnePlayerOneSide&apos;' value='0'/>
@@ -2858,6 +2929,6 @@
 		<Constant name='right' value='&apos;HorizAlign_Right&apos;'/>
 		<Constant name='top' value='&apos;VertAlign_Top&apos;'/>
 	</Constants>
-	<Version>StepMania v5.0 beta 3</Version>
-	<Date>2014-09-15</Date>
+	<Version>StepMania5.1-git-d03ec2658f</Version>
+	<Date>2020-05-11</Date>
 </Lua>


### PR DESCRIPTION
# Summary

This updates Actor classes, class methods, and Enums listed in the bundled copy of *Docs/Luadoc/Lua.xml* to be current with d03ec2658f.

I used the command-line arg `--ExportLuaInformation` to generate a wholly new file, then manually removed some methods (e.g. literally numbered `PlayerOptions` methods ported from notitg, CamelCase aliases of spline-related methods) to keep some existing manual modifications intact.

This doesn't touch GlobalFunctions in *Lua.xml*; those need further review and will hopefully follow in a future pull request.