### PR TITLE
Fix Ubuntu build with system dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,7 @@ jobs:
           libjack-dev
           libjsoncpp-dev
           libmad0-dev
+          libpcre3-dev
           libpng-dev
           libpulse-dev
           libtomcrypt-dev


### PR DESCRIPTION
This fixes one of the GitHub Actions. For the other ones we'd need to disable ffmpeg support for them to work again.