### PR TITLE
give CryptManager and Lua access to tomcrypt's SHA256

### DIFF
--- a/Docs/Luadoc/Lua.xml
+++ b/Docs/Luadoc/Lua.xml
@@ -12,6 +12,7 @@
 		<Function name='BGFitChoiceExample'/>
 		<Function name='BGFitInputActor'/>
 		<Function name='Basename'/>
+		<Function name='BinaryToHex'/>
 		<Function name='BoostColor'/>
 		<Function name='Brightness'/>
 		<Function name='Center1Player'/>
@@ -757,6 +758,8 @@
 			<Function name='MD5String'/>
 			<Function name='SHA1File'/>
 			<Function name='SHA1String'/>
+			<Function name='SHA256File'/>
+			<Function name='SHA256String'/>
 		</Class>
 		<Class name='CubicSplineN'>
 			<Function name='solve'/>

--- a/Docs/Luadoc/LuaDocumentation.xml
+++ b/Docs/Luadoc/LuaDocumentation.xml
@@ -74,6 +74,10 @@ save yourself some time, copy this for undocumented things:
 	<Function name='Basename' return='string' arguments='string path'>
 		Returns the last named component of <code>path</code>.  For example, passing in <code>"/path/to/file.txt"</code> will return <code>"file.txt"</code>, while <code>"/path/to/some/directory/"</code> will return <code>"directory"</code>.
 	</Function>
+	<Function name='BinaryToHex' return='string' arguments='string s'>
+		Converts a binary formatted string to hexadecimal format.
+		This can be useful in conjunction with <Link class="CryptManager" />'s MD5 and SHA functions.
+	</Function>
 	<Function name='BoostColor' theme='_fallback' return='color' arguments='color c, float fBoost'>
 		[02 Colors.lua] Returns the color that results from multiplying <code>c</code>'s R, G, and B values by <code>fBoost</code>.
 	</Function>
@@ -2509,6 +2513,14 @@ Def.BitmapText{
 	</Function>
 	<Function name='SHA1String' return='string' arguments='string s'>
 		Returns the SHA-1 hash for <code>s</code>.
+	</Function>
+	<Function name='SHA256File' return='string' arguments='string sPath'>
+		Returns the SHA-256 hash for the file at <code>sPath</code> as a binary formatted string.<br />
+		You can use <Link class='GLOBAL' function='BinaryToHex' /> to convert to hexadecimal format.
+	</Function>
+	<Function name='SHA256String' return='string' arguments='string s'>
+		Returns the SHA-256 hash for <code>s</code> as a binary formatted string.<br />
+		You can use <Link class='GLOBAL' function='BinaryToHex' /> to convert to hexadecimal format.
 	</Function>
 </Class>
 <Class name='CubicSplineN'>

--- a/extern/CMakeProject-tomcrypt.cmake
+++ b/extern/CMakeProject-tomcrypt.cmake
@@ -823,6 +823,7 @@ else()
   sm_add_compile_definition("tomcrypt" LTC_DEVRANDOM)
 
   # Common formulas used by our app.
+  sm_add_compile_definition("tomcrypt" LTC_SHA256)
   sm_add_compile_definition("tomcrypt" LTC_SHA1)
   sm_add_compile_definition("tomcrypt" LTC_MD5)
 

--- a/src/CryptManager.cpp
+++ b/src/CryptManager.cpp
@@ -420,6 +420,37 @@ RString CryptManager::GetSHA1ForFile( RString fn )
 	return RString( (const char *) digest, sizeof(digest) );
 }
 
+RString CryptManager::GetSHA256ForString( RString sData )
+{
+	unsigned char digest[32];
+
+	int iHash = register_hash( &sha256_desc );
+
+	hash_state hash;
+	hash_descriptor[iHash].init( &hash );
+	hash_descriptor[iHash].process( &hash, (const unsigned char *) sData.data(), sData.size() );
+	hash_descriptor[iHash].done( &hash, digest );
+
+	return RString( (const char *) digest, sizeof(digest) );
+}
+
+RString CryptManager::GetSHA256ForFile( RString fn )
+{
+	RageFile file;
+	if( !file.Open( fn, RageFile::READ ) )
+	{
+		LOG->Warn( "GetSHA256: Failed to open file '%s'", fn.c_str() );
+		return RString();
+	}
+	int iHash = register_hash( &sha256_desc );
+	ASSERT( iHash >= 0 );
+
+	unsigned char digest[32];
+	HashFile( file, digest, iHash );
+
+	return RString( (const char *) digest, sizeof(digest) );
+}
+
 RString CryptManager::GetPublicKeyFileName()
 {
 	return PUBLIC_KEY_PATH;
@@ -478,6 +509,20 @@ public:
 		lua_pushlstring(L, sha1fout, sha1fout.size());
 		return 1;
 	}
