### PR TITLE
add preference to change PacDrive light ordering

### DIFF
--- a/src/arch/Lights/LightsDriver_PacDrive.cpp
+++ b/src/arch/Lights/LightsDriver_PacDrive.cpp
@@ -63,28 +63,9 @@ LightsDriver_PacDrive::~LightsDriver_PacDrive()
 
 void LightsDriver_PacDrive::Set(const LightsState *ls)
 {
-	std::string lightOrder = g_sPacDriveLightOrdering.Get();
+	RString lightOrder = g_sPacDriveLightOrdering.Get();
 	short int outb = 0;
-	if (lightOrder.empty() || lightOrder.compare("minimaid") == 0) {
-		// Set the cabinet light values according to Minimaid order if no preference is set
-
-		if (ls->m_bCabinetLights[LIGHT_MARQUEE_UP_LEFT]) outb |= BIT(0);
-		if (ls->m_bCabinetLights[LIGHT_MARQUEE_UP_RIGHT]) outb |= BIT(1);
-		if (ls->m_bCabinetLights[LIGHT_MARQUEE_LR_LEFT]) outb |= BIT(2);
-		if (ls->m_bCabinetLights[LIGHT_MARQUEE_LR_RIGHT]) outb |= BIT(3);
-		if (ls->m_bCabinetLights[LIGHT_BASS_LEFT] || ls->m_bCabinetLights[LIGHT_BASS_RIGHT]) outb |= BIT(4);
-		if (ls->m_bGameButtonLights[GameController_1][DANCE_BUTTON_LEFT]) outb |= BIT(5);
-		if (ls->m_bGameButtonLights[GameController_1][DANCE_BUTTON_RIGHT]) outb |= BIT(6);
-		if (ls->m_bGameButtonLights[GameController_1][DANCE_BUTTON_UP]) outb |= BIT(7);
-		if (ls->m_bGameButtonLights[GameController_1][DANCE_BUTTON_DOWN]) outb |= BIT(8);
-		if (ls->m_bGameButtonLights[GameController_1][GAME_BUTTON_START]) outb |= BIT(9);
-		if (ls->m_bGameButtonLights[GameController_2][DANCE_BUTTON_LEFT]) outb |= BIT(10);
-		if (ls->m_bGameButtonLights[GameController_2][DANCE_BUTTON_RIGHT]) outb |= BIT(11);
-		if (ls->m_bGameButtonLights[GameController_2][DANCE_BUTTON_UP]) outb |= BIT(12);
-		if (ls->m_bGameButtonLights[GameController_2][DANCE_BUTTON_DOWN]) outb |= BIT(13);
-		if (ls->m_bGameButtonLights[GameController_2][GAME_BUTTON_START]) outb |= BIT(14);
-	}
-	else if (lightOrder.compare("lumenar") == 0 || lightOrder.compare("openitg") == 0) {
+	if (lightOrder.CompareNoCase("lumenar") == 0 || lightOrder.CompareNoCase("openitg") == 0) {
 		//Sets the cabinet light values to follow LumenAR/OpenITG wiring standards
 
 		if (ls->m_bGameButtonLights[GameController_1][DANCE_BUTTON_LEFT]) outb |= BIT(0);

--- a/src/arch/Lights/LightsDriver_PacDrive.cpp
+++ b/src/arch/Lights/LightsDriver_PacDrive.cpp
@@ -5,6 +5,7 @@
 #include "LightsDriver_PacDrive.h"
 #include "windows.h"
 #include "RageUtil.h"
+#include "Preference.h"
 
 REGISTER_LIGHTS_DRIVER_CLASS(PacDrive);
 
@@ -18,6 +19,9 @@ PacShutdown* m_pacdone = nullptr;
 typedef bool (WINAPI PacSetLEDStates)(int, short int);
 PacSetLEDStates* m_pacset = nullptr;
 
+//Adds new preference to allow for different light wiring setups
+static Preference<RString> g_sPacDriveLightOrdering("PacDriveLightOrdering", "");
+
 
 LightsDriver_PacDrive::LightsDriver_PacDrive()
 {
@@ -30,77 +34,118 @@ LightsDriver_PacDrive::LightsDriver_PacDrive()
 	}
 
 	//Get the function pointers
-	m_pacinit = (PacInitialize*) GetProcAddress(PachDLL, "PacInitialize");
-	m_pacset = (PacSetLEDStates*) GetProcAddress(PachDLL, "PacSetLEDStates");
-	m_pacdone = (PacShutdown*) GetProcAddress(PachDLL, "PacShutdown");
+	m_pacinit = (PacInitialize*)GetProcAddress(PachDLL, "PacInitialize");
+	m_pacset = (PacSetLEDStates*)GetProcAddress(PachDLL, "PacSetLEDStates");
+	m_pacdone = (PacShutdown*)GetProcAddress(PachDLL, "PacShutdown");
 
 	int NumPacDrives = m_pacinit(); //initialize the pac drive
 
-	if( NumPacDrives == 0 )
+	if (NumPacDrives == 0)
 	{
-		PacDriveConnected = false; // set not connected 
+		PacDriveConnected = false; // set not connected
 		MessageBox(nullptr, "Could not find connected PacDrive.", "ERROR", MB_OK);
 		return;
 	}
-	else 
+	else
 	{
-		PacDriveConnected = true; // set connected 
+		PacDriveConnected = true; // set connected
 		m_pacset(0, 0x0);  // clear all lights for device i
 	}
 }
 
 LightsDriver_PacDrive::~LightsDriver_PacDrive()
 {
-	if( PacDriveConnected )
+	if (PacDriveConnected)
 		m_pacset(0, 0x0);  // clear all lights for device i
 	m_pacdone();
-	FreeLibrary( PachDLL );
+	FreeLibrary(PachDLL);
 }
 
-void LightsDriver_PacDrive::Set( const LightsState *ls )
+void LightsDriver_PacDrive::Set(const LightsState *ls)
 {
-	// Set the cabinet light values
-	short int outb=0;
+	std::string lightOrder = g_sPacDriveLightOrdering.Get();
+	short int outb = 0;
+	if (lightOrder.empty() || lightOrder.compare("minimaid") == 0) {
+		// Set the cabinet light values according to Minimaid order if no preference is set
 
-	if (ls->m_bCabinetLights[LIGHT_MARQUEE_UP_LEFT]) outb|=BIT(0);
-	if (ls->m_bCabinetLights[LIGHT_MARQUEE_UP_RIGHT]) outb|=BIT(1);
-	if (ls->m_bCabinetLights[LIGHT_MARQUEE_LR_LEFT]) outb|=BIT(2);
-	if (ls->m_bCabinetLights[LIGHT_MARQUEE_LR_RIGHT]) outb|=BIT(3);
-	if (ls->m_bCabinetLights[LIGHT_BASS_LEFT] || ls->m_bCabinetLights[LIGHT_BASS_RIGHT]) outb|=BIT(4);
-	if (ls->m_bGameButtonLights[GameController_1][DANCE_BUTTON_LEFT]) outb|=BIT(5);
-	if (ls->m_bGameButtonLights[GameController_1][DANCE_BUTTON_RIGHT]) outb|=BIT(6);
-	if (ls->m_bGameButtonLights[GameController_1][DANCE_BUTTON_UP]) outb|=BIT(7);
-	if (ls->m_bGameButtonLights[GameController_1][DANCE_BUTTON_DOWN]) outb|=BIT(8);
-	if (ls->m_bGameButtonLights[GameController_1][GAME_BUTTON_START]) outb|=BIT(9);
-	if (ls->m_bGameButtonLights[GameController_2][DANCE_BUTTON_LEFT]) outb|=BIT(10);
-	if (ls->m_bGameButtonLights[GameController_2][DANCE_BUTTON_RIGHT]) outb|=BIT(11);
-	if (ls->m_bGameButtonLights[GameController_2][DANCE_BUTTON_UP]) outb|=BIT(12);
-	if (ls->m_bGameButtonLights[GameController_2][DANCE_BUTTON_DOWN]) outb|=BIT(13);
-	if (ls->m_bGameButtonLights[GameController_2][GAME_BUTTON_START]) outb|=BIT(14);
-	m_pacset(0,outb);
+		if (ls->m_bCabinetLights[LIGHT_MARQUEE_UP_LEFT]) outb |= BIT(0);
+		if (ls->m_bCabinetLights[LIGHT_MARQUEE_UP_RIGHT]) outb |= BIT(1);
+		if (ls->m_bCabinetLights[LIGHT_MARQUEE_LR_LEFT]) outb |= BIT(2);
+		if (ls->m_bCabinetLights[LIGHT_MARQUEE_LR_RIGHT]) outb |= BIT(3);
+		if (ls->m_bCabinetLights[LIGHT_BASS_LEFT] || ls->m_bCabinetLights[LIGHT_BASS_RIGHT]) outb |= BIT(4);
+		if (ls->m_bGameButtonLights[GameController_1][DANCE_BUTTON_LEFT]) outb |= BIT(5);
+		if (ls->m_bGameButtonLights[GameController_1][DANCE_BUTTON_RIGHT]) outb |= BIT(6);
+		if (ls->m_bGameButtonLights[GameController_1][DANCE_BUTTON_UP]) outb |= BIT(7);
+		if (ls->m_bGameButtonLights[GameController_1][DANCE_BUTTON_DOWN]) outb |= BIT(8);
+		if (ls->m_bGameButtonLights[GameController_1][GAME_BUTTON_START]) outb |= BIT(9);
+		if (ls->m_bGameButtonLights[GameController_2][DANCE_BUTTON_LEFT]) outb |= BIT(10);
+		if (ls->m_bGameButtonLights[GameController_2][DANCE_BUTTON_RIGHT]) outb |= BIT(11);
+		if (ls->m_bGameButtonLights[GameController_2][DANCE_BUTTON_UP]) outb |= BIT(12);
+		if (ls->m_bGameButtonLights[GameController_2][DANCE_BUTTON_DOWN]) outb |= BIT(13);
+		if (ls->m_bGameButtonLights[GameController_2][GAME_BUTTON_START]) outb |= BIT(14);
+	}
+	else if (lightOrder.compare("lumenar") == 0 || lightOrder.compare("openitg") == 0) {
+		//Sets the cabinet light values to follow LumenAR/OpenITG wiring standards
+
+		if (ls->m_bGameButtonLights[GameController_1][DANCE_BUTTON_LEFT]) outb |= BIT(0);
+		if (ls->m_bGameButtonLights[GameController_1][DANCE_BUTTON_RIGHT]) outb |= BIT(1);
+		if (ls->m_bGameButtonLights[GameController_1][DANCE_BUTTON_UP]) outb |= BIT(2);
+		if (ls->m_bGameButtonLights[GameController_1][DANCE_BUTTON_DOWN]) outb |= BIT(3);
+		if (ls->m_bGameButtonLights[GameController_2][DANCE_BUTTON_LEFT]) outb |= BIT(4);
+		if (ls->m_bGameButtonLights[GameController_2][DANCE_BUTTON_RIGHT]) outb |= BIT(5);
+		if (ls->m_bGameButtonLights[GameController_2][DANCE_BUTTON_UP]) outb |= BIT(6);
+		if (ls->m_bGameButtonLights[GameController_2][DANCE_BUTTON_DOWN]) outb |= BIT(7);
+		if (ls->m_bCabinetLights[LIGHT_MARQUEE_UP_LEFT]) outb |= BIT(8);
+		if (ls->m_bCabinetLights[LIGHT_MARQUEE_UP_RIGHT]) outb |= BIT(9);
+		if (ls->m_bCabinetLights[LIGHT_MARQUEE_LR_LEFT]) outb |= BIT(10);
+		if (ls->m_bCabinetLights[LIGHT_MARQUEE_LR_RIGHT]) outb |= BIT(11);
+		if (ls->m_bGameButtonLights[GameController_1][GAME_BUTTON_START]) outb |= BIT(12);
+		if (ls->m_bGameButtonLights[GameController_2][GAME_BUTTON_START]) outb |= BIT(13);
+		if (ls->m_bCabinetLights[LIGHT_BASS_LEFT] || ls->m_bCabinetLights[LIGHT_BASS_RIGHT]) outb |= BIT(14);
+	}
+	else {
+		//If all else fails, falls back to Minimaid order
+
+		if (ls->m_bCabinetLights[LIGHT_MARQUEE_UP_LEFT]) outb |= BIT(0);
+		if (ls->m_bCabinetLights[LIGHT_MARQUEE_UP_RIGHT]) outb |= BIT(1);
+		if (ls->m_bCabinetLights[LIGHT_MARQUEE_LR_LEFT]) outb |= BIT(2);
+		if (ls->m_bCabinetLights[LIGHT_MARQUEE_LR_RIGHT]) outb |= BIT(3);
+		if (ls->m_bCabinetLights[LIGHT_BASS_LEFT] || ls->m_bCabinetLights[LIGHT_BASS_RIGHT]) outb |= BIT(4);
+		if (ls->m_bGameButtonLights[GameController_1][DANCE_BUTTON_LEFT]) outb |= BIT(5);
+		if (ls->m_bGameButtonLights[GameController_1][DANCE_BUTTON_RIGHT]) outb |= BIT(6);
+		if (ls->m_bGameButtonLights[GameController_1][DANCE_BUTTON_UP]) outb |= BIT(7);
+		if (ls->m_bGameButtonLights[GameController_1][DANCE_BUTTON_DOWN]) outb |= BIT(8);
+		if (ls->m_bGameButtonLights[GameController_1][GAME_BUTTON_START]) outb |= BIT(9);
+		if (ls->m_bGameButtonLights[GameController_2][DANCE_BUTTON_LEFT]) outb |= BIT(10);
+		if (ls->m_bGameButtonLights[GameController_2][DANCE_BUTTON_RIGHT]) outb |= BIT(11);
+		if (ls->m_bGameButtonLights[GameController_2][DANCE_BUTTON_UP]) outb |= BIT(12);
+		if (ls->m_bGameButtonLights[GameController_2][DANCE_BUTTON_DOWN]) outb |= BIT(13);
+		if (ls->m_bGameButtonLights[GameController_2][GAME_BUTTON_START]) outb |= BIT(14);
+	}
+	m_pacset(0, outb);
 }
 
 /* Modified 2015 Dave Barribeau for StepMania 5.09
- * (c) 2003-2004 Chris Danford
- * All rights reserved.
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the
- * "Software"), to deal in the Software without restriction, including
- * without limitation the rights to use, copy, modify, merge, publish,
- * distribute, and/or sell copies of the Software, and to permit persons to
- * whom the Software is furnished to do so, provided that the above
- * copyright notice(s) and this permission notice appear in all copies of
- * the Software and that both the above copyright notice(s) and this
- * permission notice appear in supporting documentation.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF
- * THIRD PARTY RIGHTS. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS
- * INCLUDED IN THIS NOTICE BE LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT
- * OR CONSEQUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
- * OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
- * OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
- * PERFORMANCE OF THIS SOFTWARE.
- */
+* (c) 2003-2004 Chris Danford
+* All rights reserved.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a
+* copy of this software and associated documentation files (the
+* "Software"), to deal in the Software without restriction, including
+* without limitation the rights to use, copy, modify, merge, publish,
+* distribute, and/or sell copies of the Software, and to permit persons to
+* whom the Software is furnished to do so, provided that the above
+* copyright notice(s) and this permission notice appear in all copies of
+* the Software and that both the above copyright notice(s) and this
+* permission notice appear in supporting documentation.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF
+* THIRD PARTY RIGHTS. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS
+* INCLUDED IN THIS NOTICE BE LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT
+* OR CONSEQUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+* OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+* OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+* PERFORMANCE OF THIS SOFTWARE.
+*/

--- a/src/arch/Lights/LightsDriver_PacDrive.cpp
+++ b/src/arch/Lights/LightsDriver_PacDrive.cpp
@@ -39,7 +39,10 @@ LightsDriver_PacDrive::LightsDriver_PacDrive()
 	m_pacset = (PacSetLEDStates*)GetProcAddress(PachDLL, "PacSetLEDStates");
 	m_pacdone = (PacShutdown*)GetProcAddress(PachDLL, "PacShutdown");
 
-	int NumPacDrives = m_pacinit(); //initialize the pac drive
+	int NumPacDrives = 0;
+
+	if (m_pacinit)
+		NumPacDrives = m_pacinit(); //initialize the pac drive
 
 	if (NumPacDrives == 0)
 	{
@@ -60,9 +63,12 @@ LightsDriver_PacDrive::LightsDriver_PacDrive()
 
 LightsDriver_PacDrive::~LightsDriver_PacDrive()
 {
-	if (PacDriveConnected)
+	if (PacDriveConnected && m_pacset)
 		m_pacset(0, 0x0);  // clear all lights for device i
-	m_pacdone();
+
+	if (m_pacdone)
+		m_pacdone();
+
 	FreeLibrary(PachDLL);
 }
 
@@ -110,7 +116,10 @@ void LightsDriver_PacDrive::Set(const LightsState *ls)
 		if (ls->m_bGameButtonLights[GameController_2][GAME_BUTTON_START]) outb |= BIT(14);
 		break;
 	}
-	m_pacset(0, outb);
+
+	//ensure m_pacset function call was loaded.
+	if (m_pacset)
+		m_pacset(0, outb);
 }
 
 /* Modified 2015 Dave Barribeau for StepMania 5.09

--- a/src/arch/Lights/LightsDriver_PacDrive.cpp
+++ b/src/arch/Lights/LightsDriver_PacDrive.cpp
@@ -18,9 +18,10 @@ typedef void (WINAPI PacShutdown)(void);
 PacShutdown* m_pacdone = nullptr;
 typedef bool (WINAPI PacSetLEDStates)(int, short int);
 PacSetLEDStates* m_pacset = nullptr;
+int iLightingOrder = 0;
 
 //Adds new preference to allow for different light wiring setups
-static Preference<RString> g_sPacDriveLightOrdering("PacDriveLightOrdering", "");
+static Preference<RString> g_sPacDriveLightOrdering("PacDriveLightOrdering", "minimaid");
 
 
 LightsDriver_PacDrive::LightsDriver_PacDrive()
@@ -50,6 +51,10 @@ LightsDriver_PacDrive::LightsDriver_PacDrive()
 	{
 		PacDriveConnected = true; // set connected
 		m_pacset(0, 0x0);  // clear all lights for device i
+		RString lightOrder = g_sPacDriveLightOrdering.Get();
+		if (lightOrder.CompareNoCase("lumenar") == 0 || lightOrder.CompareNoCase("openitg") == 0) {
+			iLightingOrder = 1;
+		}
 	}
 }
 
@@ -63,9 +68,9 @@ LightsDriver_PacDrive::~LightsDriver_PacDrive()
 
 void LightsDriver_PacDrive::Set(const LightsState *ls)
 {
-	RString lightOrder = g_sPacDriveLightOrdering.Get();
 	short int outb = 0;
-	if (lightOrder.CompareNoCase("lumenar") == 0 || lightOrder.CompareNoCase("openitg") == 0) {
+	switch (iLightingOrder) {
+	case 1:
 		//Sets the cabinet light values to follow LumenAR/OpenITG wiring standards
 
 		if (ls->m_bGameButtonLights[GameController_1][DANCE_BUTTON_LEFT]) outb |= BIT(0);
@@ -83,8 +88,9 @@ void LightsDriver_PacDrive::Set(const LightsState *ls)
 		if (ls->m_bGameButtonLights[GameController_1][GAME_BUTTON_START]) outb |= BIT(12);
 		if (ls->m_bGameButtonLights[GameController_2][GAME_BUTTON_START]) outb |= BIT(13);
 		if (ls->m_bCabinetLights[LIGHT_BASS_LEFT] || ls->m_bCabinetLights[LIGHT_BASS_RIGHT]) outb |= BIT(14);
-	}
-	else {
+		break;
+	case 0:
+	default:
 		//If all else fails, falls back to Minimaid order
 
 		if (ls->m_bCabinetLights[LIGHT_MARQUEE_UP_LEFT]) outb |= BIT(0);
@@ -102,6 +108,7 @@ void LightsDriver_PacDrive::Set(const LightsState *ls)
 		if (ls->m_bGameButtonLights[GameController_2][DANCE_BUTTON_UP]) outb |= BIT(12);
 		if (ls->m_bGameButtonLights[GameController_2][DANCE_BUTTON_DOWN]) outb |= BIT(13);
 		if (ls->m_bGameButtonLights[GameController_2][GAME_BUTTON_START]) outb |= BIT(14);
+		break;
 	}
 	m_pacset(0, outb);
 }


### PR DESCRIPTION
# About

This redoes pull request #1437 for the current `5_1-new` branch rather than `master`.  The work was done by @kevinturner.  

I'm resubmitting the work to move things along (a merge was requested in #1437 by @JeffreyATW and @MrTwinkles47), but I need to be clear that I don't know enough about the changes to be comfortable merging this myself.

# What

My understanding is that this is intended to benefit players with arcade-style hardware using a [LumenAR](http://arcadency.com/lumenar) to control lights.  It adds a new preference `PacDriveLightOrdering` with two possible values:
 * `lumenar`
 * `openitg`

The behavior of these values is somewhat documented here: https://github.com/stepmania/stepmania/pull/1437#issuecomment-691287135, though not in a way that I personally understand, code-wise.

# Considerations

@kevinturner mentions that the feature request in #1833 could be an alternate solution to the underlying issue of mapping lights.  I don't know enough about the current arcade hardware landscape to meaningfully comment on whether that is a tractable approach.

In general, I'm reluctant to merge new features without considering implications for players and developers going forward.

# Requests

@DinsFire64 – I think you have some lights-specific arcade hardware knowledge.  If so, what are your thoughts on these changes?  Is this a reasonable solution to the problem?

@geefr – How does this implementation look to you, code-wise?

@kevinturner or @JeffreyATW or @MrTwinkles47 – If this pull request is to be merged in the future, can I get one of you to promise to update the Wiki's [Preferences.ini page](https://github.com/stepmania/stepmania/wiki/Preferences.ini)?  I'd like to see a new section explaining who should use the preference and what they should set it to for their needs.