### PR TITLE
Actions Badge: Branch Fixup

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ StepMania is an advanced cross-platform rhythm game for home and arcade use.
 
 Advanced cross-platform rhythm game for home and arcade use.
 
-[![Continuous integration](https://github.com/stepmania/stepmania/workflows/Continuous%20integration/badge.svg?branch=master)](https://github.com/stepmania/stepmania/actions?query=workflow%3A%22Continuous+integration%22+branch%3Amaster)
+[![Continuous integration](https://github.com/stepmania/stepmania/workflows/Continuous%20integration/badge.svg?branch=5_1-new)](https://github.com/stepmania/stepmania/actions?query=workflow%3A%22Continuous+integration%22+branch%3A5_1-new)
 [![Build Status](https://travis-ci.org/stepmania/stepmania.svg?branch=master)](https://travis-ci.org/stepmania/stepmania)
 [![Build status](https://ci.appveyor.com/api/projects/status/uvoplsnyoats81r2?svg=true)](https://ci.appveyor.com/project/Nickito12/stepmania)
 


### PR DESCRIPTION
@quietly-turning, sorry to bother you again, but I wrongly set the branch for the GitHub Actions badge to `master` in #2015. This corrects the badge branch to `5_1-new`.