### PR TITLE
Fix -Wreturn-type and its undefined behavior

### DIFF
--- a/src/NotesWriterSM.cpp
+++ b/src/NotesWriterSM.cpp
@@ -264,7 +264,7 @@ bool NotesWriterSM::Write( RString sPath, Song &out, const vector<Steps*>& vpSte
 		return false;
 	}
 
-	Write( f, out, vpStepsToSave );
+	return Write( f, out, vpStepsToSave );
 }
 
 bool NotesWriterSM::Write( RageFileBasic &f, Song &out, const vector<Steps*>& vpStepsToSave )


### PR DESCRIPTION
Silence the following warning message:
```
src/NotesWriterSM.cpp:260:11: warning: control reaches end of non-void function [-Wreturn-type]
```

This warning had meaningful implications for some reason.
When I compiled the current version with stack protector enabled, GCC optimized out successful return from the function, and encouraged undefined behavior far less intuitive than an unspecified value.

Whenever saving a steps file on a `-DCMAKE_BUILD_TYPE=Release` build, the game printed a message about stack protection violation, and aborted itself, even though no violation took place.

GCC version:
`gcc (Gentoo 10.2.0 p1) 10.2.0`