+	static int SHA256String( T* p, lua_State *L )
+	{
+		RString sha256out;
+		sha256out = p->GetSHA256ForString(SArg(1));
+		lua_pushlstring(L, sha256out, sha256out.size());
+		return 1;
+	}
+	static int SHA256File( T* p, lua_State *L )
+	{
+		RString sha256fout;
+		sha256fout = p->GetSHA256ForFile(SArg(1));
+		lua_pushlstring(L, sha256fout, sha256fout.size());
+		return 1;
+	}
 	static int GenerateRandomUUID( T* p, lua_State *L )
 	{
 		RString uuidOut;
@@ -492,6 +537,8 @@ public:
 		ADD_METHOD( MD5File );
 		ADD_METHOD( SHA1String );
 		ADD_METHOD( SHA1File );
+		ADD_METHOD( SHA256String );
+		ADD_METHOD( SHA256File );
 		ADD_METHOD( GenerateRandomUUID );
 	}
 };

--- a/src/CryptManager.h
+++ b/src/CryptManager.h
@@ -24,10 +24,12 @@ public:
 	static void GetRandomBytes( void *pData, int iBytes );
 	static RString GenerateRandomUUID();
 
-	static RString GetMD5ForFile( RString fn );		// in binary
-	static RString GetMD5ForString( RString sData );	// in binary
-	static RString GetSHA1ForString( RString sData );	// in binary
-	static RString GetSHA1ForFile( RString fn );		// in binary
+	static RString GetMD5ForFile( RString fn );         // in binary
+	static RString GetMD5ForString( RString sData );    // in binary
+	static RString GetSHA1ForString( RString sData );   // in binary
+	static RString GetSHA1ForFile( RString fn );        // in binary
+	static RString GetSHA256ForString( RString sData ); // in binary
+	static RString GetSHA256ForFile( RString fn );      // in binary
 
 	static RString GetPublicKeyFileName();
 
@@ -42,7 +44,7 @@ extern CryptManager*	CRYPTMAN;	// global and accessible from anywhere in our pro
 /*
  * (c) 2004 Chris Danford
  * All rights reserved.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the
  * "Software"), to deal in the Software without restriction, including
@@ -52,7 +54,7 @@ extern CryptManager*	CRYPTMAN;	// global and accessible from anywhere in our pro
  * copyright notice(s) and this permission notice appear in all copies of
  * the Software and that both the above copyright notice(s) and this
  * permission notice appear in supporting documentation.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
  * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
  * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF

--- a/src/RageUtil.cpp
+++ b/src/RageUtil.cpp
@@ -218,7 +218,7 @@ bool IsHexVal( const RString &s )
 		return false;
 
 	for( size_t i=0; i < s.size(); ++i )
-		if( !(s[i] >= '0' && s[i] <= '9') && 
+		if( !(s[i] >= '0' && s[i] <= '9') &&
 			!(toupper(s[i]) >= 'A' && toupper(s[i]) <= 'F'))
 			return false;
 
@@ -339,7 +339,7 @@ RString PrettyPercent( float fNumerator, float fDenominator)
 	return ssprintf("%0.2f%%",fNumerator/fDenominator*100);
 }
 
-RString Commify( int iNum ) 
+RString Commify( int iNum )
 {
 	RString sNum = ssprintf("%d",iNum);
 	return Commify( sNum );
@@ -494,7 +494,7 @@ RString vssprintf( const char *szFormat, va_list argList )
 			/* OK */
 			sStr.assign(buf, used);
 		}
