### PR TITLE
Fix lighting typo.

### DIFF
--- a/src/arch/Lights/LightsDriver_Linux_ITGIO.cpp
+++ b/src/arch/Lights/LightsDriver_Linux_ITGIO.cpp
@@ -105,7 +105,7 @@ void LightsDriver_Linux_ITGIO::Set(const LightsState *ls)
 	SetCabinetLights(cabinet_lights, ls);
 
 	SetGameControllerLights(GameController_1, player1_lights, ls);
-	SetGameControllerLights(GameController_2, player1_lights, ls);
+	SetGameControllerLights(GameController_2, player2_lights, ls);
 
 	previousLS = *ls;
 }

--- a/src/arch/Lights/LightsDriver_Linux_PIUIO_Leds.cpp
+++ b/src/arch/Lights/LightsDriver_Linux_PIUIO_Leds.cpp
@@ -177,12 +177,12 @@ void LightsDriver_Linux_PIUIO_Leds::Set(const LightsState *ls)
 	if (IsDance())
 	{
 		SetGameControllerLights(GameController_1, player1_dance_lights, ls);
-		SetGameControllerLights(GameController_2, player1_dance_lights, ls);
+		SetGameControllerLights(GameController_2, player2_dance_lights, ls);
 	}
 	else if (IsPump())
 	{
 		SetGameControllerLights(GameController_1, player1_pump_lights, ls);
-		SetGameControllerLights(GameController_2, player1_pump_lights, ls);
+		SetGameControllerLights(GameController_2, player2_pump_lights, ls);
 	}
 
 	previousLS = *ls;


### PR DESCRIPTION
I made a mistake in my last PR 2078 which causes only P1 lights to work on the ITGIO/PIUIO.

Looking at the code it was a simple typo, so here's the fix.