### PR TITLE
Mark keypad buttons as such in the input mapping screen

### DIFF
--- a/src/arch/InputHandler/InputHandler.cpp
+++ b/src/arch/InputHandler/InputHandler.cpp
@@ -128,6 +128,9 @@ RString InputHandler::GetDeviceSpecificInputString( const DeviceInput &di )
 
 	if( di.device == DEVICE_KEYBOARD )
 	{
+		if( di.button >= KEY_KP_C0 && di.button <= KEY_KP_ENTER )
+			return DeviceButtonToString( di.button );
+
 		wchar_t c = DeviceButtonToChar( di.button, false );
 		if( c && c != L' ' ) // Don't show "Key  " for space.
 			return InputDeviceToString( di.device ) + " " + Capitalize( WStringToRString(wstring()+c) );


### PR DESCRIPTION
Both the slash key and the numpad slash key were displayed as 'Key /', so it's not obvious to the user which key actually has been bound. Let's display them as 'Key /' and 'KP /' instead. Same for other KP keys.

![Screenshot_20210118_222749](https://user-images.githubusercontent.com/27127/104964353-8b51c080-59dc-11eb-8587-03f571055021.png)