### PR TITLE
cmdline arg to convert DWI to SSC+SM (simple wrapper around song->load and song->save)

### DIFF
--- a/src/CommandLineActions.cpp
+++ b/src/CommandLineActions.cpp
@@ -19,6 +19,9 @@
 #include "ScreenInstallOverlay.h"
 #include "ver.h"
 
+#include "Song.h"
+#include "SongCacheIndex.h"
+
 // only used for Version()
 #if defined(_WINDOWS)
 #include <windows.h>
@@ -121,6 +124,23 @@ void CommandLineActions::Handle(LoadingWindow* pLW)
 	if( GetCommandlineArgument("version") )
 	{
 		Version();
+		bExitAfter = true;
+	}
+	if( GetCommandlineArgument("convert") )
+	{
+		RString songDir = g_argv[2];
+		SONGINDEX = new SongCacheIndex;
+		printf("NOTE: song dir must be a subdir of dir of executable\n");
+		printf("converting: " + songDir + "\n");
+		Song* song = new Song;
+		printf("loading..\n");
+		song->LoadFromSongDir(songDir, true, ProfileSlot_Invalid);
+		RString songFilePathPrefix = song->GetSongFilePath();
+		printf("saving..\n");
+		song->Save(true);
+		song->SaveToSSCFile(songFilePathPrefix, false, false);
+		song->SaveToSMFile();
+		printf("done!\n");
 		bExitAfter = true;
 	}
 	if( bExitAfter )


### PR DESCRIPTION
quick and dirty cmdline wrapper. feel free to close it, just PR'ing in case someone else finds it useful.
converted 280 old DWI files to ssc in about 5s, seems to work well

`Usage: ./stepmania --convert Songs/MyPack/MySong`


wrapper i used to convert all my dwi-only song dirs:
https://github.com/teleshoes/wolke-home-config/blob/e40f437db7649a026891df0266d904d5a0645c1a/bin/stepmania-ensure-ssc-sm