### PR TITLE
Add MusicWheel:GetCurrentSections()

### DIFF
--- a/Docs/Luadoc/Lua.xml
+++ b/Docs/Luadoc/Lua.xml
@@ -1065,6 +1065,7 @@
 			<Function name='Move'/>
 			<Function name='SelectCourse'/>
 			<Function name='SelectSong'/>
+			<Function name='GetCurrentSections' />
 		</Class>
 		<Class name='NCSplineHandler'>
 			<Function name='get_spline'/>

--- a/Docs/Luadoc/LuaDocumentation.xml
+++ b/Docs/Luadoc/LuaDocumentation.xml
@@ -3236,7 +3236,7 @@ save yourself some time, copy this for undocumented things:
 		Selects a course. Returns <code>false</code> on failure.
 	</Function>
 	<Function name='GetCurrentSections' return='{string}' arguments=''>
-		Returns the current sections in the MusicWheel, for use with a custom group select that supports sorting.
+		Returns a string array of the currently displayed sections in the MusicWheel.
 	</Function>
 </Class>
 <Class name='NoteSkinManager'>

--- a/Docs/Luadoc/LuaDocumentation.xml
+++ b/Docs/Luadoc/LuaDocumentation.xml
@@ -3235,6 +3235,9 @@ save yourself some time, copy this for undocumented things:
 	<Function name='SelectCourse' return='bool' arguments='Course cCourse'>
 		Selects a course. Returns <code>false</code> on failure.
 	</Function>
+	<Function name='GetCurrentSections' return='{string}' arguments=''>
+		Returns the current sections in the MusicWheel, for use with a custom group select that supports sorting.
+	</Function>
 </Class>
 <Class name='NoteSkinManager'>
 	<Function name='GetMetric' return='string' arguments='string sElement, string sValue'>

--- a/src/MusicWheel.cpp
+++ b/src/MusicWheel.cpp
@@ -1468,6 +1468,16 @@ void MusicWheel::SetOpenSection( RString group )
 	RebuildWheelItems();
 }
 
+void MusicWheel::GetCurrentSections(vector<RString> &sections)
+{
+	vector<MusicWheelItemData *> &wiWheelItems = getWheelItemsData(GAMESTATE->m_SortOrder);
+	for( unsigned i = 0; i < wiWheelItems.size(); i++ )
+	{
+		if ( wiWheelItems[i]->m_Type == WheelItemDataType_Section && !wiWheelItems[i]->m_sText.empty())
+			sections.push_back(wiWheelItems[i]->m_sText);
+	}
+}
+
 // sm-ssc additions: jump to group
 RString MusicWheel::JumpToNextGroup()
 {
@@ -1693,6 +1703,13 @@ public:
 		return 1;
 	}
 	DEFINE_METHOD(GetSelectedSection, GetSelectedSection());
+	static int GetCurrentSections( T* p, lua_State *L )
+	{
+		vector<RString> v;
+		p->GetCurrentSections(v);
+		LuaHelpers::CreateTableFromArray<RString>( v, L );
+		return 1;
+	}
 	static int IsRouletting( T* p, lua_State *L ){ lua_pushboolean( L, p->IsRouletting() ); return 1; }
 	static int SelectSong( T* p, lua_State *L )
 	{
@@ -1733,6 +1750,7 @@ public:
 		ADD_METHOD( SelectSong );
 		ADD_METHOD( SelectCourse );
 		ADD_METHOD( Move );
+		ADD_METHOD( GetCurrentSections );
 	}
 };
 

--- a/src/MusicWheel.h
+++ b/src/MusicWheel.h
@@ -52,6 +52,7 @@ public:
 
 	virtual void ReloadSongList();
 
+	void GetCurrentSections(vector<RString> &sections);
 	// Lua
 	void PushSelf( lua_State *L );
 


### PR DESCRIPTION
Necessary for using a custom group select along with the built in music select since SONGMAN:GetSongGroupNames() does not have any concept of the currently used sort.

Also needed to get the number of groups in the group select when the sort is not default.