### PR TITLE
feature: Add a preference, RateModsAffectFGChanges

### DIFF
--- a/src/Background.cpp
+++ b/src/Background.cpp
@@ -729,7 +729,7 @@ void BackgroundImpl::Layer::UpdateCurBGChange( const Song *pSong, float fLastMus
 	beat_info.elapsed_time= fCurrentTime;
 	pSong->m_SongTiming.GetBeatAndBPSFromElapsedTime(beat_info);
 
-	// Calls to Update() should *not* be scaled by music rate; fCurrentTime is. Undo it.
+	// Calls to Update() should *not* be scaled by music rate unless RateModsAffectFGChanges is enabled; fCurrentTime is. Undo it.
 	const float fRate = PREFSMAN->m_bRateModsAffectTweens ? 1.0f : GAMESTATE->m_SongOptions.GetCurrent().m_fMusicRate;
 
 	// Find the BGSegment we're in

--- a/src/Background.cpp
+++ b/src/Background.cpp
@@ -578,7 +578,7 @@ void BackgroundImpl::LoadFromSong( const Song* pSong )
 			{
 				BackgroundChange change = bgc;
 				BackgroundDef &bd = change.m_def;
-				
+
 				bool bIsAlreadyLoaded = layer.m_BGAnimations.find(bd) != layer.m_BGAnimations.end();
 
 				if( bd.m_sFile1 != RANDOM_BACKGROUND_FILE  &&  !bIsAlreadyLoaded )
@@ -600,7 +600,7 @@ void BackgroundImpl::LoadFromSong( const Song* pSong )
 						}
 					}
 				}
-			
+
 				if( !bd.IsEmpty() )
 					layer.m_aBGChanges.push_back( change );
 			}
