### PR TITLE
[ScreenEdit] Mirror the right SnapDisplay icon

### DIFF
--- a/src/SnapDisplay.cpp
+++ b/src/SnapDisplay.cpp
@@ -26,6 +26,7 @@ void SnapDisplay::Load()
 
 	m_sprIndicators[0].SetX( -ARROW_SIZE * (m_iNumCols/2 + 0.5f) );
 	m_sprIndicators[1].SetX(  ARROW_SIZE * (m_iNumCols/2 + 0.5f) );
+	m_sprIndicators[1].SetBaseZoomX( -1 );
 }
 
 bool SnapDisplay::PrevSnapMode()

--- a/src/StepsDisplay.cpp
+++ b/src/StepsDisplay.cpp
@@ -225,8 +225,14 @@ void StepsDisplay::SetInternal( const SetParams &params )
 		char on = char('1');
 		char off = '0';
 
+		if( params.iMeter > 0 )
+		{
+			on = params.iMeter >= m_iNumTicks ? char('3') : char('2');
+			off = params.iMeter >= m_iNumTicks ? char('2') : char('1');
+		}
+		
 		RString sNewText;
-		int iNumOn = min( (int)m_iMaxTicks, params.iMeter );
+		int iNumOn = min( (int)m_iMaxTicks, params.iMeter % m_iNumTicks );
 		sNewText.insert( sNewText.end(), iNumOn, on );
 		int iNumOff = max( 0, m_iNumTicks-iNumOn );
 		sNewText.insert( sNewText.end(), iNumOff, off );


### PR DESCRIPTION
Useful for asymmetric images. Should have no effect on symmetric image like the one used in default theme.