### PR TITLE
Add libudev-dev to ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
           libjack-dev
           libmad0-dev
           libpulse-dev
+          libudev-dev
           libva-dev
           libvorbis-dev
           libxinerama-dev
@@ -48,6 +49,7 @@ jobs:
           libpulse-dev
           libtomcrypt-dev
           libtommath-dev
+          libudev-dev
           libva-dev
           libvorbis-dev
           libxinerama-dev


### PR DESCRIPTION
This should hopefully fix the failing continuous integration tests on Ubuntu. I wasn't quite sure how to test this locally, but I was hoping the CI test that runs on this PR will take the changes in this PR itself into account.