### PR TITLE
Change PullBackCamera's g_fImageScaleDestination value from 0.5 to 0.8

### DIFF
--- a/src/ScreenDebugOverlay.cpp
+++ b/src/ScreenDebugOverlay.cpp
@@ -1238,7 +1238,7 @@ class DebugLinePullBackCamera : public IDebugLine
 	virtual void DoAndLog( RString &sMessageOut )
 	{
 		if( g_fImageScaleDestination == 1 )
-			g_fImageScaleDestination = 0.5f;
+			g_fImageScaleDestination = 0.8f;
 		else
 			g_fImageScaleDestination = 1;
 		IDebugLine::DoAndLog( sMessageOut );


### PR DESCRIPTION
The pull back view for 1080-pixel height themes is too tiny when value is 0.5. Changing it to 0.8 is good enough for 480p, 720p and 1080p height themes.