### PR TITLE
Unix backtrace call detection

### DIFF
--- a/src/archutils/Unix/Backtrace.cpp
+++ b/src/archutils/Unix/Backtrace.cpp
@@ -236,8 +236,7 @@ static bool PointsToValidCall( const void *ptr )
 	int len = 7;
 	while( len )
 	{
-		int val = find_address( buf-len, g_ReadableBegin, g_ReadableEnd );
-		if( val != -1 )
+		if( IsExecutableAddress( buf - len ) )
 			break;
 		--len;
 	}


### PR DESCRIPTION
If the supposed return address is a pointer to the beginning of an
executable page, and the page before is an oversized file mapping,
like `[vvar]` before `[vdso]`, the backtrace would be terminated by SIGBUS.

To avoid this, check not for readable, but for executable instead.

On my box this occurred 100% of the time, as my libc puts `[vdso]` pointers on stack, and which get mistaken for return addresses by the backtrace mechanism.

A gdb crash that gets fixed by this:
```
Program received signal SIGBUS, Bus error.
0x00005555563ed105 in PointsToValidCall (ptr=0x7ffff7fd1000) at /mnt/dane/Dane/gicior/stepmania/src/archutils/Unix/Backtrace.cpp:254
254             if (len >= 5 && buf[-5] == '\xe8')
(gdb) shell cat /proc/29695/maps
# ...
7ffff7fcd000-7ffff7fd1000 r--p 00000000 00:00 0                          [vvar]
7ffff7fd1000-7ffff7fd3000 r-xp 00000000 00:00 0                          [vdso]
# ...
```