### PR TITLE
Sort Steps by StepsType and Difficulty in cache, sm and ssc files

### DIFF
--- a/src/Song.cpp
+++ b/src/Song.cpp
@@ -1278,6 +1278,8 @@ bool Song::SaveToSMFile()
 		vpStepsToSave.push_back(s);
 	}
 
+	StepsUtil::SortStepsByTypeAndDifficulty( vpStepsToSave );
+	
 	return NotesWriterSM::Write( sPath, *this, vpStepsToSave );
 
 }
@@ -1317,6 +1319,8 @@ bool Song::SaveToSSCFile( RString sPath, bool bSavingCache, bool autosave )
 		vpStepsToSave.push_back(s);
 	}
 
+	StepsUtil::SortStepsByTypeAndDifficulty( vpStepsToSave );
+	
 	if(bSavingCache || autosave)
 	{
 		return NotesWriterSSC::Write(path, *this, vpStepsToSave, bSavingCache);


### PR DESCRIPTION
Steps are sorted by StepsType and Difficulty when saving sm/ssc files in Editor. Same goes for generating song cache.