### PR TITLE
Verify that PrefsTable[name] exists before attempting to index the preference in ThemPrefs

### DIFF
--- a/Themes/_fallback/Scripts/02 ThemePrefs.lua
+++ b/Themes/_fallback/Scripts/02 ThemePrefs.lua
@@ -62,11 +62,14 @@ end
 local function ResolveTable( pref )
 	-- check the section for this theme
 	local name = GetThemeName()
-	local val = PrefsTable[name][pref]
-
-	if val ~= nil then
-		--Trace( ("ResolveTable(%s): found in %s"):format(pref,name) )
-		return PrefsTable[name]
+	local val = nil
+	
+	if PrefsTable[name] then
+		val = PrefsTable[name][pref]
+		if val ~= nil then
+			--Trace( ("ResolveTable(%s): found in %s"):format(pref,name) )
+			return PrefsTable[name]
+		end
 	end
 
 	-- not in the current theme; check the fallback if it exists


### PR DESCRIPTION
On 02 ThemePrefs.lua in the fallback theme, we're not verifying that PrefsTable[name] exists when trying to get the [pref]. It's possible for PrefsTable[name] to be nil if we're switching to a new theme thus we run into a `attempt to index field '?' (a nil value)` error.

This PR just adds some sanitization (which is already done for the FallbackTheme right below it as well).