### PR TITLE
add redir banners to _fallback for BeginnerMeter sort

### DIFF
--- a/Themes/_fallback/Graphics/Banner BeginnerMeter.redir
+++ b/Themes/_fallback/Graphics/Banner BeginnerMeter.redir
@@ -1,0 +1,1 @@
+Common fallback banner

--- a/Themes/_fallback/Graphics/Banner DoubleBeginnerMeter.redir
+++ b/Themes/_fallback/Graphics/Banner DoubleBeginnerMeter.redir
@@ -1,0 +1,1 @@
+Common fallback banner


### PR DESCRIPTION
This should fix MissingThemeElement warnings about
> The theme element "Graphics/Banner BeginnerMeter" is missing.

that would occur when sorting by BeginnerMeter.