### PR TITLE
FIx "protocol on port 9418 is no longer supported"

### DIFF
--- a/CMake/SetupFfmpeg.cmake
+++ b/CMake/SetupFfmpeg.cmake
@@ -83,7 +83,7 @@ else()
                       "n${SM_FFMPEG_VERSION}"
                       "--depth"
                       "1"
-                      "git://github.com/stepmania/ffmpeg.git"
+                      "https://github.com/stepmania/ffmpeg.git"
                       "${SM_FFMPEG_SRC_DIR}"
                       CONFIGURE_COMMAND
                       "${FFMPEG_CONFIGURE}"


### PR DESCRIPTION
I was getting the following error when building:

```
fatal: remote error:
  The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
```

Changing the protocol to `https` solves the problem for me.