### PR TITLE
Don't require assembler for system FFmpeg

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,8 +36,10 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get install -y
-          ffmpeg
           libasound2-dev
+          libavcodec-dev
+          libavformat-dev
+          libavutil-dev
           libgl-dev
           libglew-dev
           libgtk2.0-dev
@@ -45,6 +47,7 @@ jobs:
           libjsoncpp-dev
           libmad0-dev
           libpulse-dev
+          libswscale-dev
           libtomcrypt-dev
           libtommath-dev
           libva-dev

--- a/StepmaniaCore.cmake
+++ b/StepmaniaCore.cmake
@@ -443,7 +443,7 @@ elseif(LINUX)
       )
   endif()
 
-  if(WITH_FFMPEG AND NOT YASM_FOUND AND NOT NASM_FOUND)
+  if(WITH_FFMPEG AND NOT WITH_SYSTEM_FFMPEG AND NOT YASM_FOUND AND NOT NASM_FOUND)
     message(
       "Neither NASM nor YASM were found. Please install at least one of them if you wish for ffmpeg support."
       )


### PR DESCRIPTION
Fixes #2016.

When using system FFmpeg assemblers are not needed for building FFmpeg.