### PR TITLE
PIUIO Button board light support.

### DIFF
--- a/src/CMakeData-arch.cmake
+++ b/src/CMakeData-arch.cmake
@@ -230,11 +230,13 @@ if(NOT APPLE)
       list(APPEND SMDATA_ARCH_LIGHTS_SRC
                   "arch/Lights/LightsDriver_Linux_PIUIO.cpp"
                   "arch/Lights/LightsDriver_Linux_PIUIO_Leds.cpp"
+                  "arch/Lights/LightsDriver_Linux_PIUIOBTN_Leds.cpp"
                   "arch/Lights/LightsDriver_Linux_ITGIO.cpp"
                   "arch/Lights/LightsDriver_LinuxWeedTech.cpp")
       list(APPEND SMDATA_ARCH_LIGHTS_HPP
                   "arch/Lights/LightsDriver_Linux_PIUIO.h"
                   "arch/Lights/LightsDriver_Linux_PIUIO_Leds.h"
+                  "arch/Lights/LightsDriver_Linux_PIUIOBTN_Leds.h"
                   "arch/Lights/LightsDriver_Linux_ITGIO.h"
                   "arch/Lights/LightsDriver_LinuxWeedTech.h")
       if(WITH_PARALLEL_PORT)

--- a/src/LightsManager.cpp
+++ b/src/LightsManager.cpp
@@ -349,6 +349,14 @@ void LightsManager::Update( float fDeltaTime )
 					{
 						m_LightsState.m_bGameButtonLights[pn][GAME_BUTTON_MENULEFT] = true;
 						m_LightsState.m_bGameButtonLights[pn][GAME_BUTTON_MENURIGHT] = true;
+						m_LightsState.m_bGameButtonLights[pn][GAME_BUTTON_MENUUP] = true;
+						m_LightsState.m_bGameButtonLights[pn][GAME_BUTTON_MENUDOWN] = true;
+					}
+					else
+					{
+						//flash select during evaluation screen to indicate
+						//that the button can be used for screenshots etc.
+						m_LightsState.m_bGameButtonLights[pn][GAME_BUTTON_SELECT] = true;
 					}
 				}
 			}

