### PR TITLE
Log errors while reading joystick input

### DIFF
--- a/src/arch/InputHandler/InputHandler_Linux_Joystick.cpp
+++ b/src/arch/InputHandler/InputHandler_Linux_Joystick.cpp
@@ -140,6 +140,15 @@ void InputHandler_Linux_Joystick::InputThread()
 
 			js_event event;
 			int ret = read(fds[i], &event, sizeof(event));
+
+			if(ret == -1)
+			{
+				LOG->Warn("Error reading from joystick %i: %s; disabled", i, strerror(errno));
+				close(fds[i]);
+				fds[i] = -1;
+				continue;
+			}
+
 			if(ret != sizeof(event))
 			{
 				LOG->Warn("Unexpected packet (size %i != %i) from joystick %i; disabled", ret, (int)sizeof(event), i);


### PR DESCRIPTION
I hit this recently when trying to use my L-TEK DDR pad, and I can see that [other people have encountered problems before.](https://github.com/stepmania/stepmania/issues/1950) Hopefully this helps me and any future users track down the underlying problem.

Analogous to the check in the event input handler [here](https://github.com/stepmania/stepmania/blob/b11411ad2d95912342ae84e23f2383d34433e7e4/src/arch/InputHandler/InputHandler_Linux_Event.cpp#L366).

