### PR TITLE
Define ssize_t to be the same width as size_t

### DIFF
--- a/src/config.in.hpp
+++ b/src/config.in.hpp
@@ -120,7 +120,8 @@ typedef unsigned long size_t;
 /* Provide a fallback if ssize_t is not defined. */
 #cmakedefine HAVE_SIZEOF_SSIZE_T 1
 #if !defined(HAVE_SIZEOF_SSIZE_T)
-typedef long ssize_t;
+#include <type_traits>
+typedef std::make_signed<size_t>::type ssize_t;
 #endif
 
 /* Defined to 1 if the underlying system uses little endian. */


### PR DESCRIPTION
The size of size_t is defined by the architecture (32bit or 64bit). Since ssize_t is not part of the standard, unlike size_t, it might not be defined but it should always be the same size as size_t.