### PR TITLE
Add a new preference, RenderEarlierNotesOnTop, to control the ordering of tap note rendering.

### DIFF
--- a/src/NoteDisplay.cpp
+++ b/src/NoteDisplay.cpp
@@ -1,6 +1,7 @@
+#include "global.h"
+
 #include "NoteDisplay.h"
 
-#include "global.h"
 #include "ActorUtil.h"
 #include "ArrowEffects.h"
 #include "GameState.h"

--- a/src/NoteDisplay.cpp
+++ b/src/NoteDisplay.cpp
@@ -471,8 +471,8 @@ bool NoteDisplay::DrawHoldsInRange(const NoteFieldRenderArgs& field_args,
 	const vector<NoteData::TrackMap::const_iterator>& tap_set)
 {
 	bool any_upcoming = false;
-	for(vector<NoteData::TrackMap::const_iterator>::const_reverse_iterator tapit=
-		tap_set.rbegin(); tapit != tap_set.rend(); ++tapit)
+	for(vector<NoteData::TrackMap::const_iterator>::const_iterator tapit=
+		tap_set.begin(); tapit != tap_set.end(); ++tapit)
 	{
 		const TapNote& tn= (*tapit)->second;
 		const HoldNoteResult& result= tn.HoldResult;
@@ -538,8 +538,8 @@ bool NoteDisplay::DrawTapsInRange(const NoteFieldRenderArgs& field_args,
 {
 	bool any_upcoming= false;
 	// draw notes from furthest to closest
-	for(vector<NoteData::TrackMap::const_iterator>::const_reverse_iterator tapit=
-		tap_set.rbegin(); tapit != tap_set.rend(); ++tapit)
+	for(vector<NoteData::TrackMap::const_iterator>::const_iterator tapit=
+		tap_set.begin(); tapit != tap_set.end(); ++tapit)
 	{
 		int tap_row= (*tapit)->first;
 		const TapNote& tn= (*tapit)->second;
@@ -613,7 +613,6 @@ bool NoteDisplay::DrawTapsInRange(const NoteFieldRenderArgs& field_args,
 		any_upcoming |= NoteRowToBeat(tap_row) >
 			m_pPlayerState->GetDisplayedPosition().m_fSongBeat;
 
-		// TODO: change to Z Bias, remove clear
 		if(!PREFSMAN->m_FastNoteRendering)
 		{
 			DISPLAY->ClearZBuffer();


### PR DESCRIPTION
This is used to address issue: https://github.com/stepmania/stepmania/issues/2069 (more context and analysis can be found in that thread).

I looked at both ITG and DDR's behavior and noticed that the note rendering order is different for both games.

With this change we support both cases by introducing a preference.

With RenderEarlierNotesOnTop set to True
![OnTop1](https://user-images.githubusercontent.com/5017202/130868624-530d720c-2bd1-448d-a903-0927f8334431.png)

With RenderEarlierNotesOnTop set to False
![Below1](https://user-images.githubusercontent.com/5017202/130868671-8021a3d2-9bb6-4d18-adb0-82d3646769e3.png)

I also looked at how holds are rendered, and in both games it looks like hold heads are always placed below taps, and taps are always on top of hold tails. This change preserves that behavior.

The Stars Above example linked in the issue above displays correctly for both values of the preference.

Note that there is an idiosyncrasy with DDR in that for specifically the up arrow, earlier notes are rendered below later notes. Because this seems to be an inconsistency I didn't think it was worth to replicate that behavior for now.