-		
+
 		delete [] buf;
 		if (used != -1)
 		{
@@ -956,9 +956,9 @@ void splitpath( const RString &sPath, RString &sDir, RString &sFilename, RString
 	vector<RString> asMatches;
 
 	/*
-	 * One level of escapes for the regex, one for C. Ew. 
+	 * One level of escapes for the regex, one for C. Ew.
 	 * This is really:
-	 * ^(.*[\\/])?(.*)$ 
+	 * ^(.*[\\/])?(.*)$
 	 */
 	static Regex sep("^(.*[\\\\/])?(.*)$");
 	bool bCheck = sep.Compare( sPath, asMatches );
@@ -1248,10 +1248,10 @@ float calc_stddev( const float *pStart, const float *pEnd, bool bSample )
 bool CalcLeastSquares( const vector< pair<float, float> > &vCoordinates,
                        float &fSlope, float &fIntercept, float &fError )
 {
-	if( vCoordinates.empty() ) 
+	if( vCoordinates.empty() )
 		return false;
 	float fSumXX = 0.0f, fSumXY = 0.0f, fSumX = 0.0f, fSumY = 0.0f;
-	for( unsigned i = 0; i < vCoordinates.size(); ++i ) 
+	for( unsigned i = 0; i < vCoordinates.size(); ++i )
 	{
 		fSumXX += vCoordinates[i].first * vCoordinates[i].first;
 		fSumXY += vCoordinates[i].first * vCoordinates[i].second;
@@ -1263,7 +1263,7 @@ bool CalcLeastSquares( const vector< pair<float, float> > &vCoordinates,
 	fIntercept = (fSumXX * fSumY - fSumX * fSumXY) / fDenominator;
 
 	fError = 0.0f;
-	for( unsigned i = 0; i < vCoordinates.size(); ++i ) 
+	for( unsigned i = 0; i < vCoordinates.size(); ++i )
 	{
 		const float fOneError = fIntercept + fSlope * vCoordinates[i].first - vCoordinates[i].second;
 		fError += fOneError * fOneError;
@@ -1916,7 +1916,7 @@ wstring RStringToWstring( const RString &s )
 			++start;
 			continue;
 		}
-		
+
 		wchar_t ch = L'\0';
 		if( !utf8_to_wchar( s.data(), s.size(), start, ch ) )
 			ch = INVALID_CHAR;
@@ -2149,13 +2149,13 @@ RString Dirname( const RString &dir )
 	return dir.substr(0, pos+1);
 }
 
-RString Capitalize( const RString &s )	
+RString Capitalize( const RString &s )
 {
 	if( s.empty() )
 		return RString();
 
 	char *buf = const_cast<char *>(s.c_str());
-	
+
 	UnicodeDoUpper( buf, s.size(), g_UpperCase );
 
 	return buf;
@@ -2285,7 +2285,7 @@ void CollapsePath( RString &sPath, bool bRemoveLeadingDot )
 
 		sOut.append( sPath, iPos, iNext-iPos );
 	}
-	
+
 	sOut.swap( sPath );
 }
 
@@ -2436,6 +2436,7 @@ LuaFunction( URLEncode, URLEncode( SArg(1) ) );
 LuaFunction( PrettyPercent, PrettyPercent( FArg(1), FArg(2) ) );
 //LuaFunction( IsHexVal, IsHexVal( SArg(1) ) );
 LuaFunction( lerp, lerp(FArg(1), FArg(2), FArg(3)) );
+LuaFunction( BinaryToHex, BinaryToHex( SArg(1) ) );
 
 int LuaFunc_commify(lua_State* L);
 int LuaFunc_commify(lua_State* L)


### PR DESCRIPTION
# What

This adds libtomcrypt's SHA256 hash function to CryptManager with Lua hooks.  It follows along with the C++ patterns Glenn wrote a decade and a half ago for CryptMananger's MD5 and SHA1 functions.

StepMania's CMakeProject-tomcrypt file has been updated to build with *sha256* symbols.  Invoking cmake to build with system tomcrypt (e.g. `cmake -DWITH_SYSTEM_TOMCRYPT=ON`) works fine as-is.

The original SM functions for SHA1 and MD5 return binary formatted strings, so these new SHA256 functions follow suit.  This pull request also exposes RageUtil's existing `BinaryToHex` as a global Lua function to help themers who want a hash formatted in hex.

# Why

Existing SM5 themes (Simply Love, Digital Dance, Waterfall, etc.) use SHA256 hashes to generate QR codes for uploading scores to [GrooveStats](https://groovestats.com).

The current [pure-Lua implementation](https://github.com/quietly-turning/Simply-Love-SM5/blob/564bb7891e13aa8b536a092045c72d6624dfe0fb/Scripts/sha2for51.lua) works, but is slow.  Since the tomcrypt library already has SHA256 implemented, adding Lua hooks seemed like low-hanging fruit.

The faster the hash can be computed, the faster the QR code can be generated, allowing the Evaluation screen to be shown.

# Build Tests

Build tests are currently failing on Windows, but that seems unrelated to these changes.

# Performance

I used this Lua to do some rudimentary tests comparing the performance of the pure-Lua implementation with libtomcrypt's.

```lua
local songs = {
	-- 654 steps
	"Mute Sims X2/Lament Configuration",

	-- 4045 steps ("Is this hash really fast enough?")
	"Pendulum/Another Planet",

	-- 22897 steps
	"Cranked Pastry/Last Trip",

	-- 576000 steps 😭
	"Crapyard Scent/24 hours of 100 bpm stream"
}

for i,v in ipairs(songs) do
	local song = SONGMAN:FindSong(v)
	local steps = song:GetOneSteps("StepsType_Dance_Single", "Difficulty_Challenge" )
	
	-- ParseMsdFile and GetChartDataAndBpmForSM are specific to Simply Love
	local msdFile, _      = ParseMsdFile(steps)
	local chartDataAndBpm = GetChartDataAndBpmForSM(msdFile, "dance-single", "Challenge", steps:GetDescription())
	
	-- get uptime now, prior to hashing using SM engine
	local time_at_start = GetTimeSinceStart()
	-- get hash using CRYPTMAN, assess time
	local hash1 = BinaryToHex( CRYPTMAN:SHA256String(chartDataAndBpm) )
	local time1 = GetTimeSinceStart() - time_at_start
	
	-- get uptime again, prior to hashing using Lua
	time_at_start = GetTimeSinceStart()
	-- get hash using Lua, assess time
	local hash2 = sha256( chartDataAndBpm )
	local time2 = GetTimeSinceStart() - time_at_start

	-- print results to log.txt
	Trace( "-----------------------------------------" )
	Trace( v ) -- group/song name
	Trace( "CRYPTMAN hash: "..hash1)
	Trace( "     Lua hash: "..hash2)
	Trace( " hashes match: "..tostring(hash1==hash2))
	Trace( "CRYPTMAN time: "..("%f"):format(time1) )
	Trace( "     Lua time: "..("%f"):format(time2) )
end
```

Unsurprisingly, using libtomcrypt was substantially faster.
```
-----------------------------------------
Mute Sims X2/Lament Configuration
CRYPTMAN hash: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     Lua hash: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 hashes match: true
CRYPTMAN time: 0.000014
     Lua time: 0.000441
-----------------------------------------
Pendulum/Another Planet
CRYPTMAN hash: eb38b776982f998eaef3dce1c457217c864c7c9694b5b863069126cfe714ee26
     Lua hash: eb38b776982f998eaef3dce1c457217c864c7c9694b5b863069126cfe714ee26
 hashes match: true
CRYPTMAN time: 0.000133
     Lua time: 0.101661
-----------------------------------------
Cranked Pastry/Last Trip
CRYPTMAN hash: 13b104ce4d7feefa280cfdb84d8ed6be3bd3e40ad0179c6ad35fa16c1cec6eae
     Lua hash: 13b104ce4d7feefa280cfdb84d8ed6be3bd3e40ad0179c6ad35fa16c1cec6eae
 hashes match: true
CRYPTMAN time: 0.000588
     Lua time: 0.510532
-----------------------------------------
Crapyard Scent/24 hours of 100 bpm stream
CRYPTMAN hash: 55ee40e5079ebf6cad9bd0f5c6391ce44f8e2e35ae518a584bebe0fbf1394dad
     Lua hash: 55ee40e5079ebf6cad9bd0f5c6391ce44f8e2e35ae518a584bebe0fbf1394dad
 hashes match: true
CRYPTMAN time: 0.014126
     Lua time: 11.573550
-----------------------------------------
```

