### PR TITLE
Small memory fixes.

### DIFF
--- a/src/RageSurface_Load_PNG.cpp
+++ b/src/RageSurface_Load_PNG.cpp
@@ -123,7 +123,6 @@ static RageSurface *RageSurface_Load_PNG( RageFile *f, const char *fn, char erro
 		CHECKPOINT_M("Header only png about to be processed.");
 		img = CreateSurfaceFrom( width, height, 32, 0, 0, 0, 0, nullptr, width*4 );
 		png_destroy_read_struct( &png, &info_ptr, nullptr );
-
 		return img;
 	}
 
@@ -254,6 +253,11 @@ static RageSurface *RageSurface_Load_PNG( RageFile *f, const char *fn, char erro
 
 	png_read_end( png, info_ptr );
 	png_destroy_read_struct( &png, &info_ptr, nullptr );
+
+	if(row_pointers != nullptr)
+	{
+		delete[] row_pointers;
+	}
 
 	return img;
 }

--- a/src/arch/InputHandler/LinuxInputManager.cpp
+++ b/src/arch/InputHandler/LinuxInputManager.cpp
@@ -80,6 +80,8 @@ LinuxInputManager::LinuxInputManager()
 	// Sort devices for more consistent numbering.
 	std::sort(m_vsPendingEventDevices.begin(), m_vsPendingEventDevices.end(), cmpDevices);
 	std::sort(m_vsPendingJoystickDevices.begin(), m_vsPendingJoystickDevices.end(), cmpDevices);
+
+	closedir(sysClassInput);
 }
 
 void LinuxInputManager::InitDriver(InputHandler_Linux_Event* driver)

--- a/src/archutils/Unix/SignalHandler.cpp
+++ b/src/archutils/Unix/SignalHandler.cpp
@@ -3,6 +3,7 @@
 #include "RageLog.h"
 #include "SignalHandler.h"
 #include "GetSysInfo.h"
+#include <memory>
 
 #if defined(HAVE_LIBPTHREAD)
 #include "archutils/Common/PthreadHelpers.h"
@@ -31,7 +32,7 @@ static int find_stack_direction2( char *p ) NOINLINE;
 static int find_stack_direction() NOINLINE;
 
 static vector<SignalHandler::handler> handlers;
