### PR TITLE
Fix modern macOS build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 
 project(StepMania)
 

--- a/extern/CMakeProject-png.cmake
+++ b/extern/CMakeProject-png.cmake
@@ -20,6 +20,13 @@ else()
       "libpng/pngwtran.c"
       "libpng/pngwutil.c")
 
+  if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(arm64|aarch64)")
+    list(APPEND PNG_SRC
+        "libpng/arm/arm_init.c"
+        "libpng/arm/filter_neon_intrinsics.c"
+        "libpng/arm/palette_neon_intrinsics.c")
+  endif()
+
   configure_file("libpng/scripts/pnglibconf.h.prebuilt"
                  "libpng/pnglibconf.h"
                  COPYONLY)

--- a/extern/libpng/pngpriv.h
+++ b/extern/libpng/pngpriv.h
@@ -518,7 +518,7 @@
 #  include <float.h>
 
 #  if (defined(__MWERKS__) && defined(macintosh)) || defined(applec) || \
-    defined(THINK_C) || defined(__SC__) || defined(TARGET_OS_MAC)
+    defined(THINK_C) || defined(__SC__)
    /* We need to check that <math.h> hasn't already been included earlier
     * as it seems it doesn't agree with <fp.h>, yet we should really use
     * <fp.h> if possible.

--- a/extern/zlib/zutil.h
+++ b/extern/zlib/zutil.h
@@ -130,7 +130,7 @@ extern z_const char * const z_errmsg[10]; /* indexed by 2-zlib_error */
 #  endif
 #endif
 
-#if defined(MACOS) || defined(TARGET_OS_MAC)
+#if defined(MACOS)
 #  define OS_CODE  7
 #  ifndef Z_SOLO
 #    if defined(__MWERKS__) && __dest_os != __be_os && __dest_os != __win32_os


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the StepMania project under the MIT license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").
  - Technically true but Claude definitely helped me debug, search for related issues, and write up.

## Description

StepMania no longer builds with current toolchains: CMake 4 rejects the project's `cmake_minimum_required(VERSION 2.8.12)`, and on modern macOS SDKs the bundled zlib/libpng fail to compile - and on Apple Silicon, to link. The failures are layered(each hides the next), which is why CI only ever shows the first.

Four small commits fix them in the order the build surfaces them. Result: a native arm64 build that runs on macOS 26, and working configure on every platform with CMake 4.

1. **Bump `cmake_minimum_required` to 3.5** - the lowest version CMake 4 accepts. This alone unblocks configure everywhere, including the failing macOS/Linux CI jobs.(CMake 4 still warns that <3.10 compat is deprecated).

2. **zlib: Don't treat modern macOS as classic Mac OS** - a pre-OS X path gated on `defined(TARGET_OS_MAC)` defines `fdopen` to `NULL`. Modern SDKs define that macro transitively, so the macro now breaks the SDK's own `stdio.h`. Upstream zlib removed this block in 1.2.12 (we bundle 1.2.11).

3. **libpng: Don't include classic Mac `fp.h`** - same root cause: `TARGET_OS_MAC` listed among classic-Mac compilers triggers `#include <fp.h>`, which doesn't exist in any OS X SDK. Falls through to `<math.h>` like every other platform.

4. **Compile libpng's ARM NEON sources on arm64** - libpng 1.6 auto-enables NEON when `__ARM_NEON` is set (always, on Apple Silicon), but the hand-written source list omits `arm/*.c`, so linking fails on undefined `_png_*_neon` symbols. Add them on arm64/aarch64, as upstream libpng's own build does.

Commits 2–3 patch vendored sources; but the long-term fix is upgrading bundled zlib/libpng.

## Testing

Built on macOS 26.5 / Apple Silicon / Xcode 26.5 / CMake 4 with plain `cmake -DWITH_SYSTEM_FFMPEG=ON` (bundled ffmpeg 2.1.3 doesn't build on arm64 - separate pre-existing issue). Game launches, renders, and plays correctly. Note for testers: on macOS 10.15+ keyboard input requires the Input Monitoring permission (raw HID driver).

## Existing Issue(s)

Fixes #2291. Worth a retest on #2263, #2163, #1914, #2198. Supersedes #2293, which validated the same territory on macOS 14.6(thanks @brandonavant) - that PR disabled `PNG_ARM_NEON_OPT`; this one compiles the NEON sources, keeping the optimization.