### PR TITLE
Added option to set an analog threshold for joystick/fsr controllers

### DIFF
--- a/src/RageInputDevice.cpp
+++ b/src/RageInputDevice.cpp
@@ -6,6 +6,8 @@
 #include "RageUtil.h"
 #include "LocalizedString.h"
 
+Preference<float> g_analogPressThreshold( "AnalogPressThreshold", 0.1f );
+
 static const char *InputDeviceStateNames[] = {
 	"Connected",
 	"Unplugged",

--- a/src/RageInputDevice.h
+++ b/src/RageInputDevice.h
@@ -4,9 +4,12 @@
 
 #include "RageTimer.h"
 #include "EnumHelper.h"
+#include "Preference.h"
 
 const int NUM_JOYSTICKS = 32;
 const int NUM_PUMPS = 2;
+
+extern Preference<float> g_analogPressThreshold;
 
 enum InputDevice
 {
@@ -331,12 +334,16 @@ public:
 	 * debouncing applied. */
 	bool bDown;
 
+	/* An analog input as an analog FSR controller will send SM axis values
+	 * this will define which pressure is considered to be a pressed button */
+	float analogThreshold = g_analogPressThreshold;
+
 	RageTimer ts;
 
 	DeviceInput(): device(InputDevice_Invalid), button(DeviceButton_Invalid), level(0), z(0), bDown(false), ts(RageZeroTimer) { }
-	DeviceInput( InputDevice d, DeviceButton b, float l=0 ): device(d), button(b), level(l), z(0), bDown(l > 0.5f), ts(RageZeroTimer) { }
+	DeviceInput( InputDevice d, DeviceButton b, float l=0 ): device(d), button(b), level(l), z(0), bDown(l == 1.00f || l > analogThreshold), ts(RageZeroTimer) { }
 	DeviceInput( InputDevice d, DeviceButton b, float l, const RageTimer &t ):
-		device(d), button(b), level(l), z(0), bDown(level > 0.5f), ts(t) { }
+		device(d), button(b), level(l), z(0), bDown(l == 1.00f || level > analogThreshold), ts(t) { }
 	DeviceInput( InputDevice d, DeviceButton b, const RageTimer &t, int zVal=0 ):
 		device(d), button(b), level(0), z(zVal), bDown(false), ts(t) { }
 


### PR DESCRIPTION
I have observed that there are various projects as https://github.com/teejusb/fsr, where they are configuring their pad controllers to send a keystroke/joystick button when the hardware controller gets a value higher than the threshold configured at the controller firmware.

However, in these cases SM is not receiving the analog value of the FSR outputs at all, and that makes the code of the controllers to have more complexity.

After having a look around the code (https://github.com/stepmania/stepmania/blob/984dc8668f1fedacf553f279a828acdebffc5625/src/RageInputDevice.h), I see that analog inputs are supported by StepMania, but also that the threshold is hardcoded to trigger a button when the axis is above the 50% of it's values:

```
	DeviceInput( InputDevice d, DeviceButton b, float l=0 ): device(d), button(b), level(l), z(0), bDown(l > 0.5f), ts(RageZeroTimer) { }
	DeviceInput( InputDevice d, DeviceButton b, float l, const RageTimer &t ):
		device(d), button(b), level(l), z(0), bDown(level > 0.5f), ts(t) { }
```

This PR adds a preference to Preferences.ini, so the FSR pad controllers can be just HID joysticks with several axes, where StepMania considers if there is enough force or not over a button to consider that it was pressed.

Probably it's not as advanced as the current hardware solutions where each sensor sensitivity threshold is configured independently, but I think this would be okay as an initial implementation.