### PR TITLE
Change the default binding for P2/back from hyphen to backslash

### DIFF
--- a/src/InputMapper.cpp
+++ b/src/InputMapper.cpp
@@ -63,7 +63,7 @@ static const AutoMappings g_DefaultKeyMappings = AutoMappings(
 	AutoMappingEntry( 0, KEY_KP_C2,	GAME_BUTTON_MENUDOWN,	true ),
 	AutoMappingEntry( 0, KEY_KP_ENTER,	GAME_BUTTON_START,	true ),
 	AutoMappingEntry( 0, KEY_KP_C0,	GAME_BUTTON_SELECT,	true ),
-	AutoMappingEntry( 0, KEY_HYPHEN,	GAME_BUTTON_BACK,	true ), // laptop keyboards.
+	AutoMappingEntry( 0, KEY_BACKSLASH,	GAME_BUTTON_BACK,	true ), // laptop keyboards.
 	AutoMappingEntry( 0, KEY_F1,	GAME_BUTTON_COIN,	false ),
 	AutoMappingEntry( 0, KEY_SCRLLOCK,	GAME_BUTTON_OPERATOR,	false )
 );


### PR DESCRIPTION
This is a workaround to make the hyphen key usable in text entry screens. It allows to add a hyphen to profile names and set a negative offset in edit mode.
    
Technically backslash is also a typeable character, but it seems to be less common names in user names and not necessary for typing negative offsets.
    
Fwiw, in outfox P2/back is unbound.
