### PR TITLE
Added an exception to the "not a joystick" logic for the RedOctane USB Pad.

### DIFF
--- a/src/arch/InputHandler/InputHandler_Linux_Event.cpp
+++ b/src/arch/InputHandler/InputHandler_Linux_Event.cpp
@@ -132,9 +132,14 @@ bool EventDevice::Open( RString sFile, InputDevice dev )
 
 	if( !BitIsSet(iABSMask, ABS_X) && !BitIsSet(iABSMask, ABS_THROTTLE) && !BitIsSet(iABSMask, ABS_WHEEL) )
 	{
-		LOG->Info( "    Not a joystick; ignored" );
-		Close();
-		return false;
+		LOG->Info( "    Not a joystick; ignoring [%s]",m_sName.c_str() );
+		if(m_sName.compare("RedOctane USB Pad") == 0)
+		{
+			LOG->Info("RedOctane USB Pad detected, making an exception.");
+		} else {
+			Close();
+			return false;
+		}
 	}
 
 	uint8_t iKeyMask[KEY_MAX/8 + 1];


### PR DESCRIPTION
Hello StepMania developers,

First I want to say, I love StepMania.  It's the absolute best way to play DDR style rhythm games. 

I've been using StepMania for many years with my old RedOctane Afterburner USB Pad.  I went to pull down the latest StepMania 5.1 codebase to give it a go.  I discovered that it now ignores my RedOctane USB Pad outputting the message "Not a joystick; ignoring."

I found the code that decides what a joystick isn't and ignores devices that match that criteria.  I then added an exception specifically for my RedOctane USB Pad.  It works, and I'm able to play the game with my trusty old metal dance mat.

I'm not sure if the way I put this exception logic in is really the best way to include something like this.  But, I didn't see any other way to get the latest version of StepMania to accept my device.  I humbly submit a pull request.

Thanks,
Dave