--- a/src/arch/Lights/LightsDriver_Linux_PIUIOBTN_Leds.cpp
+++ b/src/arch/Lights/LightsDriver_Linux_PIUIOBTN_Leds.cpp
@@ -1,0 +1,110 @@
+#include "global.h"
+#include <stdio.h>
+#if defined(HAVE_UNISTD_H)
+#include <unistd.h>
+#endif
+#include <sys/types.h>
+#include <sys/stat.h>
+
+#if defined(HAVE_FCNTL_H)
+#include <fcntl.h>
+#endif
+
+#include "LightsDriver_Linux_PIUIOBTN_Leds.h"
+#include "GameState.h"
+#include "Game.h"
+#include "RageLog.h"
+
+REGISTER_LIGHTS_DRIVER_CLASS2(PIUIOBTN_Leds, Linux_PIUIOBTN_Leds);
+
+namespace {
+	const char *game_btn_leds[NUM_GameController][NUM_GameButton] = {
+		{
+			"/sys/class/leds/piuio::bboutput6/brightness", //P1 GAME_BUTTON_MENULEFT
+			"/sys/class/leds/piuio::bboutput5/brightness", //P1 GAME_BUTTON_MENURIGHT
+			nullptr, nullptr,
+			"/sys/class/leds/piuio::bboutput4/brightness", //P1 GAME_BUTTON_START
+			"/sys/class/leds/piuio::bboutput7/brightness", //P1 GAME_BUTTON_SELECT
+		},
+		{
+			"/sys/class/leds/piuio::bboutput2/brightness", //P2 GAME_BUTTON_MENULEFT
+			"/sys/class/leds/piuio::bboutput1/brightness", //P2 GAME_BUTTON_MENURIGHT
+			nullptr, nullptr,
+			"/sys/class/leds/piuio::bboutput0/brightness", //P2 GAME_BUTTON_START
+			"/sys/class/leds/piuio::bboutput3/brightness", //P2 GAME_BUTTON_SELECT
+		},
+	};
+
+	bool SetLight(const char *filename, bool on)
+	{
+		if (filename == nullptr)
+			return true;
+		FILE *f = fopen(filename, "w");
+		if (f == nullptr)
+		{
+			return false;
+		}
+		fprintf(f, "%d", on ? 255 : 0);
+		fclose(f);
+		return true;
+	}
+}
+
+LightsDriver_Linux_PIUIOBTN_Leds::LightsDriver_Linux_PIUIOBTN_Leds()
+{
+}
+
+LightsDriver_Linux_PIUIOBTN_Leds::~LightsDriver_Linux_PIUIOBTN_Leds()
+{
+}
+
+void LightsDriver_Linux_PIUIOBTN_Leds::Set( const LightsState *ls )
+{
+	const InputScheme *pInput = &GAMESTATE->GetCurrentGame()->m_InputScheme;
+	RString sInputName = pInput->m_szName;
+
+	FOREACH_ENUM(GameController, c)
+	{
+		FOREACH_ENUM( GameButton, gb )
+		{
+			if (ls->m_bGameButtonLights[c][gb] == previousLS.m_bGameButtonLights[c][gb])
+			{
+				continue;
+			}
+
+			if (!SetLight(game_btn_leds[c][gb], ls->m_bGameButtonLights[c][gb]))
+			{
+				LOG->Warn("Error setting button light %s",
+						GameButtonToString(pInput, gb).c_str());
+				return;
+			}
+		}
+	}
+
+	previousLS = *ls;
+}
+
+/*
+ * (c) 2020 StepMania team
+ * All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, and/or sell copies of the Software, and to permit persons to
+ * whom the Software is furnished to do so, provided that the above
+ * copyright notice(s) and this permission notice appear in all copies of
+ * the Software and that both the above copyright notice(s) and this
+ * permission notice appear in supporting documentation.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF
+ * THIRD PARTY RIGHTS. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS
+ * INCLUDED IN THIS NOTICE BE LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT
+ * OR CONSEQUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+ * OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+ * OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+ * PERFORMANCE OF THIS SOFTWARE.
+ */

--- a/src/arch/Lights/LightsDriver_Linux_PIUIOBTN_Leds.h
+++ b/src/arch/Lights/LightsDriver_Linux_PIUIOBTN_Leds.h
@@ -1,0 +1,45 @@
+/* LightsDriver_Linux_PIUIOBTN_Leds: Control PIUIO Button Board lights via /sys/class/leds */
+
+#ifndef LightsDriver_Linux_PIUIOBTN_Leds_H
+#define LightsDriver_Linux_PIUIOBTN_Leds_H
+
+#include "arch/Lights/LightsDriver.h"
+
+class LightsDriver_Linux_PIUIOBTN_Leds : public LightsDriver
+{
+private:
+	LightsState previousLS;
+
+public:
+	LightsDriver_Linux_PIUIOBTN_Leds();
+	virtual ~LightsDriver_Linux_PIUIOBTN_Leds();
+
+	virtual void Set( const LightsState *ls );
+};
+
+#endif
+
+/*
+ * (c) 2020 StepMania team
+ * All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, and/or sell copies of the Software, and to permit persons to
+ * whom the Software is furnished to do so, provided that the above
+ * copyright notice(s) and this permission notice appear in all copies of
+ * the Software and that both the above copyright notice(s) and this
+ * permission notice appear in supporting documentation.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF
+ * THIRD PARTY RIGHTS. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS
+ * INCLUDED IN THIS NOTICE BE LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT
+ * OR CONSEQUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+ * OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+ * OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+ * PERFORMANCE OF THIS SOFTWARE.
+ */


### PR DESCRIPTION
So I made a PIUIO button board for my FX cabinet and since djpohly's kernel driver supports writing lights to it, and stepmania didn't have the code already to do so...

...I made it happen.

I also added some lights that were currently not being controlled into the LightsManager. My guess is this is a hangover from the oITG / DDR cabinets since they only had three menu keys (start, left, right).

Often now we are seeing people make menu boxes / setups that incorporate cardinal directions with option buttons etc, so obviously those need to be lit up.

Let me know if you have any questions.

Demonstration:

https://twitter.com/dinsfire64/status/1339437419398111232