### PR TITLE
Fix issue 2005: incorrect announcer sounds on the evaluation screen

### DIFF
--- a/src/Grade.cpp
+++ b/src/Grade.cpp
@@ -33,7 +33,7 @@ RString GradeToLocalizedString( Grade g )
 RString GradeToOldString( Grade g )
 {
 	// string is meant to be human readable
-	switch( g )
+	switch( GradeToOldGrade(g) )
 	{
 	case Grade_Tier01:	return "AAAA";
 	case Grade_Tier02:	return "AAA";
@@ -47,6 +47,16 @@ RString GradeToOldString( Grade g )
 	default:		return "N";
 	}
 };
+
+Grade GradeToOldGrade( Grade g )
+{
+	// There used to be 7 grades (plus fail) but grades can now be defined by themes.
+	// So we need to re-scale the grade bands based on how many actual grades the theme defines.
+	if( g < NUM_GRADE_TIERS_USED )
+		g = (Grade)round((double)g * Grade_Tier07 / (NUM_GRADE_TIERS_USED - 1));
+
+	return g;
+}
 
 Grade StringToGrade( const RString &sGrade )
 {

--- a/src/Grade.h
+++ b/src/Grade.h
@@ -67,6 +67,7 @@ static inline RString GradeToString( Grade g )
  * @param g the current Grade.
  * @return the old styled grade string. */
 RString GradeToOldString( Grade g );
+Grade GradeToOldGrade( Grade g );
 RString GradeToLocalizedString( Grade g );
 /**
  * @brief Convert the given RString into a proper Grade.

--- a/src/ScreenEvaluation.cpp
+++ b/src/ScreenEvaluation.cpp
@@ -709,7 +709,7 @@ void ScreenEvaluation::Init()
 		}
 	}
 
-	switch( best_grade )
+	switch( GradeToOldGrade(best_grade) )
 	{
 		case Grade_Tier01:
 		case Grade_Tier02:


### PR DESCRIPTION
Fixes stepmania/stepmania#2005 (Incorrect announcer sound files are played on the evaluation screen if the current theme doesn't have exactly 7 grade tiers.)

This change maps the new grade tiers evenly to the 7 old grade tiers to trigger the correct sound files.

It also extends that mapping to the grade tiers used for playing cheering for the top few tiers.