### PR TITLE
Fix CMake ffmpeg download

### DIFF
--- a/CMake/SetupFfmpeg.cmake
+++ b/CMake/SetupFfmpeg.cmake
@@ -83,7 +83,7 @@ else()
                       "n${SM_FFMPEG_VERSION}"
                       "--depth"
                       "1"
-                      "git://github.com/stepmania/ffmpeg.git"
+                      "https://github.com/stepmania/ffmpeg.git"
                       "${SM_FFMPEG_SRC_DIR}"
                       CONFIGURE_COMMAND
                       "${FFMPEG_CONFIGURE}"


### PR DESCRIPTION
Small and simple change - On several boxes I've been getting timeouts / errors when ffmpeg is downloaded.
Switching to https seems to correct it. I assume the git:// protocol requires an ssh key, so anyone without write access to stepmania/ffmpeg would have this issue?