@@ -730,7 +730,7 @@ void BackgroundImpl::Layer::UpdateCurBGChange( const Song *pSong, float fLastMus
 	pSong->m_SongTiming.GetBeatAndBPSFromElapsedTime(beat_info);
 
 	// Calls to Update() should *not* be scaled by music rate; fCurrentTime is. Undo it.
-	const float fRate = GAMESTATE->m_SongOptions.GetCurrent().m_fMusicRate;
+	const float fRate = PREFSMAN->m_bRateModsAffectTweens ? 1.0f : GAMESTATE->m_SongOptions.GetCurrent().m_fMusicRate;
 
 	// Find the BGSegment we're in
 	const int i = FindBGSegmentForBeat(beat_info.beat);
@@ -773,7 +773,7 @@ void BackgroundImpl::Layer::UpdateCurBGChange( const Song *pSong, float fLastMus
 			if( m_pFadingBGA )
 			{
 				m_pFadingBGA->PlayCommand( "LoseFocus" );
-				
+
 				if( !change.m_sTransition.empty() )
 				{
 					map<RString,BackgroundTransition>::const_iterator lIter = mapNameToTransition.find( change.m_sTransition );
@@ -993,7 +993,7 @@ void Background::GetLoadedBackgroundChanges( vector<BackgroundChange> *pBackgrou
 /*
  * (c) 2001-2004 Chris Danford, Ben Nordstrom
  * All rights reserved.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the
  * "Software"), to deal in the Software without restriction, including
@@ -1003,7 +1003,7 @@ void Background::GetLoadedBackgroundChanges( vector<BackgroundChange> *pBackgrou
  * copyright notice(s) and this permission notice appear in all copies of
  * the Software and that both the above copyright notice(s) and this
  * permission notice appear in supporting documentation.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
  * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
  * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF

--- a/src/Foreground.cpp
+++ b/src/Foreground.cpp
@@ -73,7 +73,7 @@ void Foreground::LoadFromSong( const Song *pSong )
 void Foreground::Update( float fDeltaTime )
 {
 	// Calls to Update() should *not* be scaled by music rate. Undo it.
-	const float fRate = GAMESTATE->m_SongOptions.GetCurrent().m_fMusicRate;
+	const float fRate = PREFSMAN->m_bRateModsAffectTweens ? 1.0f : GAMESTATE->m_SongOptions.GetCurrent().m_fMusicRate;
 
 	for( unsigned i=0; i < m_BGAnimations.size(); ++i )
 	{
@@ -138,7 +138,7 @@ void Foreground::HandleMessage( const Message &msg )
 /*
  * (c) 2004 Glenn Maynard
  * All rights reserved.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the
  * "Software"), to deal in the Software without restriction, including
@@ -148,7 +148,7 @@ void Foreground::HandleMessage( const Message &msg )
  * copyright notice(s) and this permission notice appear in all copies of
  * the Software and that both the above copyright notice(s) and this
  * permission notice appear in supporting documentation.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
  * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
  * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF

--- a/src/Foreground.cpp
+++ b/src/Foreground.cpp
@@ -72,7 +72,7 @@ void Foreground::LoadFromSong( const Song *pSong )
 
 void Foreground::Update( float fDeltaTime )
 {
-	// Calls to Update() should *not* be scaled by music rate. Undo it.
+	// Calls to Update() should *not* be scaled by music rate unless RateModsAffectFGChanges is enabled. Undo it.
 	const float fRate = PREFSMAN->m_bRateModsAffectTweens ? 1.0f : GAMESTATE->m_SongOptions.GetCurrent().m_fMusicRate;
 
 	for( unsigned i=0; i < m_BGAnimations.size(); ++i )

--- a/src/PlayerOptions.cpp
+++ b/src/PlayerOptions.cpp
@@ -106,13 +106,15 @@ void PlayerOptions::Init()
 	ZERO( m_fTiny );		ONE( m_SpeedfTiny );
 	ZERO( m_fBumpy );		ONE( m_SpeedfBumpy );
 	ZERO( m_fReverse );		ONE( m_SpeedfReverse );
-	
+
 }
 
 void PlayerOptions::Approach( const PlayerOptions& other, float fDeltaSeconds )
 {
+	const float fRateMult = PREFSMAN->m_bRateModsAffectTweens ? GAMESTATE->m_SongOptions.GetCurrent().m_fMusicRate : 1.0f;
+
 #define APPROACH( opt ) \
-	fapproach( m_ ## opt, other.m_ ## opt, fDeltaSeconds * other.m_Speed ## opt );
+	fapproach( m_ ## opt, other.m_ ## opt, fRateMult * fDeltaSeconds * other.m_Speed ## opt );
 #define DO_COPY( x ) \
 	x = other.x;
 
@@ -263,7 +265,7 @@ void PlayerOptions::GetMods( vector<RString> &AddTo, bool bForceNoteSkin ) const
 		RString s = ssprintf( "C%.0f", m_fScrollBPM );
 		AddTo.push_back( s );
 	}
-	
+
 	switch(m_ModTimerType)
 	{
 		case ModTimerType_Game:
@@ -418,11 +420,11 @@ void PlayerOptions::GetMods( vector<RString> &AddTo, bool bForceNoteSkin ) const
 	AddPart( AddTo, m_bDizzyHolds,				"DizzyHolds");
 	AddPart( AddTo, m_bZBuffer,				"ZBuffer");
 	AddPart( AddTo, m_bCosecant,				"Cosecant");
-	
+
 	for( int i=0; i<16; i++)
 	{
 		RString s = ssprintf( "MoveX%d", i+1 );
-		
+
 		AddPart( AddTo, m_fMovesX[i],				s );
 		s = ssprintf( "MoveY%d", i+1 );
 		AddPart( AddTo, m_fMovesY[i],				s );
@@ -464,7 +466,7 @@ void PlayerOptions::GetMods( vector<RString> &AddTo, bool bForceNoteSkin ) const
 	AddPart( AddTo, m_fModTimerOffset,	"ModTimerOffset" );
 	AddPart( AddTo, m_fDrawSize,		"DrawSize" );
 	AddPart( AddTo, m_fDrawSizeBack,	"DrawSizeBack" );
-	
+
 	AddPart( AddTo, m_fDark,	"Dark" );
 
 	AddPart( AddTo, m_fBlind,	"Blind" );
@@ -1068,7 +1070,7 @@ bool PlayerOptions::FromOneModString( const RString &sOneMod, RString &sErrorOut
 		m_sNoteSkin = CommonMetrics::DEFAULT_NOTESKIN_NAME;
 	}
 	else if( sBit == "randomspeed" ) 			SET_FLOAT( fRandomSpeed )
-	else if( sBit == "failarcade" || 
+	else if( sBit == "failarcade" ||
 		 sBit == "failimmediate" )			m_FailType = FailType_Immediate;
 	else if( sBit == "failendofsong" ||
 		 sBit == "failimmediatecontinue" )		m_FailType = FailType_ImmediateContinue;
@@ -1082,7 +1084,7 @@ bool PlayerOptions::FromOneModString( const RString &sOneMod, RString &sErrorOut
 	}
 	else if( sBit == "muteonerror" )			m_bMuteOnError = on;
 	else if( sBit == "random" )				ChooseRandomModifiers();
-	
+
 	else if( sBit.find("move") != sBit.npos)
 	{
 	    if (sBit.find("x") != sBit.npos)
@@ -1552,7 +1554,7 @@ bool PlayerOptions::IsEasierForSongAndSteps( Song* pSong, Steps* pSteps, PlayerN
 	if( m_bTransforms[TRANSFORM_NOSTRETCH] )
 		return true;
 
-	// Inserted holds can be really easy on some songs, and scores will be 
+	// Inserted holds can be really easy on some songs, and scores will be
 	// highly hold-weighted, and very little tap score weighted.
 	if( m_bTransforms[TRANSFORM_LITTLE] )	return true;
 	if( m_bTransforms[TRANSFORM_PLANTED] )	return true;
@@ -1561,13 +1563,13 @@ bool PlayerOptions::IsEasierForSongAndSteps( Song* pSong, Steps* pSteps, PlayerN
 
 	// This makes songs with sparse notes easier.
 	if( m_bTransforms[TRANSFORM_ECHO] )	return true;
-	
+
 	// Removing attacks is easier in general.
 	if ((m_fNoAttack && pSteps->HasAttacks()) || m_fRandAttack)
 		return true;
-	
+
 	if( m_fCover )	return true;
-	
+
 	// M-mods make songs with indefinite BPMs easier because
 	// they ensure that the song has a scrollable speed.
 	if( m_fMaxScrollBPM != 0 )
@@ -1726,7 +1728,7 @@ void PlayerOptions::ResetPrefs( ResetPrefsType type )
 #include "LuaBinding.h"
 #include "OptionsBinding.h"
 
-/** @brief Allow Lua to have access to PlayerOptions. */ 
+/** @brief Allow Lua to have access to PlayerOptions. */
 class LunaPlayerOptions: public Luna<PlayerOptions>
 {
 public:
@@ -1914,7 +1916,7 @@ public:
 	FLOAT_INTERFACE(Tilt, PerspectiveTilt, true);
 	FLOAT_INTERFACE(Passmark, Passmark, true); // Passmark is not sanity checked to the [0, 1] range because LifeMeterBar::IsFailing is the only thing that uses it, and it's used in a <= test.  Any theme passing a value outside the [0, 1] range probably expects the result they get. -Kyz
 	FLOAT_INTERFACE(RandomSpeed, RandomSpeed, true);
-	
+
 	MULTICOL_FLOAT_INTERFACE(MoveX, MovesX, true);
 	MULTICOL_FLOAT_INTERFACE(MoveY, MovesY, true);
 	MULTICOL_FLOAT_INTERFACE(MoveZ, MovesZ, true);
@@ -1926,7 +1928,7 @@ public:
 	MULTICOL_FLOAT_INTERFACE(Tiny, Tiny, true);
 	MULTICOL_FLOAT_INTERFACE(Bumpy, Bumpy, true);
 	MULTICOL_FLOAT_INTERFACE(Reverse, Reverse, true);
-	
+
 	BOOL_INTERFACE(StealthType, StealthType);
 	BOOL_INTERFACE(StealthPastReceptors, StealthPastReceptors);
 	BOOL_INTERFACE(DizzyHolds, DizzyHolds);
@@ -2209,7 +2211,7 @@ public:
 		OPTIONAL_RETURN_SELF(original_top);
 		return 2;
 	}
-	
+
 	static int Distant(T* p, lua_State* L)
 	{
 		int original_top= lua_gettop(L);
@@ -2472,7 +2474,7 @@ public:
 		ADD_METHOD(NoQuads);
 		ADD_METHOD(NoStretch);
 		ADD_METHOD(MuteOnError);
-		
+
 		ADD_MULTICOL_METHOD(MoveX);
 		ADD_MULTICOL_METHOD(MoveY);
 		ADD_MULTICOL_METHOD(MoveZ);
@@ -2484,7 +2486,7 @@ public:
 		ADD_MULTICOL_METHOD(Tiny);
 		ADD_MULTICOL_METHOD(Bumpy);
 		ADD_MULTICOL_METHOD(Reverse);
-		
+
 
 		ADD_METHOD(NoteSkin);
 		ADD_METHOD(FailSetting);
@@ -2515,7 +2517,7 @@ LUA_REGISTER_CLASS( PlayerOptions )
 /*
  * (c) 2001-2004 Chris Danford, Glenn Maynard
  * All rights reserved.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the
  * "Software"), to deal in the Software without restriction, including
@@ -2525,7 +2527,7 @@ LUA_REGISTER_CLASS( PlayerOptions )
  * copyright notice(s) and this permission notice appear in all copies of
  * the Software and that both the above copyright notice(s) and this
  * permission notice appear in supporting documentation.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
  * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
  * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF

--- a/src/PrefsManager.cpp
+++ b/src/PrefsManager.cpp
@@ -190,6 +190,7 @@ PrefsManager::PrefsManager() :
 
 	m_fLifeDifficultyScale		( "LifeDifficultyScale",	1.0f ),
 
+	m_bRateModsAffectTweens		( "RateModsAffectFGChanges",	false ),
 
 	m_iRegenComboAfterMiss		( "RegenComboAfterMiss",	5 ),
 	m_iMaxRegenComboAfterMiss	( "MaxRegenComboAfterMiss",	5 ), // this was 10 by default in SM3.95 -dguzek
@@ -276,7 +277,7 @@ PrefsManager::PrefsManager() :
 	m_iRageSoundSampleCountClamp	("RageSoundSampleCountClamp", 0), //some sound drivers mask the sample location number, the most popular number for this is 2^27, this causes lockup after ~50 minutes at 44.1khz sample rate
 	m_iSoundPreferredSampleRate	( "SoundPreferredSampleRate",		0 ),
 	m_sLightsStepsDifficulty	( "LightsStepsDifficulty",		"hard,medium" ),
-	m_bAllowUnacceleratedRenderer	( "AllowUnacceleratedRenderer",		false ), 
+	m_bAllowUnacceleratedRenderer	( "AllowUnacceleratedRenderer",		false ),
 	m_bThreadedInput		( "ThreadedInput",			true ),
 	m_bThreadedMovieDecode		( "ThreadedMovieDecode",		true ),
 	m_sTestInitialScreen		( "TestInitialScreen",			"" ),
@@ -546,7 +547,7 @@ RString PrefsManager::GetPreferencesSection() const
 // lua start
 #include "LuaBinding.h"
 
-/** @brief Allow Lua to have access to the PrefsManager. */ 
+/** @brief Allow Lua to have access to the PrefsManager. */
 class LunaPrefsManager: public Luna<PrefsManager>
 {
 public:
@@ -607,9 +608,9 @@ public:
 		lua_pushboolean( L, true );
 		return 1;
 	}
-	
+
 	static int SavePreferences( T* p, lua_State *L ) { p->SavePrefsToDisk(); COMMON_RETURN_SELF; }
-	
+
 	LunaPrefsManager()
 	{
 		ADD_METHOD( GetPreference );
@@ -626,7 +627,7 @@ LUA_REGISTER_CLASS( PrefsManager )
 /*
  * (c) 2001-2004 Chris Danford, Chris Gomez
  * All rights reserved.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the
  * "Software"), to deal in the Software without restriction, including
@@ -636,7 +637,7 @@ LUA_REGISTER_CLASS( PrefsManager )
  * copyright notice(s) and this permission notice appear in all copies of
  * the Software and that both the above copyright notice(s) and this
  * permission notice appear in supporting documentation.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
  * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
  * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF

--- a/src/PrefsManager.h
+++ b/src/PrefsManager.h
@@ -15,36 +15,36 @@ void ValidateSongsPerPlay( int &val );
 const int MAX_SONGS_PER_PLAY = 7;
 
 enum MusicWheelUsesSections
-{ 
-	MusicWheelUsesSections_NEVER, 
-	MusicWheelUsesSections_ALWAYS, 
-	MusicWheelUsesSections_ABC_ONLY, 
-	NUM_MusicWheelUsesSections, 
+{
+	MusicWheelUsesSections_NEVER,
+	MusicWheelUsesSections_ALWAYS,
+	MusicWheelUsesSections_ABC_ONLY,
+	NUM_MusicWheelUsesSections,
 	MusicWheelUsesSections_Invalid
 };
 /** @brief The options for allowing the W1 timing. */
 enum AllowW1
-{ 
+{
 	ALLOW_W1_NEVER, /**< The W1 timing is not used. */
 	ALLOW_W1_COURSES_ONLY, /**< The W1 timing is used for courses only. */
 	ALLOW_W1_EVERYWHERE, /**< The W1 timing is used for all modes. */
-	NUM_AllowW1, 
+	NUM_AllowW1,
 	AllowW1_Invalid
 };
 enum Maybe
-{ 
-	Maybe_ASK, 
-	Maybe_NO, 
-	Maybe_YES, 
-	NUM_Maybe, 
-	Maybe_Invalid 
+{
+	Maybe_ASK,
+	Maybe_NO,
+	Maybe_YES,
+	NUM_Maybe,
+	Maybe_Invalid
 };
-enum GetRankingName 
-{ 
-	RANKING_OFF, 
-	RANKING_ON, 
-	RANKING_LIST, 
-	NUM_GetRankingName, 
+enum GetRankingName
+{
+	RANKING_OFF,
+	RANKING_ON,
+	RANKING_LIST,
+	NUM_GetRankingName,
 	GetRankingName_Invalid
 };
 enum RandomBackgroundMode
@@ -182,6 +182,12 @@ public:
 
 	Preference<float>	m_fLifeDifficultyScale;
 
+	/**
+	 * Whether ratemod should affect playback speeds of FGChanges or not.
+	 * Originally introduced in NotITG.
+	 */
+	Preference<bool>	m_bRateModsAffectTweens;
+
 	// Whoever added these: Please add a comment saying what they do. -Chris
 	Preference<int>		m_iRegenComboAfterMiss; // combo that must be met after a Miss to regen life
 	Preference<int>		m_iMaxRegenComboAfterMiss; // caps RegenComboAfterMiss if multiple Misses occur in rapid succession
@@ -281,7 +287,7 @@ public:
 	Preference<RString>	m_sVideoRenderers; // StepMania.cpp sets these on first run based on the card
 	Preference<bool>	m_bSmoothLines;
 	Preference<int>	m_iSoundWriteAhead;
-	Preference<RString>	m_iSoundDevice;	
+	Preference<RString>	m_iSoundDevice;
 	Preference<int> m_iRageSoundSampleCountClamp;
 	Preference<int>	m_iSoundPreferredSampleRate;
 	Preference<RString>	m_sLightsStepsDifficulty;
@@ -363,7 +369,7 @@ extern PrefsManager*	PREFSMAN;	// global and accessible from anywhere in our pro
  * @author Chris Danford, Chris Gomez (c) 2001-2004
  * @section LICENSE
  * All rights reserved.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the
  * "Software"), to deal in the Software without restriction, including
@@ -373,7 +379,7 @@ extern PrefsManager*	PREFSMAN;	// global and accessible from anywhere in our pro
  * copyright notice(s) and this permission notice appear in all copies of
  * the Software and that both the above copyright notice(s) and this
  * permission notice appear in supporting documentation.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
  * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
  * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF

--- a/src/ScreenEdit.cpp
+++ b/src/ScreenEdit.cpp
@@ -269,17 +269,17 @@ void ScreenEdit::InitEditMappings()
 	m_EditMappingsDeviceInput.button[EDIT_BUTTON_SCROLL_UP_PAGE][1] = DeviceInput(DEVICE_KEYBOARD, KEY_SEMICOLON);
 	m_EditMappingsDeviceInput.button[EDIT_BUTTON_SCROLL_DOWN_PAGE][0] = DeviceInput(DEVICE_KEYBOARD, KEY_PGDN);
 	m_EditMappingsDeviceInput.button[EDIT_BUTTON_SCROLL_DOWN_PAGE][1] = DeviceInput(DEVICE_KEYBOARD, KEY_SQUOTE);
-	
+
 	m_EditMappingsDeviceInput.hold[EDIT_BUTTON_SCROLL_UP_TS][0] = DeviceInput(DEVICE_KEYBOARD, KEY_LCTRL);
 	m_EditMappingsDeviceInput.hold[EDIT_BUTTON_SCROLL_UP_TS][1] = DeviceInput(DEVICE_KEYBOARD, KEY_RCTRL);
 	m_EditMappingsDeviceInput.button[EDIT_BUTTON_SCROLL_UP_TS][0] = DeviceInput(DEVICE_KEYBOARD, KEY_PGUP);
 	m_EditMappingsDeviceInput.button[EDIT_BUTTON_SCROLL_UP_TS][1] = DeviceInput(DEVICE_KEYBOARD, KEY_SEMICOLON);
-	
+
 	m_EditMappingsDeviceInput.hold[EDIT_BUTTON_SCROLL_DOWN_TS][0] = DeviceInput(DEVICE_KEYBOARD, KEY_LCTRL);
 	m_EditMappingsDeviceInput.hold[EDIT_BUTTON_SCROLL_DOWN_TS][1] = DeviceInput(DEVICE_KEYBOARD, KEY_RCTRL);
 	m_EditMappingsDeviceInput.button[EDIT_BUTTON_SCROLL_DOWN_TS][0] = DeviceInput(DEVICE_KEYBOARD, KEY_PGDN);
 	m_EditMappingsDeviceInput.button[EDIT_BUTTON_SCROLL_DOWN_TS][1] = DeviceInput(DEVICE_KEYBOARD, KEY_SQUOTE);
-	
+
 	m_EditMappingsDeviceInput.button[EDIT_BUTTON_SCROLL_HOME][0] = DeviceInput(DEVICE_KEYBOARD, KEY_HOME);
 	m_EditMappingsDeviceInput.button[EDIT_BUTTON_SCROLL_END][0] = DeviceInput(DEVICE_KEYBOARD, KEY_END);
 	m_EditMappingsDeviceInput.button[EDIT_BUTTON_SCROLL_NEXT][0] = DeviceInput(DEVICE_KEYBOARD, KEY_PERIOD);
@@ -288,11 +288,11 @@ void ScreenEdit::InitEditMappings()
 	m_EditMappingsDeviceInput.button[EDIT_BUTTON_SEGMENT_NEXT][0] = DeviceInput(DEVICE_KEYBOARD, KEY_PERIOD);
 	m_EditMappingsDeviceInput.hold[EDIT_BUTTON_SEGMENT_NEXT][0] = DeviceInput(DEVICE_KEYBOARD, KEY_LCTRL);
 	m_EditMappingsDeviceInput.hold[EDIT_BUTTON_SEGMENT_NEXT][1] = DeviceInput(DEVICE_KEYBOARD, KEY_RCTRL);
-	
+
 	m_EditMappingsDeviceInput.button[EDIT_BUTTON_SEGMENT_PREV][0] = DeviceInput(DEVICE_KEYBOARD, KEY_COMMA);
 	m_EditMappingsDeviceInput.hold[EDIT_BUTTON_SEGMENT_PREV][0] = DeviceInput(DEVICE_KEYBOARD, KEY_LCTRL);
 	m_EditMappingsDeviceInput.hold[EDIT_BUTTON_SEGMENT_PREV][1] = DeviceInput(DEVICE_KEYBOARD, KEY_RCTRL);
-	
+
 	m_EditMappingsDeviceInput.button[EDIT_BUTTON_SCROLL_SELECT][0] = DeviceInput(DEVICE_KEYBOARD, KEY_LSHIFT);
 	m_EditMappingsDeviceInput.button[EDIT_BUTTON_SCROLL_SELECT][1] = DeviceInput(DEVICE_KEYBOARD, KEY_RSHIFT);
 
@@ -323,7 +323,7 @@ void ScreenEdit::InitEditMappings()
 		m_EditMappingsMenuButton.button   [EDIT_BUTTON_OPEN_EDIT_MENU][0]    = GAME_BUTTON_START;
 		m_EditMappingsMenuButton.button   [EDIT_BUTTON_OPEN_EDIT_MENU][1]    = GAME_BUTTON_BACK;
 
-			
+
 		// Escape, Enter = exit play/record
 		m_PlayMappingsDeviceInput.button   [EDIT_BUTTON_RETURN_TO_EDIT][0]    = DeviceInput(DEVICE_KEYBOARD, KEY_ENTER);
 		m_PlayMappingsDeviceInput.button   [EDIT_BUTTON_RETURN_TO_EDIT][1]    = DeviceInput(DEVICE_KEYBOARD, KEY_ESC);
@@ -356,7 +356,7 @@ void ScreenEdit::InitEditMappings()
 	case EditMode_Full:
 		// F4 = Show timing menu
 		m_EditMappingsDeviceInput.button[EDIT_BUTTON_OPEN_TIMING_MENU][0] = DeviceInput(DEVICE_KEYBOARD, KEY_F4);
-		
+
 		/* Don't allow F5/F6 in home mode. It breaks the "delay creation until first save" logic. */
 		m_EditMappingsDeviceInput.button[EDIT_BUTTON_OPEN_PREV_STEPS][0] = DeviceInput(DEVICE_KEYBOARD, KEY_F5);
 		m_EditMappingsDeviceInput.button[EDIT_BUTTON_OPEN_NEXT_STEPS][0] = DeviceInput(DEVICE_KEYBOARD, KEY_F6);
@@ -364,14 +364,14 @@ void ScreenEdit::InitEditMappings()
 		m_EditMappingsDeviceInput.button[EDIT_BUTTON_BPM_UP][0] = DeviceInput(DEVICE_KEYBOARD, KEY_F8);
 		m_EditMappingsDeviceInput.button[EDIT_BUTTON_STOP_DOWN][0] = DeviceInput(DEVICE_KEYBOARD, KEY_F9);
 		m_EditMappingsDeviceInput.button[EDIT_BUTTON_STOP_UP][0]  = DeviceInput(DEVICE_KEYBOARD, KEY_F10);
-	
+
 		m_EditMappingsDeviceInput.button[EDIT_BUTTON_DELAY_DOWN][0] = DeviceInput(DEVICE_KEYBOARD, KEY_F9);
 		m_EditMappingsDeviceInput.hold[EDIT_BUTTON_DELAY_DOWN][0] = DeviceInput(DEVICE_KEYBOARD, KEY_LSHIFT);
 		m_EditMappingsDeviceInput.hold[EDIT_BUTTON_DELAY_DOWN][1] = DeviceInput(DEVICE_KEYBOARD, KEY_RSHIFT);
 		m_EditMappingsDeviceInput.button[EDIT_BUTTON_DELAY_UP][0]  = DeviceInput(DEVICE_KEYBOARD, KEY_F10);
 		m_EditMappingsDeviceInput.hold[EDIT_BUTTON_DELAY_UP][0] = DeviceInput(DEVICE_KEYBOARD, KEY_LSHIFT);
 		m_EditMappingsDeviceInput.hold[EDIT_BUTTON_DELAY_UP][1] = DeviceInput(DEVICE_KEYBOARD, KEY_RSHIFT);
-			
+
 		m_EditMappingsDeviceInput.button[EDIT_BUTTON_OFFSET_DOWN][0] = DeviceInput(DEVICE_KEYBOARD, KEY_F11);
 		m_EditMappingsDeviceInput.button[EDIT_BUTTON_OFFSET_UP][0]  = DeviceInput(DEVICE_KEYBOARD, KEY_F12);
 
@@ -430,11 +430,11 @@ void ScreenEdit::InitEditMappings()
 	m_EditMappingsDeviceInput.button[EDIT_BUTTON_CYCLE_SEGMENT_LEFT][0] = DeviceInput(DEVICE_KEYBOARD, KEY_Cn);
 	m_EditMappingsDeviceInput.hold[EDIT_BUTTON_CYCLE_SEGMENT_LEFT][0] = DeviceInput(DEVICE_KEYBOARD, KEY_LCTRL);
 	m_EditMappingsDeviceInput.hold[EDIT_BUTTON_CYCLE_SEGMENT_LEFT][1] = DeviceInput(DEVICE_KEYBOARD, KEY_RCTRL);
-	
+
 	m_EditMappingsDeviceInput.button[EDIT_BUTTON_CYCLE_SEGMENT_RIGHT][0] = DeviceInput(DEVICE_KEYBOARD, KEY_Cm);
 	m_EditMappingsDeviceInput.hold[EDIT_BUTTON_CYCLE_SEGMENT_RIGHT][0] = DeviceInput(DEVICE_KEYBOARD, KEY_LCTRL);
 	m_EditMappingsDeviceInput.hold[EDIT_BUTTON_CYCLE_SEGMENT_RIGHT][1] = DeviceInput(DEVICE_KEYBOARD, KEY_RCTRL);
-	
+
 	m_EditMappingsDeviceInput.button    [EDIT_BUTTON_SCROLL_SPEED_UP][0] = DeviceInput(DEVICE_KEYBOARD, KEY_UP);
 	m_EditMappingsDeviceInput.hold[EDIT_BUTTON_SCROLL_SPEED_UP][0] = DeviceInput(DEVICE_KEYBOARD, KEY_LCTRL);
 	m_EditMappingsDeviceInput.hold[EDIT_BUTTON_SCROLL_SPEED_UP][1] = DeviceInput(DEVICE_KEYBOARD, KEY_RCTRL);
@@ -489,7 +489,7 @@ void ScreenEdit::InitEditMappings()
 
 	// Switch players, if it makes sense to do so.
 	m_EditMappingsDeviceInput.button[EDIT_BUTTON_SWITCH_PLAYERS][0] = DeviceInput(DEVICE_KEYBOARD, KEY_SLASH);
-	
+
 	// Allow song and step timing to be swapped.
 	m_EditMappingsDeviceInput.button[EDIT_BUTTON_SWITCH_TIMINGS][0] = DeviceInput(DEVICE_KEYBOARD, KEY_Ct);
 
@@ -584,7 +584,7 @@ EditButton ScreenEdit::DeviceToEdit( const DeviceInput &DeviceI ) const
 		}
 	}
 
-	/* No shifted keys matched.  See if any unshifted inputs are bound to this key. */  
+	/* No shifted keys matched.  See if any unshifted inputs are bound to this key. */
 	FOREACH_EditButton(e)
 	{
 		for( int slot = 0; slot < NUM_EDIT_TO_DEVICE_SLOTS; ++slot )
@@ -650,7 +650,7 @@ bool ScreenEdit::EditPressed( EditButton button, const DeviceInput &DeviceI )
 			return true;
 	}
 
-	/* No shifted keys matched. */  
+	/* No shifted keys matched. */
 	return false;
 }
 
@@ -810,7 +810,7 @@ static MenuDef g_MainMenu(
 	MenuRowDef(ScreenEdit::edit_song_info,
 		"Edit song info",
 		true, EditMode_Full, true, true, 0, nullptr ),
-	MenuRowDef(ScreenEdit::edit_steps_information,	
+	MenuRowDef(ScreenEdit::edit_steps_information,
 		"Edit steps information",
 		true, EditMode_Practice, true, true, 0, nullptr ),
 	MenuRowDef(ScreenEdit::edit_timing_data,
@@ -831,27 +831,27 @@ static MenuDef g_AlterMenu(
 	"ScreenMiniMenuAlterMenu",
 	MenuRowDef(ScreenEdit::cut,
 		"Cut",
-		true, 
+		true,
 		EditMode_Practice, true, true, 0, nullptr ),
 	MenuRowDef(ScreenEdit::copy,
 		"Copy",
 		true, EditMode_Practice, true, true, 0, nullptr ),
-	MenuRowDef(ScreenEdit::clear,			"Clear area",				true, 
+	MenuRowDef(ScreenEdit::clear,			"Clear area",				true,
 	      EditMode_Practice, true, true, 0, nullptr ),
-	MenuRowDef(ScreenEdit::quantize,			"Quantize",				true, 
-	      EditMode_Practice, true, true, 0, 
+	MenuRowDef(ScreenEdit::quantize,			"Quantize",				true,
+	      EditMode_Practice, true, true, 0,
 	      "4th","8th","12th","16th","24th","32nd","48th","64th","192nd"),
-	MenuRowDef(ScreenEdit::turn,				"Turn",					true, 
+	MenuRowDef(ScreenEdit::turn,				"Turn",					true,
 	      EditMode_Practice, true, true, 0, "Left","Right","Mirror","Backwards","Shuffle","SuperShuffle" ),
-	MenuRowDef(ScreenEdit::transform,			"Transform",				true, 
+	MenuRowDef(ScreenEdit::transform,			"Transform",				true,
 	      EditMode_Practice, true, true, 0, "NoHolds","NoMines","Little","Wide",
 	      "Big","Quick","Skippy","Mines","Echo","Stomp","Planted","Floored",
 	      "Twister","NoJumps","NoHands","NoQuads","NoStretch" ),
-	MenuRowDef(ScreenEdit::alter,			"Alter",				true, 
+	MenuRowDef(ScreenEdit::alter,			"Alter",				true,
 	      EditMode_Practice, true, true, 0, "Autogen To Fill Width","Backwards","Swap Sides",
 	      "Copy Left To Right","Copy Right To Left","Clear Left","Clear Right",
 		"Collapse To One","Collapse Left","Shift Left","Shift Right", "Swap Up/Down", "Arbitrary Remap Columns" ),
-	MenuRowDef(ScreenEdit::tempo,			"Tempo",				true, 
+	MenuRowDef(ScreenEdit::tempo,			"Tempo",				true,
 	      EditMode_Full, true, true, 0, "Compress 2x","Compress 3->2",
 	      "Compress 4->3","Expand 3->4","Expand 2->3","Expand 2x" ),
 	MenuRowDef(ScreenEdit::play,
@@ -860,7 +860,7 @@ static MenuDef g_AlterMenu(
 		EditMode_Practice, true, true, 0, nullptr ),
 	MenuRowDef(ScreenEdit::record,
 		"Record in selection",
-		true, 
+		true,
 		EditMode_Practice, true, true, 0, nullptr ),
 	MenuRowDef(ScreenEdit::preview_designation,
 		"Designate as Music Preview",
@@ -868,19 +868,19 @@ static MenuDef g_AlterMenu(
 		EditMode_Full, true, true, 0, nullptr ),
 	MenuRowDef(ScreenEdit::convert_to_pause,
 		"Convert selection to pause",
-		true, 
+		true,
 		EditMode_Full, true, true, 0, nullptr ),
 	MenuRowDef(ScreenEdit::convert_to_delay,
-		"Convert selection to delay",	
-		true, 
+		"Convert selection to delay",
+		true,
 		EditMode_Full, true, true, 0, nullptr ),
-	MenuRowDef(ScreenEdit::convert_to_warp,	
+	MenuRowDef(ScreenEdit::convert_to_warp,
 		"Convert selection to warp",
-		true, 
+		true,
 		EditMode_Full, true, true, 0, nullptr ),
 	MenuRowDef(ScreenEdit::convert_to_fake,
 		"Convert selection to fake",
-		true, 
+		true,
 		EditMode_Full, true, true, 0, nullptr ),
 	MenuRowDef(ScreenEdit::convert_to_attack,
 		"Convert selection to attack",
@@ -895,7 +895,7 @@ static MenuDef g_AlterMenu(
 		true,
 		EditMode_Full, true, true, 0, nullptr ),
 	MenuRowDef(ScreenEdit::routine_mirror_2_to_1,
-		"Mirror Player 2 to 1",	
+		"Mirror Player 2 to 1",
 		true,
 		EditMode_Full, true, true, 0, nullptr )
 );
@@ -912,7 +912,7 @@ static MenuDef g_AreaMenu(
 		"Insert beat and shift down",
 		true, EditMode_Practice, true, true, RCC_CHOICES ),
 	MenuRowDef(ScreenEdit::delete_and_shift,
-		"Delete beat and shift up",	
+		"Delete beat and shift up",
 		true, EditMode_Practice, true, true, RCC_CHOICES ),
 	MenuRowDef(ScreenEdit::shift_pauses_forward,
 		"Shift all timing changes down",
@@ -922,7 +922,7 @@ static MenuDef g_AreaMenu(
 		true, EditMode_Full, true, true, RCC_CHOICES ),
 	MenuRowDef(ScreenEdit::convert_pause_to_beat,
 		"Convert pause to beats",
-		true, 
+		true,
 		EditMode_Full, true, true, 0, nullptr ),
 	MenuRowDef(ScreenEdit::convert_delay_to_beat,
 		"Convert delay to beats",
@@ -944,7 +944,7 @@ static MenuDef g_AreaMenu(
 	MenuRowDef(ScreenEdit::modify_keysounds_at_row,
 		"Modify Keysounds at current beat",
 		true, EditMode_Full, true, true, 0, nullptr)
-			  
+
 );
 
 static MenuDef g_StepsInformation(
@@ -967,7 +967,7 @@ static MenuDef g_StepsInformation(
 	MenuRowDef(ScreenEdit::chartstyle,
 		"Chart Style",
 		true, EditMode_Practice, true, true, 0, nullptr ),
-	MenuRowDef(ScreenEdit::step_credit,	
+	MenuRowDef(ScreenEdit::step_credit,
 		"Step Author",
 		true, EditMode_Practice, true, true, 0, nullptr ),
     MenuRowDef(ScreenEdit::step_display_bpm,
@@ -1021,7 +1021,7 @@ static MenuDef g_SongInformation(
 	MenuRowDef(ScreenEdit::preview,
 		"Preview",
 		true, EditMode_Full, true, true, 0, nullptr ),
-	MenuRowDef(ScreenEdit::main_title_transliteration,	
+	MenuRowDef(ScreenEdit::main_title_transliteration,
 		"Main title transliteration",
 		true, EditMode_Practice, true, true, 0, nullptr ),
 	MenuRowDef(ScreenEdit::sub_title_transliteration,
@@ -1228,9 +1228,9 @@ static MenuDef g_BackgroundChange(
 	MenuRowDef(ScreenEdit::file1_type,
 		"File1 Type",
 		true,
-		EditMode_Full, true, true, 0, "Song BGAnimation", "Song Movie", 
-		"Song Bitmap", "Global BGAnimation", "Global Movie", 
-		"Global Movie from Song Group", "Global Movie from Song Group and Genre", 
+		EditMode_Full, true, true, 0, "Song BGAnimation", "Song Movie",
+		"Song Bitmap", "Global BGAnimation", "Global Movie",
+		"Global Movie from Song Group", "Global Movie from Song Group and Genre",
 		"Dynamic Random", "Baked Random", "None" ),
 	MenuRowDef(ScreenEdit::file1_song_bganimation,
 		"File1 Song BGAnimation",
@@ -1264,8 +1264,8 @@ static MenuDef g_BackgroundChange(
 		"File2 Type",
 		true,
 		EditMode_Full, true, true, 0, "Song BGAnimation", "Song Movie",
-		"Song Bitmap", "Global BGAnimation", "Global Movie", 
-		"Global Movie from Song Group", "Global Movie from Song Group and Genre", 
+		"Song Bitmap", "Global BGAnimation", "Global Movie",
+		"Global Movie from Song Group", "Global Movie from Song Group and Genre",
 		"Dynamic Random", "Baked Random", "None" ),
 	MenuRowDef(ScreenEdit::file2_song_bganimation,
 		"File2 Song BGAnimation",
@@ -1281,7 +1281,7 @@ static MenuDef g_BackgroundChange(
 		EditMode_Full, true, false, 0, nullptr ),
 	MenuRowDef(ScreenEdit::file2_global_bganimation,
 		"File2 Global BGAnimation",
-		EnabledIfSet2GlobalBGAnimation,	
+		EnabledIfSet2GlobalBGAnimation,
 		EditMode_Full, true, false, 0, nullptr ),
 	MenuRowDef(ScreenEdit::file2_global_movie,
 		"File2 Global Movie",
@@ -1317,12 +1317,12 @@ static bool EnabledIfSet2GlobalMovieSongGroupAndGenre() { return ScreenMiniMenu:
 
 static RString GetOneBakedRandomFile( Song *pSong, bool bTryGenre = true )
 {
-	vector<RString> vsPaths; 
+	vector<RString> vsPaths;
 	vector<RString> vsNames;
 	BackgroundUtil::GetGlobalRandomMovies(
 		pSong,
 		"",
-		vsPaths, 
+		vsPaths,
 		vsNames,
 		bTryGenre );
 
@@ -1395,7 +1395,7 @@ REGISTER_SCREEN_CLASS( ScreenEdit );
 void ScreenEdit::Init()
 {
 	m_pSoundMusic = nullptr;
-	
+
 	GAMESTATE->m_bIsUsingStepTiming = false;
 	GAMESTATE->m_bInStepEditor = true;
 
@@ -1408,7 +1408,7 @@ void ScreenEdit::Init()
 	ScreenWithMenuElements::Init();
 
 	InitEditMappings();
-	
+
 	currentCycleSegment = SEGMENT_LABEL;
 
 	// save the originals for reverting later
@@ -1426,8 +1426,8 @@ void ScreenEdit::Init()
 
 	m_pSong = GAMESTATE->m_pCurSong;
 	m_pSteps = GAMESTATE->m_pCurSteps[PLAYER_1];
-	
-	/*	The user will most likely switch into Step Timing after laying down 
+
+	/*	The user will most likely switch into Step Timing after laying down
 		some initial notes. It also throws off many people at first glance.
 	*/
 	if( m_pSong->IsStepsUsingDifferentTiming(m_pSteps) )
@@ -1435,7 +1435,7 @@ void ScreenEdit::Init()
 
 	m_bReturnToRecordMenuAfterPlay = false;
 	m_fBeatToReturnTo = 0;
-	
+
 	m_selectedTap = TAP_ORIGINAL_TAP;
 
 	GAMESTATE->m_bGameplayLeadIn.Set( true );
@@ -1446,10 +1446,10 @@ void ScreenEdit::Init()
 	m_iShiftAnchor = -1;
 	m_iStartPlayingAt = -1;
 	m_iStopPlayingAt = -1;
-	
+
 	attackInProcess = -1;
 	modInProcess = -1;
-	
+
 	this->AddChild( &m_Background );
 
 	m_SnapDisplay.SetXY( EDIT_X, PLAYER_Y_STANDARD );
@@ -1461,14 +1461,14 @@ void ScreenEdit::Init()
 	// We keep track of this bit of state so that when the user is in Edit/Sync Songs and makes a change to the NoteSkins,
 	// that change is "sticky" across multiple ScreenEdits.  That is the way the rest of the options work.
 	// TODO: It would be cleaner to do this by making it possible to set an option in metrics.ini.
-	if( !GAMESTATE->m_bDidModeChangeNoteSkin ) 
+	if( !GAMESTATE->m_bDidModeChangeNoteSkin )
 	{
 		GAMESTATE->m_bDidModeChangeNoteSkin = true;
-		FOREACH_PlayerNumber( pn ) 
+		FOREACH_PlayerNumber( pn )
 		{
 			const RString &sNoteSkin = EDITOR_NOTE_SKINS[pn].Get();
 			if( NOTESKIN->DoesNoteSkinExist( sNoteSkin ) )
-				PO_GROUP_ASSIGN( GAMESTATE->m_pPlayerState[pn]->m_PlayerOptions, 
+				PO_GROUP_ASSIGN( GAMESTATE->m_pPlayerState[pn]->m_PlayerOptions,
 				                 ModsLevel_Preferred, m_sNoteSkin, sNoteSkin );
 		}
 	}
@@ -1488,7 +1488,7 @@ void ScreenEdit::Init()
 		PO_GROUP_ASSIGN( m_PlayerStateEdit.m_PlayerOptions, ModsLevel_Stage, m_sNoteSkin, GAMESTATE->m_pPlayerState[PLAYER_1]->m_PlayerOptions.GetStage().m_sNoteSkin );
 	}
 	m_PlayerStateEdit.m_PlayerOptions.FromString( ModsLevel_Stage, EDIT_MODIFIERS );
-	
+
 	this->originalPlayerOptions.FromString(ModsLevel_Stage, EDIT_MODIFIERS);
 
 	m_pSteps->GetNoteData( m_NoteDataEdit );
@@ -1510,7 +1510,7 @@ void ScreenEdit::Init()
 	m_bRemoveNoteButtonDown = false;
 
 	m_Clipboard.SetNumTracks( m_NoteDataEdit.GetNumTracks() );
-	
+
 	clipboardFullTiming = GAMESTATE->m_pCurSong->m_SongTiming; // always have a backup.
 	clipboard_full_timing= &clipboardFullTiming;
 
@@ -1578,7 +1578,7 @@ ScreenEdit::~ScreenEdit()
 
 	LOG->Trace( "ScreenEdit::~ScreenEdit()" );
 	m_pSoundMusic->StopPlaying();
-	
+
 	// Go back to Step Timing on leave.
 	GAMESTATE->m_bIsUsingStepTiming = true;
 	// DEFINITELY reset the InStepEditor variable.
@@ -1615,7 +1615,7 @@ static ThemeMetric<float> FADE_OUT_PREVIEW("ScreenEdit", "FadeOutPreview");
 void ScreenEdit::PlayPreviewMusic()
 {
 	SOUND->StopMusic();
-	SOUND->PlayMusic( 
+	SOUND->PlayMusic(
 		m_pSong->GetPreviewMusicPath(),
 		nullptr,
 		false,
@@ -1651,6 +1651,8 @@ void ScreenEdit::Update( float fDeltaTime )
 {
 	m_PlayerStateEdit.Update( fDeltaTime );
 
+	const float fRate = PREFSMAN->m_bRateModsAffectTweens ? GAMESTATE->m_SongOptions.GetCurrent().m_fMusicRate : 1.0f;
+
 	if( m_pSoundMusic->IsPlaying() )
 	{
 		RageTimer tm;
@@ -1668,10 +1670,10 @@ void ScreenEdit::Update( float fDeltaTime )
 	}
 
 
-	if( m_EditState == STATE_RECORDING  )	
+	if( m_EditState == STATE_RECORDING  )
 	{
 		// TODO: Find a way to prevent STATE_RECORDING when in Song Timing.
-		
+
 		for( int t=0; t<GAMESTATE->GetCurrentStyle(GAMESTATE->GetMasterPlayerNumber())->m_iColsPerPlayer; t++ )	// for each track
 		{
 			vector<GameInput> GameI;
@@ -1755,7 +1757,14 @@ void ScreenEdit::Update( float fDeltaTime )
 	}
 
 	//LOG->Trace( "ScreenEdit::Update(%f)", fDeltaTime );
-	ScreenWithMenuElements::Update( fDeltaTime );
+	if( m_EditState == STATE_PLAYING )
+	{
+		ScreenWithMenuElements::Update( fDeltaTime * fRate );
+	}
+	else
+	{
+		ScreenWithMenuElements::Update( fDeltaTime );
+	}
 
 
 	// Update trailing beat
@@ -1919,13 +1928,13 @@ void ScreenEdit::UpdateTextInfo()
 		sText += ssprintf( SEGMENT_TYPE_FORMAT.GetValue(), SEGMENT_TYPE.GetValue().c_str(), TimingSegmentTypeToString(currentCycleSegment).c_str() );
         const RString tapnoteType = TapNoteTypeToString( m_selectedTap.type );
 		sText += ssprintf( TAP_NOTE_TYPE_FORMAT.GetValue(), TAP_NOTE_TYPE.GetValue().c_str(), tapnoteType.c_str() );
-		
+
 		AttackArray &attacks =
 			(GAMESTATE->m_bIsUsingStepTiming ? m_pSteps->m_Attacks : m_pSong->m_Attacks);
 		float beat = GetAppropriateTiming().GetElapsedTimeFromBeat(GetBeat());
 		sText += ssprintf("Attack here?: %s\n", FindAttackAtTime(attacks, beat) > -1 ? "YES" : "NO");
 	}
-	
+
 	GAMESTATE->SetProcessedTimingData(m_pSteps->GetTimingData());
 	const StepsTypeCategory &cat = GAMEMAN->GetStepsTypeInfo(m_pSteps->m_StepsType).m_StepsTypeCategory;
 	if (cat == StepsTypeCategory_Couple || cat == StepsTypeCategory_Routine)
@@ -1987,8 +1996,8 @@ void ScreenEdit::UpdateTextInfo()
 				  ( GAMESTATE->m_bIsUsingStepTiming ?
 				   STEP_TIMING.GetValue().c_str() :
 				   SONG_TIMING.GetValue().c_str() ) );
-		sText += ssprintf( BEAT_0_OFFSET_FORMAT.GetValue(), 
-				  BEAT_0_OFFSET.GetValue().c_str(), 
+		sText += ssprintf( BEAT_0_OFFSET_FORMAT.GetValue(),
+				  BEAT_0_OFFSET.GetValue().c_str(),
 				  GetAppropriateTiming().m_fBeat0OffsetInSeconds );
 		sText += ssprintf( PREVIEW_START_FORMAT.GetValue(), PREVIEW_START.GetValue().c_str(), m_pSong->m_fMusicSampleStartSeconds );
 		sText += ssprintf( PREVIEW_LENGTH_FORMAT.GetValue(), PREVIEW_LENGTH.GetValue().c_str(), m_pSong->m_fMusicSampleLengthSeconds );
@@ -2001,7 +2010,7 @@ void ScreenEdit::UpdateTextInfo()
 	}
 
 	m_textInfo.SetText( sText );
-	
+
 	GAMESTATE->SetProcessedTimingData(nullptr);
 }
 
@@ -2016,7 +2025,7 @@ void ScreenEdit::DrawPrimitives()
 
 	// HACK:  Draw using the trailing beat
 	PlayerState *pPlayerState = const_cast<PlayerState *> (m_NoteFieldEdit.GetPlayerState());
-	
+
 	float fPlayerSongBeat = pPlayerState->m_Position.m_fSongBeat;	// save song beat
 	float fPlayerSongBeatNoOffset = pPlayerState->m_Position.m_fSongBeatNoOffset;
 	float fPlayerSongBeatVisible = pPlayerState->m_Position.m_fSongBeatVisible;
@@ -2028,7 +2037,7 @@ void ScreenEdit::DrawPrimitives()
 	pPlayerState->m_Position.m_fSongBeat = m_fTrailingBeat;	// put trailing beat in effect
 	pPlayerState->m_Position.m_fSongBeatNoOffset = m_fTrailingBeat;	// put trailing beat in effect
 	pPlayerState->m_Position.m_fSongBeatVisible = m_fTrailingBeat;	// put trailing beat in effect
-	
+
 	GAMESTATE->m_Position.m_fSongBeat = m_fTrailingBeat;	// put trailing beat in effect
 	GAMESTATE->m_Position.m_fSongBeatNoOffset = m_fTrailingBeat;	// put trailing beat in effect
 	GAMESTATE->m_Position.m_fSongBeatVisible = m_fTrailingBeat;	// put trailing beat in effect
@@ -2038,7 +2047,7 @@ void ScreenEdit::DrawPrimitives()
 	pPlayerState->m_Position.m_fSongBeat = fPlayerSongBeat;	// restore real song beat
 	pPlayerState->m_Position.m_fSongBeatNoOffset = fPlayerSongBeatNoOffset;
 	pPlayerState->m_Position.m_fSongBeatVisible = fPlayerSongBeatVisible;
-	
+
 	GAMESTATE->m_Position.m_fSongBeat = fGameSongBeat;	// restore real song beat
 	GAMESTATE->m_Position.m_fSongBeatNoOffset = fGameSongBeatNoOffset;
 	GAMESTATE->m_Position.m_fSongBeatVisible = fGameSongBeatVisible;
@@ -2048,7 +2057,7 @@ void ScreenEdit::DrawPrimitives()
 bool ScreenEdit::Input( const InputEventPlus &input )
 {
 //	LOG->Trace( "ScreenEdit::Input()" );
-	
+
 	// invalidate input if cmd/meta is being held.
 	if( INPUTFILTER->IsBeingPressed(DeviceInput(DEVICE_KEYBOARD, KEY_LMETA)) ||
 	    INPUTFILTER->IsBeingPressed(DeviceInput(DEVICE_KEYBOARD, KEY_RMETA)) )
@@ -2119,7 +2128,7 @@ bool ScreenEdit::InputEdit( const InputEventPlus &input, EditButton EditB )
 	const TimingData &sTiming = GetAppropriateTiming();
 	float playerBeat = GetAppropriatePosition().m_fSongBeat;
 	int beatsPerMeasure = sTiming.GetTimeSignatureSegmentAtBeat( playerBeat )->GetNum();
-	
+
 	switch( EditB )
 	{
 	case EDIT_BUTTON_COLUMN_0:
@@ -2142,13 +2151,13 @@ bool ScreenEdit::InputEdit( const InputEventPlus &input, EditButton EditB )
 			// Alt + number = input to right half
 			if( EditIsBeingPressed(EDIT_BUTTON_RIGHT_SIDE) )
 				ShiftToRightSide( iCol, m_NoteDataEdit.GetNumTracks() );
-			
+
 			if( iCol >= m_NoteDataEdit.GetNumTracks() )
 				return false; // this button is not in the range of columns for this Style
 
 			const float fSongBeat = GetBeat();
 			const int iSongIndex = BeatToNoteRow( fSongBeat );
-			
+
 			// check for to see if the user intended to remove a HoldNote
 			int iHeadRow;
 			if( m_NoteDataEdit.IsHoldNoteAtRow( iCol, iSongIndex, &iHeadRow ) )
@@ -2184,7 +2193,7 @@ bool ScreenEdit::InputEdit( const InputEventPlus &input, EditButton EditB )
 			}
 		}
 		return true;
-			
+
 	case EDIT_BUTTON_CYCLE_TAP_LEFT:
 		{
 			switch ( m_selectedTap.type )
@@ -2406,7 +2415,7 @@ bool ScreenEdit::InputEdit( const InputEventPlus &input, EditButton EditB )
 				SCREENMAN->SystemMessage( ALTER_MENU_NO_SELECTION );
 				SCREENMAN->PlayInvalidSound();
 			}
-			else 
+			else
 			{
 				bool isRoutine = (m_InputPlayerNumber != PLAYER_INVALID);
 				g_AlterMenu.rows[routine_invert_notes].bEnabled = isRoutine;
@@ -2436,7 +2445,7 @@ bool ScreenEdit::InputEdit( const InputEventPlus &input, EditButton EditB )
 
 			// get the second of the current step.
 			float curSecond = GetAppropriateTiming().GetElapsedTimeFromBeat(GetBeat());
-			
+
 			// save current steps
 			Steps* pSteps = GAMESTATE->m_pCurSteps[PLAYER_1];
 			ASSERT( pSteps != nullptr );
@@ -2457,7 +2466,7 @@ bool ScreenEdit::InputEdit( const InputEventPlus &input, EditButton EditB )
 			switch( EditB )
 			{
 			DEFAULT_FAIL( EditB );
-			case EDIT_BUTTON_OPEN_PREV_STEPS:	
+			case EDIT_BUTTON_OPEN_PREV_STEPS:
 				if( it==vSteps.begin() )
 				{
 					SCREENMAN->PlayInvalidSound();
@@ -2492,7 +2501,7 @@ bool ScreenEdit::InputEdit( const InputEventPlus &input, EditButton EditB )
 			// Reload the music because it can be different for every steps. -Kyz
 			m_AutoKeysounds.FinishLoading();
 			m_pSoundMusic = m_AutoKeysounds.GetSound();
-			
+
 			ScrollTo( GetAppropriateTiming().GetBeatFromElapsedTime(curSecond) );
 		}
 		return true;
@@ -2595,7 +2604,7 @@ bool ScreenEdit::InputEdit( const InputEventPlus &input, EditButton EditB )
 				else
 					fDelta *= 40;
 			}
-			
+
 			// is there a StopSegment on the current row?
 			TimingData & timing = GetAppropriateTimingForUpdate();
 			DelaySegment *seg = timing.GetDelaySegmentAtRow( GetRow() );
@@ -2614,7 +2623,7 @@ bool ScreenEdit::InputEdit( const InputEventPlus &input, EditButton EditB )
 				if( seg->GetPause() <= 0 )
 					stops.erase( stops.begin()+i, stops.begin()+i+1);
 			}
-			
+
 			(fDelta>0 ? m_soundValueIncrease : m_soundValueDecrease).Play(true);
 			SetDirty( true );
 		}
@@ -2668,7 +2677,7 @@ bool ScreenEdit::InputEdit( const InputEventPlus &input, EditButton EditB )
 			case EDIT_BUTTON_SAMPLE_LENGTH_DOWN:		fDelta = -0.02f;	break;
 			case EDIT_BUTTON_SAMPLE_LENGTH_UP:		fDelta = +0.02f;	break;
 			}
-			
+
 			if( input.type == IET_REPEAT )
 			{
 				if( INPUTFILTER->GetSecsHeld(input.DeviceI) < 1.0f )
@@ -2737,7 +2746,7 @@ bool ScreenEdit::InputEdit( const InputEventPlus &input, EditButton EditB )
 
 				// Fill in lines enabled/disabled
 				bool bAlreadyBGChangeHere = false;
-				BackgroundChange bgChange; 
+				BackgroundChange bgChange;
 				for (BackgroundChange &bgc : m_pSong->GetBackgroundChanges(g_CurrentBGChangeLayer))
 				{
 					if( bgc.m_fStartBeat == GAMESTATE->m_pPlayerState[PLAYER_1]->m_Position.m_fSongBeat )
@@ -2874,7 +2883,7 @@ bool ScreenEdit::InputEdit( const InputEventPlus &input, EditButton EditB )
 		float start = -1;
 		float end = -1;
 		PlayerOptions po;
-		
+
 		if (m_NoteFieldEdit.m_iBeginMarker == -1) // not highlighted
 		{
 			po.FromString("");
@@ -2883,10 +2892,10 @@ bool ScreenEdit::InputEdit( const InputEventPlus &input, EditButton EditB )
 		{
 			const TimingData &timing = GetAppropriateTiming();
 			start = timing.GetElapsedTimeFromBeat(NoteRowToBeat(m_NoteFieldEdit.m_iBeginMarker));
-			AttackArray &attacks = 
+			AttackArray &attacks =
 				(GAMESTATE->m_bIsUsingStepTiming ? m_pSteps->m_Attacks : m_pSong->m_Attacks);
 			int index = FindAttackAtTime(attacks, start);
-			
+
 			if (index >= 0)
 			{
 				po.FromString("");
@@ -2899,7 +2908,7 @@ bool ScreenEdit::InputEdit( const InputEventPlus &input, EditButton EditB )
 			{
 				end = timing.GetElapsedTimeFromBeat(NoteRowToBeat(m_NoteFieldEdit.m_iEndMarker));
 			}
-			
+
 		}
 		ModsGroup<PlayerOptions> &toEdit = GAMESTATE->m_pPlayerState[PLAYER_1]->m_PlayerOptions;
 		this->originalPlayerOptions.Assign(ModsLevel_Preferred, toEdit.GetPreferred());
@@ -2926,7 +2935,7 @@ bool ScreenEdit::InputEdit( const InputEventPlus &input, EditButton EditB )
 			}
 			else
 			{
-				// TODO: Give Song/Step Timing switches/functions here? 
+				// TODO: Give Song/Step Timing switches/functions here?
 				TimingData *timing = m_pSteps->GetTimingData();
 				fStart = timing->GetElapsedTimeFromBeat( NoteRowToBeat(m_NoteFieldEdit.m_iBeginMarker) );
 				int iAttack = FindAttackAtTime( ce.attacks, fStart );
@@ -3081,7 +3090,7 @@ bool ScreenEdit::InputEdit( const InputEventPlus &input, EditButton EditB )
 			m_InputPlayerNumber = PLAYER_1;
 		m_soundSwitchPlayer.Play(true);
 		return true;
-	
+
 	case EDIT_BUTTON_SWITCH_TIMINGS:
 		GAMESTATE->m_bIsUsingStepTiming = !GAMESTATE->m_bIsUsingStepTiming;
 		m_soundSwitchTiming.Play(true);
@@ -3309,7 +3318,7 @@ void ScreenEdit::TransitionEditState( EditState em )
 			bGoToRecordMenu = true;
 			m_bReturnToRecordMenuAfterPlay = false;
 		}
-		
+
 		if( bGoToRecordMenu )
 			em = STATE_RECORDING_PAUSED;
 	}
@@ -3395,7 +3404,7 @@ void ScreenEdit::TransitionEditState( EditState em )
 		GAMESTATE->UpdateSongPosition( fSeconds, GetAppropriateTiming(), RageZeroTimer );
 
 		GAMESTATE->m_bGameplayLeadIn.Set( false );
-		
+
 		if (!GAMESTATE->m_bIsUsingStepTiming)
 		{
 			// Substitute the song timing for the step timing during
@@ -3655,7 +3664,7 @@ void ScreenEdit::HandleScreenMessage( const ScreenMessage SM )
 		HandleStepsDataChoice((StepsDataChoice)ScreenMiniMenu::s_iLastRowCode,
 							  ScreenMiniMenu::s_viLastAnswers);
 	}
-	
+
 	else if( SM == SM_BackFromSongInformation )
 	{
 		HandleSongInformationChoice( (SongInformationChoice)ScreenMiniMenu::s_iLastRowCode, ScreenMiniMenu::s_viLastAnswers );
@@ -3856,7 +3865,7 @@ void ScreenEdit::HandleScreenMessage( const ScreenMessage SM )
 		const int row = this->GetRow();
 		unsigned int sound = ScreenMiniMenu::s_viLastAnswers[track];
 		vector<RString> &kses = m_pSong->m_vsKeysoundFile;
-		
+
 		if (track < tracks)
 		{
 			if (sound == kses.size())
@@ -3907,7 +3916,7 @@ void ScreenEdit::HandleScreenMessage( const ScreenMessage SM )
 					}
 					else if (newNote.iKeysoundIndex > static_cast<int>(sound))
 						newNote.iKeysoundIndex--;
-					
+
 					m_NoteDataEdit.SetTapNote(t, r, newNote);
 				}
 			}
@@ -3960,11 +3969,11 @@ void ScreenEdit::HandleScreenMessage( const ScreenMessage SM )
 		const int row = BeatToNoteRow( GAMESTATE->m_Position.m_fSongBeat );
 
 		TapNote tn(
-			TapNoteType_Attack, 
+			TapNoteType_Attack,
 			TapNoteSubType_Invalid,
-			TapNoteSource_Original, 
+			TapNoteSource_Original,
 			sMods,
-			g_fLastInsertAttackDurationSeconds, 
+			g_fLastInsertAttackDurationSeconds,
 			-1 );
 		tn.pn = m_InputPlayerNumber;
 		SetDirty( true );
@@ -3975,7 +3984,7 @@ void ScreenEdit::HandleScreenMessage( const ScreenMessage SM )
 	else if (SM == SM_BackFromEditingAttackStart && !ScreenTextEntry::s_bCancelledLast)
 	{
 		float time = StringToFloat(ScreenTextEntry::s_sLastAnswer);
-		AttackArray &attacks = 
+		AttackArray &attacks =
 		(GAMESTATE->m_bIsUsingStepTiming ? m_pSteps->m_Attacks : m_pSong->m_Attacks);
 		Attack &attack = attacks[attackInProcess];
 		attack.fStartSecond = time;
@@ -3984,7 +3993,7 @@ void ScreenEdit::HandleScreenMessage( const ScreenMessage SM )
 	else if (SM == SM_BackFromEditingAttackLength && !ScreenTextEntry::s_bCancelledLast)
 	{
 		float time = StringToFloat(ScreenTextEntry::s_sLastAnswer);
-		AttackArray &attacks = 
+		AttackArray &attacks =
 		(GAMESTATE->m_bIsUsingStepTiming ? m_pSteps->m_Attacks : m_pSong->m_Attacks);
 		Attack &attack = attacks[attackInProcess];
 		attack.fSecsRemaining = time;
@@ -3996,21 +4005,21 @@ void ScreenEdit::HandleScreenMessage( const ScreenMessage SM )
 		Trim(mod);
 		if (mod.length() > 0)
 		{
-			AttackArray &attacks = 
+			AttackArray &attacks =
 			(GAMESTATE->m_bIsUsingStepTiming ? m_pSteps->m_Attacks : m_pSong->m_Attacks);
 			Attack &attack = attacks[attackInProcess];
 			attack.sModifiers += "," + mod;
 			SetDirty(true);
 		}
-		
+
 	}
 	else if (SM == SM_BackFromEditingModToExistingAttack && !ScreenTextEntry::s_bCancelledLast)
 	{
-		AttackArray &attacks = 
+		AttackArray &attacks =
 		(GAMESTATE->m_bIsUsingStepTiming ? m_pSteps->m_Attacks : m_pSong->m_Attacks);
 		Attack &attack = attacks[attackInProcess];
 		vector<RString> mods;
-		split(attack.sModifiers, ",", mods);		
+		split(attack.sModifiers, ",", mods);
 		RString mod = ScreenTextEntry::s_sLastAnswer;
 		Trim(mod);
 		if (mod.length() > 0)
@@ -4034,7 +4043,7 @@ void ScreenEdit::HandleScreenMessage( const ScreenMessage SM )
 	else if (SM == SM_BackFromInsertStepAttack)
 	{
 		unsigned option = ScreenMiniMenu::s_iLastRowCode;
-		AttackArray &attacks = 
+		AttackArray &attacks =
 		(GAMESTATE->m_bIsUsingStepTiming ? m_pSteps->m_Attacks : m_pSong->m_Attacks);
 		Attack &attack = attacks[attackInProcess];
 		vector<RString> mods;
@@ -4075,7 +4084,7 @@ void ScreenEdit::HandleScreenMessage( const ScreenMessage SM )
 		Trim(mod);
 		if (mod.length() > 0)
 		{
-			AttackArray &attacks = 
+			AttackArray &attacks =
 			(GAMESTATE->m_bIsUsingStepTiming ? m_pSteps->m_Attacks : m_pSong->m_Attacks);
 			Attack attack;
 			attack.fStartSecond = GetAppropriateTiming().GetElapsedTimeFromBeat(GetBeat());
@@ -4091,7 +4100,7 @@ void ScreenEdit::HandleScreenMessage( const ScreenMessage SM )
 		int attackDecision = ScreenMiniMenu::s_viLastAnswers[attackChoice];
 		const TimingData &timing = GetAppropriateTiming();
 		float startTime = timing.GetElapsedTimeFromBeat(GetBeat());
-		AttackArray &attacks = 
+		AttackArray &attacks =
 		(GAMESTATE->m_bIsUsingStepTiming ? m_pSteps->m_Attacks : m_pSong->m_Attacks);
 		vector<int> points = FindAllAttacksAtTime(attacks, startTime);
 		if (attackChoice == (int)points.size())
@@ -4114,7 +4123,7 @@ void ScreenEdit::HandleScreenMessage( const ScreenMessage SM )
 			{
 				Attack &attack = attacks[attackInProcess];
 				g_IndividualAttack.rows.clear();
-				
+
 				g_IndividualAttack.rows.push_back(MenuRowDef(0,
 															 "Starting Time",
 															 true,
@@ -4148,7 +4157,7 @@ void ScreenEdit::HandleScreenMessage( const ScreenMessage SM )
 																 nullptr));
 					g_IndividualAttack.rows[col].SetOneUnthemedChoice(mods[i].c_str());
 				}
-				
+
 				g_IndividualAttack.rows.push_back(MenuRowDef(mods.size() + 2,
 															 "Add Mod",
 															 true,
@@ -4157,7 +4166,7 @@ void ScreenEdit::HandleScreenMessage( const ScreenMessage SM )
 															 true,
 															 0,
 															 nullptr));
-				
+
 				EditMiniMenu(&g_IndividualAttack, SM_BackFromInsertStepAttack);
 			}
 		}
@@ -4170,7 +4179,7 @@ void ScreenEdit::HandleScreenMessage( const ScreenMessage SM )
 		g_fLastInsertAttackDurationSeconds = StringToFloat( g_InsertStepAttack.rows[0].choices[iDurationChoice] );
 		AttackArray &attacks = GAMESTATE->m_bIsUsingStepTiming ? m_pSteps->m_Attacks : m_pSong->m_Attacks;
 		int iAttack = FindAttackAtTime(attacks, g_fLastInsertAttackPositionSeconds);
-		
+
 		if (ScreenMiniMenu::s_iLastRowCode == ScreenEdit::remove )
 		{
 			if (iAttack > 0)
@@ -4183,7 +4192,7 @@ void ScreenEdit::HandleScreenMessage( const ScreenMessage SM )
 			PlayerOptions po;
 			if (iAttack >= 0)
 				po.FromString(attacks[iAttack].sModifiers);
-			
+
 			toEdit.Assign( ModsLevel_Preferred, po );
 			SCREENMAN->AddNewScreenToTop( SET_MOD_SCREEN, SM_BackFromInsertStepAttackPlayerOptions );
 		}
@@ -4195,7 +4204,7 @@ void ScreenEdit::HandleScreenMessage( const ScreenMessage SM )
 		Course *pCourse = GAMESTATE->m_pCurCourse;
 		CourseEntry &ce = pCourse->m_vEntries[GAMESTATE->m_iEditCourseEntryIndex];
 		int iAttack;
-		
+
 		// TODO: Handle Song/Step Timing functions/switches here?
 
 		g_fLastInsertAttackPositionSeconds = m_pSteps->GetTimingData()->GetElapsedTimeFromBeat( GAMESTATE->m_Position.m_fSongBeat );
@@ -4223,7 +4232,7 @@ void ScreenEdit::HandleScreenMessage( const ScreenMessage SM )
 		ModsGroup<PlayerOptions> &toRestore = GAMESTATE->m_pPlayerState[PLAYER_1]->m_PlayerOptions;
 		PlayerOptions poChosen = toRestore.GetPreferred();
 		RString mods = poChosen.GetString();
-		
+
 		if (g_fLastInsertAttackPositionSeconds >= 0)
 		{
 			Attack a(ATTACK_LEVEL_1,
@@ -4370,7 +4379,7 @@ void ScreenEdit::HandleScreenMessage( const ScreenMessage SM )
 		/* FIXME: This code causes all the steps to be deleted if you quit
 		 * without saving. However, without this code, any new steps will get
 		 * saved on quit. -aj */
-		
+
 		// At this point, the last good song copy is in use.
 		Song *pSong = GAMESTATE->m_pCurSong;
 		const vector<Steps*> &apSteps = pSong->GetAllSteps();
@@ -4401,7 +4410,7 @@ void ScreenEdit::HandleScreenMessage( const ScreenMessage SM )
 			if( GAMESTATE->m_pCurSteps[PLAYER_1].Get() == pSteps )
 				GAMESTATE->m_pCurSteps[PLAYER_1].Set(nullptr);
 		}
-		
+
 
 		m_Out.StartTransitioning( SM_GoToNextScreen );
 	}
@@ -4980,7 +4989,7 @@ void ScreenEdit::HandleMainMenuChoice( MainMenuChoice c, const vector<int> &iAns
 				DisplayTimingMenu();
 			}
 			break;
-		
+
 		case play_preview_music:
 			PlayPreviewMusic();
 			break;
@@ -5077,7 +5086,7 @@ void ScreenEdit::HandleAlterMenuChoice(AlterMenuChoice c, const vector<int> &ans
 {
 	ASSERT_M(m_NoteFieldEdit.m_iBeginMarker!=-1 && m_NoteFieldEdit.m_iEndMarker!=-1,
 			 "You can only alter a selection of notes with a selection to begin with!");
-	
+
 	bool bSaveUndo = true;
 	switch (c)
 	{
@@ -5091,19 +5100,19 @@ void ScreenEdit::HandleAlterMenuChoice(AlterMenuChoice c, const vector<int> &ans
 		default:
 			break;
 	}
-	
+
 	if( bSaveUndo )
 		SetDirty( true );
-	
+
 	/* We call HandleAreaMenuChoice recursively. Only the outermost
 	 * HandleAreaMenuChoice should allow Undo so that the inner calls don't
 	 * also save Undo and mess up the outermost */
 	if(!allow_undo)
 		bSaveUndo = false;
-	
+
 	if( bSaveUndo )
 		SaveUndo();
-	
+
 	switch(c)
 	{
 		case cut:
@@ -5114,7 +5123,7 @@ void ScreenEdit::HandleAlterMenuChoice(AlterMenuChoice c, const vector<int> &ans
 			break;
 		case copy:
 		{
-			
+
 			m_Clipboard.ClearAll();
 			m_Clipboard.CopyRange( m_NoteDataEdit, m_NoteFieldEdit.m_iBeginMarker, m_NoteFieldEdit.m_iEndMarker );
 		}
@@ -5146,7 +5155,7 @@ void ScreenEdit::HandleAlterMenuChoice(AlterMenuChoice c, const vector<int> &ans
 		{
 			const NoteData OldClipboard( m_Clipboard );
 			HandleAlterMenuChoice( cut, false );
-			
+
 			StepsType st = GAMESTATE->GetCurrentStyle(GAMESTATE->GetMasterPlayerNumber())->m_StepsType;
 			TurnType tt = (TurnType)answers[c];
 			switch( tt )
@@ -5159,7 +5168,7 @@ void ScreenEdit::HandleAlterMenuChoice(AlterMenuChoice c, const vector<int> &ans
 				case shuffle:		NoteDataUtil::Turn( m_Clipboard, st, NoteDataUtil::shuffle );		break;
 				case super_shuffle:	NoteDataUtil::Turn( m_Clipboard, st, NoteDataUtil::super_shuffle );	break;
 			}
-			
+
 			HandleAreaMenuChoice( paste_at_begin_marker, false );
 			m_Clipboard = OldClipboard;
 		}
@@ -5170,7 +5179,7 @@ void ScreenEdit::HandleAlterMenuChoice(AlterMenuChoice c, const vector<int> &ans
 			int iEndRow = m_NoteFieldEdit.m_iEndMarker;
 			TransformType tt = (TransformType)answers[c];
 			StepsType st = GAMESTATE->GetCurrentStyle(GAMESTATE->GetMasterPlayerNumber())->m_StepsType;
-			
+
 			switch( tt )
 			{
 					DEFAULT_FAIL( tt );
@@ -5192,7 +5201,7 @@ void ScreenEdit::HandleAlterMenuChoice(AlterMenuChoice c, const vector<int> &ans
 				case noquads:		NoteDataUtil::RemoveQuads( m_NoteDataEdit, iBeginRow, iEndRow );	break;
 				case nostretch:		NoteDataUtil::RemoveStretch( m_NoteDataEdit, st, iBeginRow, iBeginRow );break;
 			}
-			
+
 			// bake in the additions
 			NoteDataUtil::ConvertAdditionsToRegular( m_NoteDataEdit );
 			break;
@@ -5201,7 +5210,7 @@ void ScreenEdit::HandleAlterMenuChoice(AlterMenuChoice c, const vector<int> &ans
 		{
 			const NoteData OldClipboard( m_Clipboard );
 			HandleAlterMenuChoice( cut, false );
-			
+
 			AlterType at = (AlterType)answers[c];
 			switch( at )
 			{
@@ -5237,7 +5246,7 @@ void ScreenEdit::HandleAlterMenuChoice(AlterMenuChoice c, const vector<int> &ans
 				);
 					break;
 			}
-			
+
 			HandleAreaMenuChoice( paste_at_begin_marker, false );
 			m_Clipboard = OldClipboard;
 			break;
@@ -5247,7 +5256,7 @@ void ScreenEdit::HandleAlterMenuChoice(AlterMenuChoice c, const vector<int> &ans
 			// This affects all steps.
 			AlterType at = (AlterType)answers[c];
 			float fScale = -1;
-			
+
 			switch( at )
 			{
 					DEFAULT_FAIL( at );
@@ -5258,24 +5267,24 @@ void ScreenEdit::HandleAlterMenuChoice(AlterMenuChoice c, const vector<int> &ans
 				case expand_3_2:	fScale = 1.5f;		break;
 				case expand_2x:		fScale = 2;		break;
 			}
-			
+
 			int iStartIndex  = m_NoteFieldEdit.m_iBeginMarker;
 			int iEndIndex    = m_NoteFieldEdit.m_iEndMarker;
 			int iNewEndIndex = iEndIndex + lrintf( (iEndIndex - iStartIndex) * (fScale - 1) );
-			
+
 			// scale currently editing notes
 			NoteDataUtil::ScaleRegion( m_NoteDataEdit, fScale, iStartIndex, iEndIndex );
-			
+
 			// scale timing data
-			GetAppropriateTimingForUpdate().ScaleRegion(fScale, 
-							   m_NoteFieldEdit.m_iBeginMarker, 
+			GetAppropriateTimingForUpdate().ScaleRegion(fScale,
+							   m_NoteFieldEdit.m_iBeginMarker,
 							   m_NoteFieldEdit.m_iEndMarker, true );
-			
+
 			m_NoteFieldEdit.m_iEndMarker = iNewEndIndex;
 			break;
-			
+
 		}
-			
+
 		case play:
 			m_iStartPlayingAt = m_NoteFieldEdit.m_iBeginMarker;
 			m_iStopPlayingAt = m_NoteFieldEdit.m_iEndMarker;
@@ -5298,14 +5307,14 @@ void ScreenEdit::HandleAlterMenuChoice(AlterMenuChoice c, const vector<int> &ans
 		{
 			float fMarkerStart = GetAppropriateTiming().GetElapsedTimeFromBeat( NoteRowToBeat(m_NoteFieldEdit.m_iBeginMarker) );
 			float fMarkerEnd = GetAppropriateTiming().GetElapsedTimeFromBeat( NoteRowToBeat(m_NoteFieldEdit.m_iEndMarker) );
-			
+
 			// The length of the stop segment we're going to create.  This includes time spent in any
 			// stops in the selection, which will be deleted and subsumed into the new stop.
 			float fStopLength = fMarkerEnd - fMarkerStart;
-			
+
 			// be sure not to clobber the row at the start - a row at the end
 			// can be dropped safely, though
-			NoteDataUtil::DeleteRows( m_NoteDataEdit, 
+			NoteDataUtil::DeleteRows( m_NoteDataEdit,
 						 m_NoteFieldEdit.m_iBeginMarker + 1,
 						 m_NoteFieldEdit.m_iEndMarker-m_NoteFieldEdit.m_iBeginMarker
 						 );
@@ -5321,12 +5330,12 @@ void ScreenEdit::HandleAlterMenuChoice(AlterMenuChoice c, const vector<int> &ans
 		{
 			float fMarkerStart = GetAppropriateTiming().GetElapsedTimeFromBeat( NoteRowToBeat(m_NoteFieldEdit.m_iBeginMarker) );
 			float fMarkerEnd = GetAppropriateTiming().GetElapsedTimeFromBeat( NoteRowToBeat(m_NoteFieldEdit.m_iEndMarker) );
-			
+
 			// The length of the delay segment we're going to create.  This includes time spent in any
 			// stops in the selection, which will be deleted and subsumed into the new stop.
 			float fStopLength = fMarkerEnd - fMarkerStart;
-			
-			NoteDataUtil::DeleteRows( m_NoteDataEdit, 
+
+			NoteDataUtil::DeleteRows( m_NoteDataEdit,
 						 m_NoteFieldEdit.m_iBeginMarker,
 						 m_NoteFieldEdit.m_iEndMarker-m_NoteFieldEdit.m_iBeginMarker
 						 );
@@ -5354,17 +5363,17 @@ void ScreenEdit::HandleAlterMenuChoice(AlterMenuChoice c, const vector<int> &ans
 			float &length = g_fLastInsertAttackDurationSeconds;
 			start = timing.GetElapsedTimeFromBeat(startBeat);
 			length = timing.GetElapsedTimeFromBeat(endBeat) - start;
-			
+
 			AttackArray &attacks = GAMESTATE->m_bIsUsingStepTiming ?
 				m_pSteps->m_Attacks : m_pSong->m_Attacks;
 			int iAttack = FindAttackAtTime(attacks, start);
-			
+
 			ModsGroup<PlayerOptions> &toEdit = GAMESTATE->m_pPlayerState[PLAYER_1]->m_PlayerOptions;
 			this->originalPlayerOptions.Assign(ModsLevel_Preferred, toEdit.GetPreferred());
 			PlayerOptions po;
 			if (iAttack >= 0)
 				po.FromString(attacks[iAttack].sModifiers);
-				
+
 			toEdit.Assign( ModsLevel_Preferred, po );
 			SCREENMAN->AddNewScreenToTop( SET_MOD_SCREEN, SM_BackFromInsertStepAttackPlayerOptions );
 			SetDirty(true);
@@ -5453,7 +5462,7 @@ void ScreenEdit::HandleAlterMenuChoice(AlterMenuChoice c, const vector<int> &ans
 		}
 		default: break;
 	}
-	
+
 }
 
 void ScreenEdit::HandleAreaMenuChoice( AreaMenuChoice c, const vector<int> &iAnswers, bool bAllowUndo )
@@ -5505,7 +5514,7 @@ void ScreenEdit::HandleAreaMenuChoice( AreaMenuChoice c, const vector<int> &iAns
 				m_NoteDataEdit.CopyRange( m_Clipboard, 0, iRowsToCopy, iDestFirstRow );
 			}
 			break;
-			
+
 		case insert_and_shift:
 			NoteDataUtil::InsertRows( m_NoteDataEdit, GetRow(),
 				GetRowsFromAnswers(c, iAnswers));
@@ -5597,7 +5606,7 @@ void ScreenEdit::HandleStepsInformationChoice( StepsInformationChoice c, const v
 	Difficulty dc = (Difficulty)iAnswers[difficulty];
 	pSteps->SetDifficulty( dc );
 	pSteps->SetDisplayBPM(static_cast<DisplayBPM>(iAnswers[step_display_bpm]));
-	
+
 	switch( c )
 	{
 		case chartname:
@@ -5624,12 +5633,12 @@ void ScreenEdit::HandleStepsInformationChoice( StepsInformationChoice c, const v
 		}
 		case chartstyle:
 		{
-			ScreenTextEntry::TextEntry(SM_None, 
+			ScreenTextEntry::TextEntry(SM_None,
 									   ENTER_NEW_CHART_STYLE,
-									   m_pSteps->GetChartStyle(), 
+									   m_pSteps->GetChartStyle(),
 									   255,
 									   nullptr,
-									   ChangeChartStyle, 
+									   ChangeChartStyle,
 									   nullptr);
 			break;
 		}
@@ -5735,8 +5744,8 @@ void ScreenEdit::HandleSongInformationChoice( SongInformationChoice c, const vec
 		ScreenTextEntry::TextEntry( SM_None, ENTER_ARTIST_TRANSLIT, pSong->m_sArtistTranslit, 100, nullptr, ChangeArtistTranslit, nullptr );
 		break;
 	case last_second_hint:
-		ScreenTextEntry::TextEntry( SM_None, ENTER_LAST_SECOND_HINT, 
-					   std::to_string(pSong->GetSpecifiedLastSecond()), 20, 
+		ScreenTextEntry::TextEntry( SM_None, ENTER_LAST_SECOND_HINT,
+					   std::to_string(pSong->GetSpecifiedLastSecond()), 20,
 					   ScreenTextEntry::FloatValidate, ChangeLastSecondHint, nullptr );
 		break;
 	case preview_start:
@@ -5793,25 +5802,25 @@ void ScreenEdit::HandleTimingDataInformationChoice( TimingDataInformationChoice 
 			);
 		break;
 	case bpm:
-		ScreenTextEntry::TextEntry( 
-			SM_BackFromBPMChange, 
-			ENTER_BPM_VALUE, 
+		ScreenTextEntry::TextEntry(
+			SM_BackFromBPMChange,
+			ENTER_BPM_VALUE,
 			std::to_string( GetAppropriateTiming().GetBPMAtBeat( GetBeat() ) ),
 			10
 			);
 		break;
 	case stop:
-		ScreenTextEntry::TextEntry( 
-			SM_BackFromStopChange, 
-			ENTER_STOP_VALUE, 
+		ScreenTextEntry::TextEntry(
+			SM_BackFromStopChange,
+			ENTER_STOP_VALUE,
 			std::to_string( GetAppropriateTiming().GetStopAtBeat( GetBeat() ) ),
 			10
 			);
 		break;
 	case delay:
-		ScreenTextEntry::TextEntry( 
-			SM_BackFromDelayChange, 
-			ENTER_DELAY_VALUE, 
+		ScreenTextEntry::TextEntry(
+			SM_BackFromDelayChange,
+			ENTER_DELAY_VALUE,
 			std::to_string( GetAppropriateTiming().GetDelayAtBeat( GetBeat() ) ),
 			10
 		);
@@ -5844,9 +5853,9 @@ void ScreenEdit::HandleTimingDataInformationChoice( TimingDataInformationChoice 
 		   );
 		break;
 	case warp:
-		ScreenTextEntry::TextEntry( 
-		   SM_BackFromWarpChange, 
-		   ENTER_WARP_VALUE, 
+		ScreenTextEntry::TextEntry(
+		   SM_BackFromWarpChange,
+		   ENTER_WARP_VALUE,
 		   std::to_string( GetAppropriateTiming().GetWarpAtBeat( GetBeat() ) ),
 		   10
 		   );
@@ -5875,7 +5884,7 @@ void ScreenEdit::HandleTimingDataInformationChoice( TimingDataInformationChoice 
 		   10
 		   );
 		break;
-	case speed_mode: 
+	case speed_mode:
 		{
 			ScreenTextEntry::TextEntry(
 						SM_BackFromSpeedModeChange,
@@ -5883,7 +5892,7 @@ void ScreenEdit::HandleTimingDataInformationChoice( TimingDataInformationChoice 
 						   "",
 						   3
 			);
-			
+
 			break;
 		}
 	case fake:
@@ -5938,7 +5947,7 @@ void ScreenEdit::HandleTimingDataInformationChoice( TimingDataInformationChoice 
 	case erase_step_timing:
 		ScreenPrompt::Prompt( SM_DoEraseStepTiming, CONFIRM_TIMING_ERASE , PROMPT_YES_NO, ANSWER_NO );
 	break;
-		
+
 	}
 }
 
@@ -6099,7 +6108,7 @@ void ScreenEdit::SetupCourseAttacks()
 	if( GAMESTATE->m_pCurCourse )
 	{
 		AttackArray Attacks;
-		
+
 		if( EDIT_MODE == EditMode_CourseMods )
 		{
 			Attacks = GAMESTATE->m_pCurCourse->m_vEntries[GAMESTATE->m_iEditCourseEntryIndex].attacks;
@@ -6121,7 +6130,7 @@ void ScreenEdit::SetupCourseAttacks()
 		for (Attack &attack: Attacks)
 			GAMESTATE->m_pPlayerState[PLAYER_1]->LaunchAttack( attack );
 	}
-	else 
+	else
 	{
 		const PlayerOptions &p = GAMESTATE->m_pPlayerState[PLAYER_1]->m_PlayerOptions.GetCurrent();
 		if (GAMESTATE->m_pCurSong && p.m_fNoAttack == 0 && p.m_fRandAttack == 0 )
@@ -6129,7 +6138,7 @@ void ScreenEdit::SetupCourseAttacks()
 			AttackArray &attacks = GAMESTATE->m_bIsUsingStepTiming ?
 				GAMESTATE->m_pCurSteps[PLAYER_1]->m_Attacks :
 				GAMESTATE->m_pCurSong->m_Attacks;
-			
+
 			if (attacks.size() > 0)
 			{
 				for (Attack &attack : attacks)
@@ -6142,7 +6151,7 @@ void ScreenEdit::SetupCourseAttacks()
 			}
 		}
 	}
-	
+
 	GAMESTATE->m_pPlayerState[PLAYER_1]->RebuildPlayerOptionsFromActiveAttacks();
 }
 
@@ -6187,7 +6196,7 @@ void ScreenEdit::RevertFromDisk()
 	{
 		// If the Steps we were currently editing vanished when we did the revert,
 		// put a blank Steps in its place.  Note that this does not have to be the
-		// work of someone maliciously changing the simfile; it could happen to 
+		// work of someone maliciously changing the simfile; it could happen to
 		// someone editing a new stepchart and reverting from disk, for example.
 		pNewSteps = GAMESTATE->m_pCurSong->CreateSteps();
 		pNewSteps->CreateBlank( id.GetStepsType() );
@@ -6281,7 +6290,7 @@ float ScreenEdit::GetMaximumBeatForNewNote() const
 			Song &s = *GAMESTATE->m_pCurSong;
 			float fEndBeat = s.GetLastBeat();
 
-			/* Round up to the next measure end.  Some songs end on weird beats 
+			/* Round up to the next measure end.  Some songs end on weird beats
 			 * mid-measure, and it's odd to have movement capped to these weird
 			 * beats. */
 			TimingData &timing = s.m_SongTiming;
@@ -6302,8 +6311,8 @@ float ScreenEdit::GetMaximumBeatForMoving() const
 	float fEndBeat = GetMaximumBeatForNewNote();
 
 	/* Jump to GetLastBeat even if it's past the song's last beat
-	 * so that users can delete garbage steps past then end that they have 
-	 * have inserted in a text editor.  Once they delete all steps on 
+	 * so that users can delete garbage steps past then end that they have
+	 * have inserted in a text editor.  Once they delete all steps on
 	 * GetLastBeat() and move off of that beat, they won't be able to return. */
 	fEndBeat = max( fEndBeat, m_NoteDataEdit.GetLastBeat() );
 
@@ -6315,31 +6324,31 @@ struct EditHelpLine
 	const char *szEnglishDescription;
 	vector<EditButton> veb;
 
-	EditHelpLine( 
+	EditHelpLine(
 		const char *_szEnglishDescription,
-		EditButton eb0, 
-		EditButton eb1 = EditButton_Invalid, 
-		EditButton eb2 = EditButton_Invalid, 
-		EditButton eb3 = EditButton_Invalid, 
-		EditButton eb4 = EditButton_Invalid, 
-		EditButton eb5 = EditButton_Invalid, 
-		EditButton eb6 = EditButton_Invalid, 
-		EditButton eb7 = EditButton_Invalid, 
-		EditButton eb8 = EditButton_Invalid, 
+		EditButton eb0,
+		EditButton eb1 = EditButton_Invalid,
+		EditButton eb2 = EditButton_Invalid,
+		EditButton eb3 = EditButton_Invalid,
+		EditButton eb4 = EditButton_Invalid,
+		EditButton eb5 = EditButton_Invalid,
+		EditButton eb6 = EditButton_Invalid,
+		EditButton eb7 = EditButton_Invalid,
+		EditButton eb8 = EditButton_Invalid,
 		EditButton eb9 = EditButton_Invalid )
 	{
 		szEnglishDescription = _szEnglishDescription;
 #define PUSH_IF_VALID( x ) if( x != EditButton_Invalid ) veb.push_back( x );
 		PUSH_IF_VALID( eb0 );
 		PUSH_IF_VALID( eb1 );
-		PUSH_IF_VALID( eb2 ); 
-		PUSH_IF_VALID( eb3 ); 
-		PUSH_IF_VALID( eb4 ); 
-		PUSH_IF_VALID( eb5 ); 
-		PUSH_IF_VALID( eb6 ); 
-		PUSH_IF_VALID( eb7 ); 
-		PUSH_IF_VALID( eb8 ); 
-		PUSH_IF_VALID( eb9 ); 
+		PUSH_IF_VALID( eb2 );
+		PUSH_IF_VALID( eb3 );
+		PUSH_IF_VALID( eb4 );
+		PUSH_IF_VALID( eb5 );
+		PUSH_IF_VALID( eb6 );
+		PUSH_IF_VALID( eb7 );
+		PUSH_IF_VALID( eb8 );
+		PUSH_IF_VALID( eb9 );
 #undef PUSH_IF_VALID
 	}
 };
@@ -6436,20 +6445,20 @@ void ScreenEdit::DoStepAttackMenu()
 {
 	const TimingData &timing = GetAppropriateTiming();
 	float startTime = timing.GetElapsedTimeFromBeat(GetBeat());
-	AttackArray &attacks = 
+	AttackArray &attacks =
 		(GAMESTATE->m_bIsUsingStepTiming ? m_pSteps->m_Attacks : m_pSong->m_Attacks);
 	vector<int> points = FindAllAttacksAtTime(attacks, startTime);
-		
+
 	g_AttackAtTimeMenu.rows.clear();
 	unsigned index = 0;
-	
+
 	for (int &i : points)
 	{
 		const Attack &attack = attacks[i];
 		RString desc = ssprintf("%g -> %g (%d mod[s])",
 			startTime, startTime + attack.fSecsRemaining,
 			attack.GetNumAttacks());
-			
+
 		g_AttackAtTimeMenu.rows.push_back(MenuRowDef(index++,
 			desc,
 			true,
@@ -6468,7 +6477,7 @@ void ScreenEdit::DoStepAttackMenu()
 		true,
 		0,
 		nullptr));
-		
+
 	EditMiniMenu(&g_AttackAtTimeMenu, SM_BackFromAttackAtTime);
 }
 
@@ -6480,7 +6489,7 @@ void ScreenEdit::DoKeyboardTrackMenu()
 {
 	g_KeysoundTrack.rows.clear();
 	vector<RString> &kses = m_pSong->m_vsKeysoundFile;
-	
+
 	vector<RString> choices;
 	for (RString const &ks : kses)
 	{
@@ -6502,13 +6511,13 @@ void ScreenEdit::DoKeyboardTrackMenu()
 		{
 			++foundKeysounds;
 		}
-		
+
 		g_KeysoundTrack.rows.push_back(MenuRowDef(i, ssprintf(TRACK_NUM.GetValue(), i + 1),
 												  true, EditMode_Full, false, false, keyIndex, choices));
 	}
 	g_KeysoundTrack.rows.push_back(MenuRowDef(m_NoteDataEdit.GetNumTracks(), "Remove Keysound",
 											  foundKeysounds > 0, EditMode_Full, false, false, 0, kses));
-	
+
 	EditMiniMenu(&g_KeysoundTrack, SM_BackFromKeysoundTrack);
 }
 
@@ -6525,13 +6534,13 @@ void ScreenEdit::DoHelp()
 
 		RString sButtons = GetDeviceButtonsLocalized( hl.veb, m_EditMappingsDeviceInput );
 		RString sDescription = THEME->GetString( "EditHelpDescription", hl.szEnglishDescription );
-		
+
 		// TODO: Better way of hiding routine only key on non-routine.
 		if( hl.veb[0] == EDIT_BUTTON_SWITCH_PLAYERS && m_InputPlayerNumber == PLAYER_INVALID )
 		{
 			continue;
 		}
-		
+
 		g_EditHelp.rows.push_back( MenuRowDef( -1, sDescription, false, EditMode_Practice, false, false, 0, sButtons ) );
 	}
 
@@ -6541,7 +6550,7 @@ void ScreenEdit::DoHelp()
 // lua start
 #include "LuaBinding.h"
 
-/** @brief Allow Lua to have access to ScreenEdit. */ 
+/** @brief Allow Lua to have access to ScreenEdit. */
 class LunaScreenEdit: public Luna<ScreenEdit>
 {
 public:
@@ -6557,7 +6566,7 @@ LUA_REGISTER_DERIVED_CLASS( ScreenEdit, ScreenWithMenuElements )
 /*
  * (c) 2001-2004 Chris Danford
  * All rights reserved.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the
  * "Software"), to deal in the Software without restriction, including
@@ -6567,7 +6576,7 @@ LUA_REGISTER_DERIVED_CLASS( ScreenEdit, ScreenWithMenuElements )
  * copyright notice(s) and this permission notice appear in all copies of
  * the Software and that both the above copyright notice(s) and this
  * permission notice appear in supporting documentation.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
  * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
  * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF

--- a/src/ScreenGameplay.cpp
+++ b/src/ScreenGameplay.cpp
@@ -99,14 +99,14 @@ static Preference<bool> g_bEasterEggs( "EasterEggs", true );
 
 PlayerInfo::PlayerInfo(): m_pn(PLAYER_INVALID), m_mp(MultiPlayer_Invalid),
 	m_bIsDummy(false), m_iDummyIndex(0), m_iAddToDifficulty(0),
-	m_bPlayerEnabled(false), m_PlayerStateDummy(), 
+	m_bPlayerEnabled(false), m_PlayerStateDummy(),
 	m_PlayerStageStatsDummy(), m_SoundEffectControl(),
-	m_vpStepsQueue(), m_asModifiersQueue(), m_pLifeMeter(nullptr), 
+	m_vpStepsQueue(), m_asModifiersQueue(), m_pLifeMeter(nullptr),
 	m_ptextCourseSongNumber(nullptr), m_ptextStepsDescription(nullptr),
 	m_pPrimaryScoreDisplay(nullptr), m_pSecondaryScoreDisplay(nullptr),
 	m_pPrimaryScoreKeeper(nullptr), m_pSecondaryScoreKeeper(nullptr),
 	m_ptextPlayerOptions(nullptr), m_pActiveAttackList(nullptr),
-	m_NoteData(), m_pPlayer(nullptr), m_pInventory(nullptr), 
+	m_NoteData(), m_pPlayer(nullptr), m_pInventory(nullptr),
 	m_pStepsDisplay(nullptr), m_sprOniGameOver() {}
 
 void PlayerInfo::Load( PlayerNumber pn, MultiPlayer mp, bool bShowNoteField, int iAddToDifficulty )
@@ -250,7 +250,7 @@ bool PlayerInfo::IsEnabled()
 	FAIL_M("Invalid non-dummy player.");
 }
 
-vector<PlayerInfo>::iterator 
+vector<PlayerInfo>::iterator
 GetNextEnabledPlayerInfo( vector<PlayerInfo>::iterator iter, vector<PlayerInfo> &v )
 {
 	for( ; iter != v.end(); ++iter )
@@ -262,7 +262,7 @@ GetNextEnabledPlayerInfo( vector<PlayerInfo>::iterator iter, vector<PlayerInfo> 
 	return iter;
 }
 
-vector<PlayerInfo>::iterator 
+vector<PlayerInfo>::iterator
 GetNextEnabledPlayerInfoNotDummy( vector<PlayerInfo>::iterator iter, vector<PlayerInfo> &v )
 {
 	for( ; iter != v.end(); iter++ )
@@ -423,7 +423,7 @@ void ScreenGameplay::Init()
 	FOREACH_EnabledPlayerInfo( m_vPlayerInfo, pi )
 	{
 		unsigned int count = pi->m_vpStepsQueue.size();
-		
+
 		for (unsigned int i = 0; i < count; i++)
 		{
 			Steps *curSteps = pi->m_vpStepsQueue[i];
@@ -433,7 +433,7 @@ void ScreenGameplay::Init()
 				{
 					LOG->Trace("Notes should be loaded for player %d", player);
 				}
-				else 
+				else
 				{
 					LOG->Trace("Error loading notes for player %d", player);
 				}
@@ -441,7 +441,7 @@ void ScreenGameplay::Init()
 		}
 		player++;
 	}
-	
+
 	if(!GAMESTATE->IsCourseMode() && !GAMESTATE->m_bDemonstrationOrJukebox)
 	{
 		// fill in difficulty of CPU players with that of the first human player
@@ -582,7 +582,7 @@ void ScreenGameplay::Init()
 			right_marge= margins[PLAYER_2][1]; \
 			field_space= screen_space - left_marge - right_marge; \
 		}
-		// If pi->m_pn is set, then the player will be visible.  If not, then it's not 
+		// If pi->m_pn is set, then the player will be visible.  If not, then it's not
 		// visible and don't bother setting its position.
 		if(GAMESTATE->m_bMultiplayer && !pi->m_bIsDummy)
 		CENTER_PLAYER_BLOCK
@@ -650,7 +650,7 @@ void ScreenGameplay::Init()
 	// if you wait too long at the second checkpoint, you will
 	// appear dead when you begin your game.
 	if( !m_bForceNoNetwork )
-		NSMAN->StartRequest(0); 
+		NSMAN->StartRequest(0);
 
 
 	// Add individual life meter
@@ -861,16 +861,16 @@ void ScreenGameplay::Init()
 		RString sType = PLAYER_TYPE;
 		if( pi->m_bIsDummy )
 			sType += "Dummy";
-		pi->m_pPlayer->Init( 
+		pi->m_pPlayer->Init(
 			sType,
 			pi->GetPlayerState(),
 			pi->GetPlayerStageStats(),
-			pi->m_pLifeMeter, 
-			m_pCombinedLifeMeter, 
-			pi->m_pPrimaryScoreDisplay, 
-			pi->m_pSecondaryScoreDisplay, 
-			pi->m_pInventory, 
-			pi->m_pPrimaryScoreKeeper, 
+			pi->m_pLifeMeter,
+			m_pCombinedLifeMeter,
+			pi->m_pPrimaryScoreDisplay,
+			pi->m_pSecondaryScoreDisplay,
+			pi->m_pInventory,
+			pi->m_pPrimaryScoreKeeper,
 			pi->m_pSecondaryScoreKeeper );
 	}
 
@@ -914,7 +914,7 @@ bool ScreenGameplay::Center1Player() const
 	 * StyleType for ONE_PLAYER_ONE_CREDIT_AND_ONE_COMPUTER,
 	 * but for now just ignore Center1Player when it's Battle or Rave
 	 * Mode. This doesn't begin to address two-player solo (6 arrows) */
-	return g_bCenter1Player && 
+	return g_bCenter1Player &&
 		(bool)ALLOW_CENTER_1_PLAYER &&
 		GAMESTATE->m_PlayMode != PLAY_MODE_BATTLE &&
 		GAMESTATE->m_PlayMode != PLAY_MODE_RAVE &&
@@ -958,7 +958,7 @@ void ScreenGameplay::InitSongQueues()
 			// In a survival course, override stored mods
 			if( pCourse->GetCourseType() == COURSE_TYPE_SURVIVAL && SURVIVAL_MOD_OVERRIDE )
 			{
-				pi->GetPlayerState()->m_PlayerOptions.FromString( ModsLevel_Stage, 
+				pi->GetPlayerState()->m_PlayerOptions.FromString( ModsLevel_Stage,
 										 "clearall,"
 										 + CommonMetrics::DEFAULT_NOTESKIN_NAME.GetValue()
 										 + ","
@@ -975,7 +975,7 @@ void ScreenGameplay::InitSongQueues()
 			Steps *pSteps = GAMESTATE->m_pCurSteps[ pi->GetStepsAndTrailIndex() ];
 			pi->m_vpStepsQueue.push_back( pSteps );
 			const PlayerOptions &p = pi->GetPlayerState()->m_PlayerOptions.GetCurrent();
-			
+
 			if (p.m_fNoAttack == 0 && p.m_fRandAttack == 0 &&
 			    pSteps->m_Attacks.size() > 0 )
 			{
@@ -1072,7 +1072,7 @@ void ScreenGameplay::SetupSong( int iSongIndex )
 		Steps *pSteps = pi->m_vpStepsQueue[iSongIndex];
  		GAMESTATE->m_pCurSteps[ pi->GetStepsAndTrailIndex() ].Set( pSteps );
 
-		/* Load new NoteData into Player. Do this before 
+		/* Load new NoteData into Player. Do this before
 		 * RebuildPlayerOptionsFromActiveAttacks or else transform mods will get
 		 * propagated to GAMESTATE->m_pPlayerOptions too early and be double-applied
 		 * to the NoteData:
@@ -1145,7 +1145,7 @@ void ScreenGameplay::SetupSong( int iSongIndex )
 			Attack a = pi->m_asModifiersQueue[iSongIndex][i];
 			if( a.fStartSecond == 0 )
 				a.fStartSecond = ATTACK_STARTS_NOW;	// now
-			
+
 			pi->GetPlayerState()->LaunchAttack( a );
 			GAMESTATE->m_SongOptions.FromString( ModsLevel_Song, a.sModifiers );
 		}
@@ -1273,7 +1273,7 @@ void ScreenGameplay::LoadNextSong()
 				else
 					pi->GetPlayerState()->m_PlayerController = GamePreferences::m_AutoPlay;
 			}
-		} 
+		}
 	}
 
 	bool bAllReverse = true;
@@ -1625,7 +1625,7 @@ void ScreenGameplay::BeginScreen()
 
 		float startOffset = g_fNetStartOffset;
 
-		NSMAN->StartRequest(1); 
+		NSMAN->StartRequest(1);
 
 		RageSoundParams p;
 		p.m_fSpeed = 1.0f;	// Force 1.0 playback speed
@@ -1701,7 +1701,8 @@ void ScreenGameplay::Update( float fDeltaTime )
 	}
 	else
 	{
-		Screen::Update( fDeltaTime );
+		const float fRate = PREFSMAN->m_bRateModsAffectTweens ? GAMESTATE->m_SongOptions.GetCurrent().m_fMusicRate : 1.0f;
+		Screen::Update( fDeltaTime * fRate );
 	}
 
 	/* This happens if ScreenDemonstration::HandleScreenMessage sets a new screen when
@@ -1850,7 +1851,7 @@ void ScreenGameplay::Update( float fDeltaTime )
 			}
 
 			// Update living players' alive time
-			// HACK: Don't scale alive time when using tab/tilde.  Instead of accumulating time from a timer, 
+			// HACK: Don't scale alive time when using tab/tilde.  Instead of accumulating time from a timer,
 			// this time should instead be tied to the music position.
 			float fUnscaledDeltaTime = m_timerGameplaySeconds.GetDeltaTime();
 
@@ -1862,7 +1863,7 @@ void ScreenGameplay::Update( float fDeltaTime )
 			STATSMAN->m_CurStageStats.m_fGameplaySeconds += fUnscaledDeltaTime;
 			float curBeat = GAMESTATE->m_Position.m_fSongBeat;
 			Song &s = *GAMESTATE->m_pCurSong;
-			
+
 			if( curBeat >= s.GetFirstBeat() && curBeat < s.GetLastBeat() )
 			{
 				STATSMAN->m_CurStageStats.m_fStepsSeconds += fUnscaledDeltaTime;
@@ -2949,7 +2950,7 @@ void ScreenGameplay::HandleScreenMessage( const ScreenMessage SM )
 				if(course->GetCourseType() == COURSE_TYPE_SURVIVAL &&
 					SURVIVAL_MOD_OVERRIDE)
 				{
-					pi->GetPlayerState()->m_PlayerOptions.FromString(ModsLevel_Stage, 
+					pi->GetPlayerState()->m_PlayerOptions.FromString(ModsLevel_Stage,
 						"clearall," + CommonMetrics::DEFAULT_NOTESKIN_NAME.GetValue() +
 						"," + CommonMetrics::DEFAULT_MODIFIERS.GetValue());
 					pi->GetPlayerState()->RebuildPlayerOptionsFromActiveAttacks();
@@ -3134,7 +3135,7 @@ void ScreenGameplay::HandleMessage( const Message &msg )
 
 	ScreenWithMenuElements::HandleMessage( msg );
 }
- 
+
 void ScreenGameplay::Cancel( ScreenMessage smSendWhenDone )
 {
 	m_pSoundMusic->Stop();
@@ -3257,7 +3258,7 @@ bool ScreenGameplay::LoadReplay()
 #include "LuaBinding.h"
 #include "OptionsBinding.h"
 
-/** @brief Allow Lua to have access to the ScreenGameplay. */ 
+/** @brief Allow Lua to have access to the ScreenGameplay. */
 class LunaScreenGameplay: public Luna<ScreenGameplay>
 {
 public:
@@ -3344,7 +3345,7 @@ public:
 		lua_pushnumber(L, true_bps);
 		return 1;
 	}
-	
+
 	LunaScreenGameplay()
 	{
 		ADD_METHOD( GetNextCourseSong );
@@ -3368,7 +3369,7 @@ public:
 LUA_REGISTER_DERIVED_CLASS( ScreenGameplay, ScreenWithMenuElements )
 
 
-/** @brief Allow Lua to have access to the PlayerInfo. */ 
+/** @brief Allow Lua to have access to the PlayerInfo. */
 class LunaPlayerInfo: public Luna<PlayerInfo>
 {
 public:
@@ -3381,7 +3382,7 @@ public:
 		}
 		return 0;
 	}
-		
+
 	static int GetStepsQueueWrapped( T* p, lua_State *L )
 	{
 		int iIndex = IArg(1);
@@ -3404,7 +3405,7 @@ LUA_REGISTER_CLASS( PlayerInfo )
 /*
  * (c) 2001-2004 Chris Danford, Glenn Maynard
  * All rights reserved.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the
  * "Software"), to deal in the Software without restriction, including
@@ -3414,7 +3415,7 @@ LUA_REGISTER_CLASS( PlayerInfo )
  * copyright notice(s) and this permission notice appear in all copies of
  * the Software and that both the above copyright notice(s) and this
  * permission notice appear in supporting documentation.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
  * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
  * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF


### PR DESCRIPTION
### What is this?

- This is a ported feature from NotITG
    - I already have a permission about this PR from Taro
- With the option the speed of tweens is affected by ratemods
    - It's disabled by default for compatibility. It's enabled by default in NotITG though
- It's kinda required feature for who play modfiles with ratemods

### Points need to review

- Is the feature appropriate for SM5.1?
- Should I enable this feature by default? (Should I set its default value to be `true` ?)
- I just have copy&paste codes from NotITG
    - feel free to request changes if there are any syntax suggestions or whatever
    - I have tried the feature and I think it's working as intended
- Since `.editorconfig` is there some existing trailing spaces are removed. Is this ok?

### Self introduction, just in case?

- It's my first time to contribute to this project
- I'm one of NotITG dev
- Interested in mods