-SaveSignals *saved_sigs;
+unique_ptr<SaveSignals> saved_sigs;
 
 static int signals[] =
 {
@@ -143,10 +144,10 @@ static void *CreateStack( int size )
 /* Hook up events to fatal signals, so we can clean up if we're killed. */
 void SignalHandler::OnClose( handler h )
 {
-	if( saved_sigs == nullptr )
+	//if the unique_ptr has not been set, then enter.
+	if( !saved_sigs )
 	{
-		saved_sigs = new SaveSignals;
-
+		saved_sigs.reset(new SaveSignals());
 		bool bUseAltSigStack = true;
 
 #if defined(LINUX)


### PR DESCRIPTION
So for a while now I've known that StepMania has had a memory leak as I imagine it to be used in an arcade like manner: leaving it on for extended periods of time with little to no restarting required.

I wrote some watchdog and some other hotfixes, but overall the error remains true: leave StepMania on with minimal amount of RAM on a dedicated system, and it will start to thrash swap or run out of memory.

My test case for this has been changing the Rate of the game in `ScreenDebugOverlay` to be 20 and allowing MonkeyInput to updated every 0.025s...in addition to overloading the game completely with "too many songs" at around 10k.

Here's the before and after testing graphed out: https://twitter.com/dinsfire64/status/1260296447439716352

It makes quite a difference in an "extreme" scenario.

I was able to find these with Valgrind. Here's are the stack traces that lead me to find them.

```
==15968== 175,632 (93,328 direct, 82,304 indirect) bytes in 20 blocks are definitely lost in loss record 2,202 of 2,202
==15968==    at 0x483950F: operator new[](unsigned long) (vg_replace_malloc.c:433)
==15968==    by 0xE27A83: (anonymous namespace)::RageSurface_Load_PNG(RageFile*, char const*, char*, bool) (in /home/dance/build/stepmania-git/src/stepmania/stepmania)
==15968==    by 0xE27D4B: RageSurface_Load_PNG(StdString::CStdStr<char> const&, RageSurface*&, bool, StdString::CStdStr<char>&) (in /home/dance/build/stepmania-git/src/stepmania/stepmania)
==15968==    by 0xE23A8C: TryOpenFile(StdString::CStdStr<char>, bool, StdString::CStdStr<char>&, StdString::CStdStr<char>, bool&) (in /home/dance/build/stepmania-git/src/stepmania/stepmania)
==15968==    by 0xE23EB3: RageSurfaceUtils::LoadFile(StdString::CStdStr<char> const&, StdString::CStdStr<char>&, bool) (in /home/dance/build/stepmania-git/src/stepmania/stepmania)
==15968==    by 0xDFE3DA: RageBitmapTexture::Create() (in /home/dance/build/stepmania-git/src/stepmania/stepmania)
==15968==    by 0xDFE1D5: RageBitmapTexture::RageBitmapTexture(RageTextureID) (in /home/dance/build/stepmania-git/src/stepmania/stepmania)
==15968==    by 0xE36292: RageTextureManager::LoadTextureInternal(RageTextureID) (in /home/dance/build/stepmania-git/src/stepmania/stepmania)
==15968==    by 0xE363E6: RageTextureManager::LoadTexture(RageTextureID) (in /home/dance/build/stepmania-git/src/stepmania/stepmania)
==15968==    by 0xC0AC9D: FontPage::Load(FontPageSettings const&) (in /home/dance/build/stepmania-git/src/stepmania/stepmania)
==15968==    by 0xC0EC59: Font::Load(StdString::CStdStr<char> const&, StdString::CStdStr<char>) (in /home/dance/build/stepmania-git/src/stepmania/stepmania)
==15968==    by 0xC0EA1C: Font::Load(StdString::CStdStr<char> const&, StdString::CStdStr<char>) (in /home/dance/build/stepmania-git/src/stepmania/stepmania)
```
```
==16133== 32,816 bytes in 1 blocks are definitely lost in loss record 2,186 of 2,186
==16133==    at 0x483877F: malloc (vg_replace_malloc.c:309)
==16133==    by 0x7241B5A: __alloc_dir (in /usr/lib/libc-2.29.so)
==16133==    by 0x7241C5C: opendir_tail (in /usr/lib/libc-2.29.so)
==16133==    by 0xBB18BA: LinuxInputManager::LinuxInputManager() (in /home/dance/build/stepmania-git/src/stepmania/stepmania)
==16133==    by 0xBB4604: InputHandler_Linux_Event::InputHandler_Linux_Event() (in /home/dance/build/stepmania-git/src/stepmania/stepmania)
==16133==    by 0xBB5607: RageDriver* CreateClass<InputHandler_Linux_Event, RageDriver>() (in /home/dance/build/stepmania-git/src/stepmania/stepmania)
==16133==    by 0xBA5406: DriverList::Create(StdString::CStdStr<char> const&) (in /home/dance/build/stepmania-git/src/stepmania/stepmania)
==16133==    by 0xBAEEC2: InputHandler::Create(StdString::CStdStr<char> const&, std::vector<InputHandler*, std::allocator<InputHandler*> >&) (in /home/dance/build/stepmania-git/src/stepmania/stepmania)
==16133==    by 0xE3F69E: RageInput::LoadDrivers() (in /home/dance/build/stepmania-git/src/stepmania/stepmania)
==16133==    by 0xE3F4FD: RageInput::RageInput() (in /home/dance/build/stepmania-git/src/stepmania/stepmania)
==16133==    by 0x8DFA76: sm_main(int, char**) (in /home/dance/build/stepmania-git/src/stepmania/stepmania)
==16133==    by 0x101AF48: main (in /home/dance/build/stepmania-git/src/stepmania/stepmania)
```

```
==16133== 2,432 bytes in 1 blocks are still reachable in loss record 2,148 of 2,186
==16133==    at 0x4838DEF: operator new(unsigned long) (vg_replace_malloc.c:344)
==16133==    by 0xFFAD31: __gnu_cxx::new_allocator<sigaction>::allocate(unsigned long, void const*) (in /home/dance/build/stepmania-git/src/stepmania/stepmania)
==16133==    by 0xFFAAD1: std::allocator_traits<std::allocator<sigaction> >::allocate(std::allocator<sigaction>&, unsigned long) (in /home/dance/build/stepmania-git/src/stepmania/stepmania)
==16133==    by 0xFFA667: std::_Vector_base<sigaction, std::allocator<sigaction> >::_M_allocate(unsigned long) (in /home/dance/build/stepmania-git/src/stepmania/stepmania)
==16133==    by 0xFF9D56: void std::vector<sigaction, std::allocator<sigaction> >::_M_realloc_insert<sigaction const&>(__gnu_cxx::__normal_iterator<sigaction*, std::vector<sigaction, std::allocator<sigaction> > >, sigaction const&) (in /home/dance/build/stepmania-git/src/stepmania/stepmania)
==16133==    by 0xFF99C4: std::vector<sigaction, std::allocator<sigaction> >::push_back(sigaction const&) (in /home/dance/build/stepmania-git/src/stepmania/stepmania)
==16133==    by 0xFF92D5: SaveSignals::SaveSignals() (in /home/dance/build/stepmania-git/src/stepmania/stepmania)
==16133==    by 0xFF967A: SignalHandler::OnClose(bool (*)(int, siginfo_t*, ucontext_t const*)) (in /home/dance/build/stepmania-git/src/stepmania/stepmania)
==16133==    by 0xBAC989: ArchHooks_Unix::Init() (in /home/dance/build/stepmania-git/src/stepmania/stepmania)
==16133==    by 0x8DED68: sm_main(int, char**) (in /home/dance/build/stepmania-git/src/stepmania/stepmania)
==16133==    by 0x101AF48: main (in /home/dance/build/stepmania-git/src/stepmania/stepmania)
```